### PR TITLE
Avoid commit credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Copyright (C) TOSHIBA CORPORATION, 2023.
-# Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.
-# SPDX-License-Identifier: EPL-2.0
-# License-Filename: LICENSE
-
-NEXTAUTH_SECRET='secret'
-SW360_API_URL='http://localhost:8080'

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env


### PR DESCRIPTION
Credentials should not be committed, even with default data.
With **.env** marked as a git object, a probable mistake can happens when someone forgot to cleanup their own credentials.