### PR TITLE
Add basic commit checks

### DIFF
--- a/.github/deny_list.sh
+++ b/.github/deny_list.sh
@@ -1,0 +1,29 @@
+# Copyright (C) 2023 SW360 Project Authors (see <https://github.com/eclipse-sw360/sw360-frontend/NOTICE>)
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+#!/bin/bash
+
+set -e
+
+# Check for files not intented to be present
+declare -a denyfiles=("yarn.lock")
+declare -a denyextensions=("png" "jpg" "jpeg" "tiff")
+
+for file in "${denyfiles[@]}"; do
+    if [[ -n $(find * -name "$file" -mmin -5) ]]; then
+        echo "File $file is not permitted in this codebase."
+        exit 1
+    fi
+done
+
+for extension in "${denyextensions[@]}"; do
+    if [[ -n $(find * -iname \*."$extension" -mmin -5) ]]; then
+        echo "Files with $file type are not permitted in this codebase."
+        exit 1
+    fi
+done

--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -1,0 +1,20 @@
+name: Commit Checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    name: Validade Pull Request Commits
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: webiny/action-conventional-commits@v1.1.0
+
+      - name: Check deny listed files
+        run: bash .github/deny_list.sh


### PR DESCRIPTION
Minimal checks for:
* Commit done without validation on the origin ( Husky is not installed )
* Prevent to add yarn.lock file to not mixe up with npm package lock.
* Prevent add png, jpg, gif and tiff files. Only svg files are allowed.