### PR TITLE
Revert licenses to traditional SW360

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1.4
 
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,8 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/.devcontainer/scripts/nodejs.sh
+++ b/.devcontainer/scripts/nodejs.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE

--- a/.github/deny_list.sh
+++ b/.github/deny_list.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
-
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE
 

--- a/.github/workflows/commit_checks.yaml
+++ b/.github/workflows/commit_checks.yaml
@@ -1,5 +1,9 @@
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
-
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE
 

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,4 +1,8 @@
-# Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+# Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
 
 # SPDX-License-Identifier: EPL-2.0
 # License-Filename: LICENSE
@@ -9,14 +13,10 @@ header:
     copyright-owner: SW360 Frontend Authors
     copyright-year: '2023'
     software-name: sw360-frontend
-    content: |
-      Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
-
-      SPDX-License-Identifier: EPL-2.0
-      License-Filename: LICENSE
-
     pattern: |
-      Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+      This program and the accompanying materials are made
+      available under the terms of the Eclipse Public License 2.0
+      which is available at https://www.eclipse.org/legal/epl-2.0/
 
       SPDX-License-Identifier: EPL-2.0
       License-Filename: LICENSE
@@ -38,6 +38,7 @@ header:
     - .gitignore
     - .husky
     - package.json
+    - package-lock.json
 
   comment: on-failure
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,4 +1,8 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/contexts/public.context.tsx
+++ b/src/contexts/public.context.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/AuthToken.ts
+++ b/src/object-types/AuthToken.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/Constants.ts
+++ b/src/object-types/Constants.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/OAuthClient.ts
+++ b/src/object-types/OAuthClient.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/RequestContent.ts
+++ b/src/object-types/RequestContent.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/UserCredentialInfo.ts
+++ b/src/object-types/UserCredentialInfo.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/object-types/enums/HttpStatus.ts
+++ b/src/object-types/enums/HttpStatus.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/services/async.storage.service.ts
+++ b/src/services/async.storage.service.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/styles/auth.css
+++ b/src/styles/auth.css
@@ -1,7 +1,14 @@
-/* Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+/*
+  Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+  Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
 
-SPDX-License-Identifier: EPL-2.0
-License-Filename: LICENSE */
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+
+  SPDX-License-Identifier: EPL-2.0
+  License-Filename: LICENSE
+*/
 
 .btn-primary {
     background-color: #F7941E;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,15 @@
-/* Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+/*
+  Copyright (C) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+  Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+  Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
 
-SPDX-License-Identifier: EPL-2.0
-License-Filename: LICENSE */
+  This program and the accompanying materials are made
+  available under the terms of the Eclipse Public License 2.0
+  which is available at https://www.eclipse.org/legal/epl-2.0/
+
+  SPDX-License-Identifier: EPL-2.0
+  License-Filename: LICENSE
+*/
 
 body {
   background-color: #FAFAFA;

--- a/src/utils/api/api.util.ts
+++ b/src/utils/api/api.util.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,9 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
-// Copyright (C) SW360 Frontend Authors (see <https://github.com/eclipse-sw360/sw360-frontend/blob/main/NOTICE>)
+// Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
 
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE


### PR DESCRIPTION
Reference: [Discussion for Header Format](https://github.com/eclipse-sw360/sw360-frontend/discussions/22)