### PR TITLE
fix(table-row-selector): Fixed selector field to show on necessary pl…

### DIFF
--- a/src/app/[locale]/projects/page.tsx
+++ b/src/app/[locale]/projects/page.tsx
@@ -176,6 +176,7 @@ function Project() {
                             columns={columns}
                             data={data.map((data) => [data.name, data.description, data.projectResponsible])}
                             pagination={pagination}
+                            selector={true}
                         />
                     </div>
                 </div>

--- a/src/components/sw360/Table/Table.tsx
+++ b/src/components/sw360/Table/Table.tsx
@@ -58,7 +58,7 @@ class Table extends Component<TableProps, unknown> {
     render(): React.ReactElement {
         return (
             <>
-                {defaultOptions.selector && (
+                {this.props.selector && (
                     <div className='col-11 mt-3 mb-3'>
                         <div className='dataTables_length'>
                             <span className='my-2'>Show</span>


### PR DESCRIPTION
Fixed table row selector field on required places.
Initially by default table row selector was on for all the tables.
Now based on the passed props (`selector={boolean}`), the selector will be activated / de-activated