### PR TITLE
Fix Gridjs error and warning logs, add missing page size selector for component and release page

### DIFF
--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -151,7 +151,7 @@ const ComponentsTable = ({ session, setNumberOfComponent }: Props) => {
         <>
             <div className='row'>
                 {loading == false ? (
-                    <Table data={componentData} columns={columns} />
+                    <Table data={componentData} columns={columns} selector={true}/>
                 ) : (
                     <div className='col-12' style={{ textAlign: 'center' }}>
                         <PageSpinner />

--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -94,10 +94,12 @@ const ComponentsTable = ({ session, setNumberOfComponent }: Props) => {
 
     const columns = [
         {
+            id: 'vendor',
             name: t('Vendor'),
             sort: true,
         },
         {
+            id: 'name',
             name: t('Component Name'),
             formatter: ([id, name]: any) =>
                 _(
@@ -108,6 +110,7 @@ const ComponentsTable = ({ session, setNumberOfComponent }: Props) => {
             sort: true,
         },
         {
+            id: 'mainLicenses',
             name: t('Main Licenses'),
             formatter: (licenseIds: any) =>
                 licenseIds.length > 0 &&
@@ -124,10 +127,12 @@ const ComponentsTable = ({ session, setNumberOfComponent }: Props) => {
             sort: true,
         },
         {
+            id: 'type',
             name: t('Component Type'),
             sort: true,
         },
         {
+            id: 'action',
             name: t('Actions'),
             formatter: (id: string) =>
                 _(

--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -146,7 +146,7 @@ const ReleaseOverview = ({ session, componentId }: Props) => {
     return (
         <>
             <div className='row'>
-                <Table data={data} search={true} columns={columns} />
+                <Table data={data} search={true} columns={columns} selector={true}/>
             </div>
             <DeleteReleaseModal
                 releaseId={deletingRelease}

--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -89,10 +89,12 @@ const ReleaseOverview = ({ session, componentId }: Props) => {
 
     const columns = [
         {
+            id: 'name',
             name: t('Name'),
             sort: true,
         },
         {
+            id: 'version',
             name: t('Version'),
             formatter: ([id, version]: Array<string>) =>
                 _(
@@ -103,18 +105,22 @@ const ReleaseOverview = ({ session, componentId }: Props) => {
             sort: true,
         },
         {
+            id: 'clearingState',
             name: t('Clearing State'),
             sort: true,
         },
         {
+            id: 'clearingReport',
             name: t('Clearing Report'),
             sort: true,
         },
         {
+            id: 'mainlineState',
             name: t('Release Mainline State'),
             sort: true,
         },
         {
+            id: 'action',
             name: t('Actions'),
             formatter: (id: string) =>
                 _(

--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -203,7 +203,7 @@ const Attachments = ({ documentId, session, documentType }: Props) => {
             {totalRows ? (
                 <>
                     <div className={`row ${styles['attachment-table']}`}>
-                        <Table data={attachmentData} columns={columns} search={true} />
+                        <Table data={attachmentData} columns={columns} search={true} selector={true}/>
                     </div>
                 </>
             ) : (

--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -141,43 +141,53 @@ const Attachments = ({ documentId, session, documentType }: Props) => {
 
     const columns = [
         {
+            id: 'check',
             name: _(<FaDownload className={styles['download-btn']} style={{ width: '100%' }} onClick={downloadBundle}/>),
             formatter: (item: any) => _(<i className={styles.collapse} onClick={buildAttachmentDetail(item)}></i>),
             sort: false,
             width: '60px'
         },
         {
+            id: 'fileName',
             name: t('File name'),
             sort: true,
         },
         {
+            id: 'size',
             name: t('Size'),
             sort: true,
         },
         {
+            id: 'type',
             name: t('Type'),
             sort: true,
         },
         {
+            id: 'group',
             name: t('Group'),
             sort: true,
         },
         {
+            id: 'uploadedBy',
             name: t('Uploaded By'),
             sort: true,
         },
         {
+            id: 'group',
             name: t('Group'),
             sort: true,
         },
         {
+            id: 'checkedBy',
             name: t('Checked By'),
             sort: true,
         },
         {
+            id: 'usage',
             name: t('Usage'),
         },
         {
+            id: 'action',
             name: t('Action'),
             formatter: ([attachmentId, attachmentName]: Array<string>) => _
                                     (<FaDownload className={styles['download-btn']} style={{ width: '100%' }} 

--- a/src/components/ChangeLog/ChangeLogList/ChangeLogList.tsx
+++ b/src/components/ChangeLog/ChangeLogList/ChangeLogList.tsx
@@ -75,7 +75,7 @@ const ChangeLogList = ({ documentId, setChangeLogIndex, setChangesLogTab, change
     return (
         <>
             <div className='row'>
-                <Table data={changeLogData} search={true} columns={columns} />
+                <Table data={changeLogData} search={true} columns={columns} selector={true}/>
             </div>
         </>
     )

--- a/src/components/ComponentVulnerabilities/ComponentVulnerabilities.tsx
+++ b/src/components/ComponentVulnerabilities/ComponentVulnerabilities.tsx
@@ -174,7 +174,7 @@ const ComponentVulnerabilities = ({ vulnerData, session }: Props) => {
                 >
                     {t('Vulnerabilities')}
                 </h5>
-                <Table columns={columns} data={data} />
+                <Table columns={columns} data={data} selector={true}/>
                 <Form.Group className='mb-3' controlId='createdOn'>
                     <Form.Label>
                         <b>{t('Change verification state of selected vulnerabilities to')}</b>

--- a/src/components/ComponentVulnerabilities/ComponentVulnerabilities.tsx
+++ b/src/components/ComponentVulnerabilities/ComponentVulnerabilities.tsx
@@ -82,6 +82,7 @@ const ComponentVulnerabilities = ({ vulnerData, session }: Props) => {
 
     const columns = [
         {
+            id: 'check',
             name: _(<Form.Check defaultChecked={checkAll} type='checkbox' onClick={handleCheckAll}></Form.Check>),
             formatter: ({ checked, index }: any) =>
                 _(<Form.Check defaultChecked={checked}
@@ -89,10 +90,12 @@ const ComponentVulnerabilities = ({ vulnerData, session }: Props) => {
             sort: false,
         },
         {
+            id: 'release',
             name: t('Release'),
             sort: true,
         },
         {
+            id: 'externalId',
             name: t('External Id'),
             formatter: ([externalId, id]: Array<string>) =>
                 _(
@@ -103,18 +106,22 @@ const ComponentVulnerabilities = ({ vulnerData, session }: Props) => {
             sort: true,
         },
         {
+            id: 'priority',
             name: t('Priority'),
             sort: true,
         },
         {
+            id: 'matchedBy',
             name: t('Matched by'),
             sort: true,
         },
         {
+            id: 'title',
             name: t('Title'),
             sort: true,
         },
         {
+            id: 'verification',
             name: t('Verification'),
             formatter: (verificationStateInfos: Array<VerificationStateInfo>) =>
                 _(

--- a/src/components/sw360/Table/Table.tsx
+++ b/src/components/sw360/Table/Table.tsx
@@ -41,14 +41,20 @@ class Table extends Component<TableProps, unknown> {
     }
 
     componentDidMount(): void {
+        if (this.wrapper.current.childNodes.length > 0) {
+            this.wrapper.current.innerHTML = ''
+        }
         this.instance.render(this.wrapper.current)
     }
 
     componentDidUpdate(): void {
+        this.instance.config.plugin.remove('pagination')
+        this.instance.config.plugin.remove('search')
         this.instance.updateConfig(this.props).forceRender()
     }
 
     handlePageSizeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        this.instance.config.plugin.remove('pagination')
         const pageSize = parseInt(event.target.value, 10)
         this.instance
             .updateConfig({

--- a/src/components/sw360/Table/wrapper.tsx
+++ b/src/components/sw360/Table/wrapper.tsx
@@ -9,8 +9,9 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+'use client'
 import { h, createRef as gCreateRef, Component as gComponent } from 'gridjs'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 
 export class ReactWrapper extends gComponent<{
     element: any
@@ -23,7 +24,8 @@ export class ReactWrapper extends gComponent<{
     ref = gCreateRef()
 
     componentDidMount(): void {
-        ReactDOM.render(this.props.element, this.ref.current)
+        const root = createRoot(this.ref.current);
+        root.render(this.props.element);
     }
 
     render() {


### PR DESCRIPTION
### Fix the following Gridjs's error and warning logs
 1. [Grid.js] [ERROR] Duplicate plugin ID: pagination
 2. [Grid.js] [ERROR] Duplicate plugin ID: search
 3. [Grid.js] [ERROR]: The container element [object HTMLDivElement] is not empty. Make sure the container is empty and call render() again
 4. [Warning] ReactDOM.render is no longer supported in React 18
### Add missing page size selector for component and release page