### PR TITLE
Expose language option to table

### DIFF
--- a/src/components/sw360/Table/Table.tsx
+++ b/src/components/sw360/Table/Table.tsx
@@ -23,6 +23,7 @@ const defaultOptions = {
 
 interface TableProps extends Partial<Config> {
     selector?: boolean
+    language?: any
 }
 
 class Table extends Component<TableProps, unknown> {


### PR DESCRIPTION
Exposing the language structure from GridJs to our internal component.

Table will allow to set custom messages for specific parts of the table structure, like noRecordsFound, Next, Previous, etc.

The message should be set on the **Table** component  passing language structure in the format of GridJs own translation structure. 
Reference: [GridJs example](https://gridjs.io/docs/config/language) and the complete [GridJs structure](https://github.com/grid-js/gridjs/blob/master/src/i18n/en_US.ts)

Since we are not using the internal GridJs translation engine, but next-i18n from the point of view of the internal components of the table, it will always be treated as en_US and irrelevant for our code.

To do change from our Table component, we just need to pass the structure like stated above but created on our page:

Example:
```javascript
function TestPage() {
   const [data, setData] = useState([])
   const language = { 
        search: {
               placeholder: t("This is SW360 Search")
               },
        noRecordsFound: t("NO RECORDS, DUDE !")
    }
   const columns = [ { name: t("test columns") } ]

   <div className='row mt-2'>
       <Table data={data}, columns={columns} language={language}/>
   </div>
}

export default TestPage
```

Closes #89 