### PR TITLE
feat(CR): Added scenario to handle deleted project after CR creation

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Clearing-Bericht",
     "Clearing Request": "Clearing-Anfrage",
     "Clearing Request Comments": "Kommentare zur Clearing-Anfrage:",
+    "Clearing Request Information For DELETED Project": "Löschanforderungsinformationen für GELÖSCHTES Projekt",
     "Clearing Request Information For Project": "Clearing-Anfrageinformationen für das Projekt:",
     "Clearing Standard": "Clearing Standard",
     "Clearing State": "Clearingstaat",

--- a/messages/en.json
+++ b/messages/en.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Clearing Report",
     "Clearing Request": "Clearing Request",
     "Clearing Request Comments": "Clearing Request Comments:",
+    "Clearing Request Information For DELETED Project": "Clearing Request Information For DELETED Project",
     "Clearing Request Information For Project": "Clearing Request Information For Project:",
     "Clearing Standard": "Clearing Standard",
     "Clearing State": "Clearing State",

--- a/messages/es.json
+++ b/messages/es.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Clearing Report",
     "Clearing Request": "Solicitud de compensación",
     "Clearing Request Comments": "Comentarios de la solicitud de compensación:",
+    "Clearing Request Information For DELETED Project": "Información de solicitud de compensación para proyecto ELIMINADO",
     "Clearing Request Information For Project": "Información de solicitud de compensación para proyecto:",
     "Clearing Standard": "Estándar de limpieza",
     "Clearing State": "Estado de limpieza",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Rapport d'effacement",
     "Clearing Request": "Demande de compensation",
     "Clearing Request Comments": "Commentaires sur la demande de compensation :",
+    "Clearing Request Information For DELETED Project": "Informations sur la demande de compensation pour le projet SUPPRIMÉ",
     "Clearing Request Information For Project": "Informations sur la demande de compensation pour le projet :",
     "Clearing Standard": "Norme de compensation",
     "Clearing State": "État compensateur",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -135,6 +135,7 @@
     "Clearing Report": "クリアリングレポート",
     "Clearing Request": "決済リクエスト",
     "Clearing Request Comments": "リクエストのコメントをクリアします:",
+    "Clearing Request Information For DELETED Project": "DELETEDプロジェクトのリクエスト情報をクリアします",
     "Clearing Request Information For Project": "プロジェクトのリクエスト情報のクリア:",
     "Clearing Standard": "クリアリング基準",
     "Clearing State": "クリアリングステータス",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -135,6 +135,7 @@
     "Clearing Report": "자주 묻는 질문",
     "Clearing Request": "청산요청",
     "Clearing Request Comments": "요청 설명 지우기:",
+    "Clearing Request Information For DELETED Project": "삭제된 프로젝트에 대한 요청 정보 지우기",
     "Clearing Request Information For Project": "프로젝트에 대한 요청 정보 지우기:",
     "Clearing Standard": "Clearing 기준",
     "Clearing State": "정리 국가",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Relatório de compensação",
     "Clearing Request": "Solicitação de compensação",
     "Clearing Request Comments": "Comentários de solicitação de compensação:",
+    "Clearing Request Information For DELETED Project": "Limpando informações de solicitação para projeto EXCLUÍDO",
     "Clearing Request Information For Project": "Limpeza de informações de solicitação para projeto:",
     "Clearing Standard": "Padrão de Compensação",
     "Clearing State": "Estado de compensação",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -135,6 +135,7 @@
     "Clearing Report": "Xóa báo cáo",
     "Clearing Request": "Xóa yêu cầu",
     "Clearing Request Comments": "Xóa yêu cầu nhận xét:",
+    "Clearing Request Information For DELETED Project": "Xóa thông tin yêu cầu cho dự án đã bị xóa",
     "Clearing Request Information For Project": "Xóa thông tin yêu cầu cho dự án:",
     "Clearing Standard": "Tiêu chuẩn thanh toán bù trừ",
     "Clearing State": "Trạng thái thanh toán bù trừ",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -135,6 +135,7 @@
     "Clearing Report": "清算报告",
     "Clearing Request": "清算请求",
     "Clearing Request Comments": "清算请求评论：",
+    "Clearing Request Information For DELETED Project": "清除已删除项目的请求信息",
     "Clearing Request Information For Project": "清除项目请求信息：",
     "Clearing Standard": "清算标准",
     "Clearing State": "清算状态",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -135,6 +135,7 @@
     "Clearing Report": "清除報告",
     "Clearing Request": "清算請求",
     "Clearing Request Comments": "清算請求評論：",
+    "Clearing Request Information For DELETED Project": "清除已刪除項目的請求訊息",
     "Clearing Request Information For Project": "清除項目請求資訊：",
     "Clearing Standard": "清除標準",
     "Clearing State": "清除狀態",

--- a/src/app/[locale]/requests/clearingRequest/[id]/components/ClearingRequestDetail.tsx
+++ b/src/app/[locale]/requests/clearingRequest/[id]/components/ClearingRequestDetail.tsx
@@ -30,6 +30,7 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
     const { data: session, status } = useSession()
     const router = useRouter()
     const toastShownRef = useRef(false);
+    const [isProjectDeleted, setIsProjectDeleted] = useState<boolean>(false)
     const [clearingRequestData, setClearingRequestData] = useState<ClearingRequestDetails>({
         id: '',
         requestedClearingDate: '',
@@ -67,6 +68,9 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
 
         void fetchData(`clearingrequest/${clearingRequestId}`).then(
                       (clearingRequestDetails: ClearingRequestDetails) => {
+            if (!Object.hasOwn(clearingRequestDetails, 'projectId')){
+                setIsProjectDeleted(true)
+            }
             setClearingRequestData(clearingRequestDetails)
         })}, [fetchData, session])
 
@@ -102,6 +106,7 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                                             variant='btn btn-primary'
                                             className='me-2 col-auto'
                                             onClick={handleEditClearingRequest}
+                                            hidden={isProjectDeleted}
                                         >
                                             {t('Edit Request')}
                                         </Button>

--- a/src/app/[locale]/requests/clearingRequest/[id]/components/ClearingRequestDetail.tsx
+++ b/src/app/[locale]/requests/clearingRequest/[id]/components/ClearingRequestDetail.tsx
@@ -133,10 +133,15 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                                             <div>
                                                 <ShowInfoOnHover text={''} />
                                                 {' '}
-                                                {t('Clearing Request Information For Project') + ` `}
-                                                <a href={`/projects/detail/${clearingRequestData.projectId}`}>
-                                                    {clearingRequestData.projectId}
-                                                </a>
+                                                {isProjectDeleted ? (
+                                                    t('Clearing Request Information For DELETED Project')
+                                                ) : ( <>
+                                                        {t('Clearing Request Information For Project') + ` `}
+                                                        <a href={`/projects/detail/${clearingRequestData.projectId}`}>
+                                                            {clearingRequestData.projectId}
+                                                        </a>
+                                                    </>
+                                                )}
                                             </div>
                                             </Button>
                                         </Card.Header>


### PR DESCRIPTION
Handle CR details and Open CR table if project is deleted after CR creation :

Open CR Table : 
- Show `Deleted Project` in open CR table.
- Show releases as `not available`

CR Details page :
- Disable edit CR button if project is deleted
- Change the CR details header for deleted project
