### PR TITLE
fix(Project): Fixed license info header under project detail page

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/Administration.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Administration.tsx
@@ -188,7 +188,7 @@ export default function Administration({ data }: { data: AdministrationDataType 
                                 id='administration.licenseInfoHeader'
                                 aria-describedby={t('License Info Header')}
                                 style={{ height: '600px' }}
-                                value={data.licenseInfoHeader}
+                                value={data.licenseInfoHeaderText}
                                 readOnly
                             />
                         </td>

--- a/src/object-types/AdministrationDataType.ts
+++ b/src/object-types/AdministrationDataType.ts
@@ -22,7 +22,7 @@ interface AdministrationDataType {
     systemTestEnd?: string
     deliveryStart?: string
     phaseOutSince?: string
-    licenseInfoHeader?: string
+    licenseInfoHeaderText?: string
     _embedded?: {
         clearingTeam?: {
             email: string


### PR DESCRIPTION
Fixed license info header at `Administration` tab of project detail page 