### PR TITLE
Fixed Visibility field in Project detail

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
@@ -76,7 +76,7 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
                     </tr>
                     <tr>
                         <td>{t('Visibility')}:</td>
-                        <td>{Capitalize(summaryData.visibility) ?? ''}</td>
+                        <td>{Capitalize(summaryData.visibility === 'BUISNESSUNIT_AND_MODERATORS' ? 'GROUP_AND_MODERATORS' : summaryData.visibility) ?? ''}</td>
                     </tr>
                     <tr>
                         <td>{t('Created On')}:</td>


### PR DESCRIPTION
Fixed the Visibility field in Project detail page to display **"Group And Moderators" i**nstead of **"Buisnessunit And Moderators"**.