### PR TITLE
Fix: Choose a department in Group field (Create and Edit Project)

### DIFF
--- a/src/app/[locale]/projects/add/page.tsx
+++ b/src/app/[locale]/projects/add/page.tsx
@@ -56,7 +56,7 @@ function AddProjects(): JSX.Element {
         moderators: [],
         contributors: [],
         clearingState: 'OPEN',
-        businessUnit: 'CT',
+        businessUnit: '',
         preevaluationDeadline: '',
         clearingSummary: '',
         specialRisksOSS: '',

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -286,7 +286,7 @@ function EditProject({ projectId }: { projectId: string }): JSX.Element {
                     ownerGroup: project.ownerGroup ?? '',
                     ownerCountry: project.ownerCountry ?? '',
                     clearingState: project.clearingState ?? 'OPEN',
-                    businessUnit: project.businessUnit ?? 'CT',
+                    businessUnit: project.businessUnit ?? '',
                     preevaluationDeadline: project.preevaluationDeadline ?? '',
                     clearingSummary: project.clearingSummary ?? '',
                     specialRisksOSS: project.specialRisksOSS ?? '',

--- a/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
+++ b/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
@@ -10,42 +10,121 @@
 'use client'
 
 import { Modal, Form, Row, Col, Button } from 'react-bootstrap'
-import { _, Table } from '@/components/sw360'
+import { _ } from 'next-sw360'
 import { useTranslations } from 'next-intl'
+import { getSession } from 'next-auth/react'
+import CommonUtils from '@/utils/common.utils'
+import MessageService from '@/services/message.service'
+import { ApiUtils } from '@/utils/index'
+import { useState, useEffect, useMemo } from 'react'
+import React from 'react'
+import Table, { TableProps } from '@/components/sw360/Table/Table'
 
-interface DepartmentType {
-    departmentId: string
+interface Props {
+    show: boolean
+    setShow: React.Dispatch<React.SetStateAction<boolean>>
+    setDepartment: (department: string) => void
+    department: string
+    multiple: boolean
+}
+
+interface DepartmentGroups {
+    primaryGrpList: string[]
+    secondaryGrpList: string[]
+}
+
+interface Department {
     departmentName: string
     priority: string
 }
 
-export default function DepartmentModal({ show, setShow }: { show: boolean; setShow: (show: boolean) => void }) : JSX.Element {
+const compare = (preState: TableProps, nextState: TableProps) => {
+    return Object.entries(preState.data ?? {}).sort().toString() === Object.entries(nextState.data ?? {}).sort().toString()
+}
+
+const MemoTable = React.memo(Table, compare)
+
+export default function DepartmentModal({ show, setShow, department, setDepartment  }: Props) : JSX.Element {
     const t = useTranslations('default')
+    const [departments, setDepartments] = useState<Department[]>([])
+    const [selectingDepartment, setSelectingDepartment] = useState<string>(department || '')
 
-    const columns = [
-        {
-            id: 'selectDepartmentRadio',
-            name: '',
-            formatter: (departmentId: string) =>
-                _(
-                    <div className='form-check d-flex justify-content-center'>
-                        <input className='form-check-input' type='radio' name='department' id={departmentId} />
-                    </div>
-                ),
-            width: '10%',
-        },
-        {
-            id: 'departmentName',
-            name: t('Deparment Name'),
-            width: '30%',
-        },
-        {
-            id: 'priority',
-            name: t('Priority'),
-        },
-    ]
+    const tableData = useMemo(() => 
+        departments.map((dept) => [
+            dept.departmentName,
+            dept.departmentName,
+            dept.priority
+        ])
+    , [departments])
 
-    const data: DepartmentType[] = []
+    const columns = useMemo(() => {
+        return [
+            {
+                id: 'selectDepartmentRadio',
+                name: '',
+                formatter: (departmentName: string) => {
+                    return _(
+                        <div className='form-check d-flex justify-content-center'>
+                            <input 
+                                className='form-check-input' 
+                                type='radio' 
+                                name='departmentRadioGroup'
+                                defaultChecked={departmentName == selectingDepartment}
+                                onClick={() => handleDepartmentSelect(departmentName)}
+                            />
+                        </div>
+                    )
+                },
+                width: '10%',
+                sort: false,
+            },
+            {
+                id: 'departmentName',
+                name: t('Deparment Name'),
+                width: '30%',
+            },
+            {
+                id: 'priority',
+                name: t('Priority'),
+            },
+        ]
+    }, [show, selectingDepartment, t])
+
+    const handleDepartmentSelect = (departmentName: string) => {
+        setSelectingDepartment(departmentName)
+    }
+
+    const fetchDepartments = async () => {
+        const session = await getSession()
+        if (CommonUtils.isNullOrUndefined(session)) {
+            MessageService.error(t('Session has expired'))
+            return
+        }
+        const response = await ApiUtils.GET(`users/groupList`, session.user.access_token)
+        const departmentGroups = await response.json() as DepartmentGroups
+        
+        const transformedDepartments: Department[] = [
+            ...departmentGroups.primaryGrpList.map(dept => ({
+                departmentName: dept,
+                priority: 'PRIMARY'
+            })),
+            ...departmentGroups.secondaryGrpList.map(dept => ({
+                departmentName: dept,
+                priority: 'SECONDARY'
+            }))
+        ]
+        
+        setDepartments(transformedDepartments)
+    }
+
+    useEffect(() => {
+        if (show) {
+            fetchDepartments()
+            setSelectingDepartment(department)
+        } else {
+            setSelectingDepartment('')
+        }
+    }, [show, department])
 
     return (
         <>
@@ -61,16 +140,22 @@ export default function DepartmentModal({ show, setShow }: { show: boolean; setS
                 </Modal.Header>
                 <Modal.Body>
                     <Row>
-                        <Table
+                        <MemoTable
                             columns={columns}
-                            data={data.map((data) => [data.departmentId, data.departmentName, data.priority])}
+                            data={tableData}
+                            sort={false}
                         />
                     </Row>
                     <Form>
                         <Col>
                             <Row className='mb-3 d-flex justify-content-end'>
                                 <Col xs={6}>
-                                    <Form.Control type='text' name='department' />
+                                    <Form.Control 
+                                        type='text' 
+                                        name='department' 
+                                        value={selectingDepartment}
+                                        readOnly
+                                    />
                                 </Col>
                             </Row>
                         </Col>
@@ -83,6 +168,7 @@ export default function DepartmentModal({ show, setShow }: { show: boolean; setS
                     <Button
                         variant='primary'
                         onClick={() => {
+                            setDepartment(selectingDepartment)
                             setShow(false)
                         }}
                     >

--- a/src/components/ProjectAddSummary/Roles/Roles.tsx
+++ b/src/components/ProjectAddSummary/Roles/Roles.tsx
@@ -191,9 +191,29 @@ export default function Roles({
         })
     }
 
+    const setDepartmentToPayload = (department: string) => {
+        setProjectPayload({
+            ...projectPayload,
+            businessUnit: department,
+        })
+    }
+
+    const handleClearDepartment = () => {
+        setProjectPayload({
+            ...projectPayload,
+            businessUnit: '',
+        })
+    }
+
     return (
         <>
-            <DepartmentModal show={showDepartmentModal} setShow={setShowDepartmentModal} />
+            <DepartmentModal 
+                show={showDepartmentModal} 
+                setShow={setShowDepartmentModal} 
+                department={projectPayload.businessUnit ?? ''} 
+                setDepartment={setDepartmentToPayload} 
+                multiple={false}
+            />
             <div className='row mb-4'>
                 <h6 className='header pb-2 px-2'>{t('Roles')}</h6>
                 <div className='row'>
@@ -208,10 +228,11 @@ export default function Roles({
                             aria-label={t('Group')}
                             placeholder={t('Click to edit')}
                             readOnly={true}
+                            value={projectPayload.businessUnit ?? ''}
                             required
                             onClick={() => setShowDepartmentModal(true)}
                         />
-                        <div className='form-text'>
+                        <div className='form-text' onClick={handleClearDepartment}>
                             {' '}
                             <GiCancel />
                         </div>


### PR DESCRIPTION
# Pull Request Description

### What does this PR do?
- Allow user to select a department in group field when creating or editing a project.
---
### How to Test?
- Navigate to Create Project or Edit Project.
- Select the "Group" field, the Department selection appear.
- Click search and choose the appropriate department.
- Click Select and then Create Project or Update Project to complete the process.

![image](https://github.com/user-attachments/assets/c42973b1-0739-4bd2-b19f-58f750caf4d8)
