### PR TITLE
fix(licenses): Fix the license url that cause 404

### DIFF
--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -68,7 +68,7 @@ function ComponentsTable({ setNumberOfComponent }: Props) {
                     Object.entries(licenseIds)
                         .map(
                             ([, item]: Array<string>): React.ReactNode => (
-                                <Link key={item} className='link' href={'/licenses/' + item}>
+                                <Link key={item} className='link' href={'/licenses/detail/?id=' + item}>
                                     {' '}
                                     {item}{' '}
                                 </Link>

--- a/src/app/[locale]/search/components/SearchPage.tsx
+++ b/src/app/[locale]/search/components/SearchPage.tsx
@@ -63,7 +63,7 @@ export default function Search() : ReactNode {
                             } else if (type === 'component') {
                                 return <Link href={`/components/detail/${id}`}>{name}</Link>
                             } else if (type === 'license') {
-                                return <Link href={`/licenses/detail/${id}`}>{name}</Link>
+                                return <Link href={`/licenses/detail/?id=${id}`}>{name}</Link>
                             } else if (type === 'package') {
                                 return <Link href={`/packages/detail/${id}`}>{name}</Link>
                             } else if (type === 'obligation') {


### PR DESCRIPTION
Summary: 
---
This pull request fixes the issue where clicking the license detail in the Search Bar and the components table that cause 404 error.

This fix updates the URL to the correct format, ensuring that the license detail can be accessed without any errors.