### PR TITLE
Fix: TypeScript build failure in TableLicense component's RefObject definition

### DIFF
--- a/src/components/LinkedObligations/TableLicense.tsx
+++ b/src/components/LinkedObligations/TableLicense.tsx
@@ -34,7 +34,7 @@ interface TableProps extends Partial<Config> {
 }
 
 class TableLicense extends Component<TableProps, unknown> {
-    private wrapper: RefObject<HTMLDivElement | null> = createRef()
+    private wrapper: RefObject<HTMLDivElement> = createRef()
     // Grid.js instance
     private readonly instance: Grid | null = null
     private tableProps: TableProps = {}

--- a/src/components/sw360/Table/Table.tsx
+++ b/src/components/sw360/Table/Table.tsx
@@ -50,7 +50,7 @@ const createTableProps = (tableProps: TableProps) => {
 }
 
 class Table extends Component<TableProps, unknown> {
-    private wrapper: RefObject<HTMLDivElement | null> = createRef()
+    private wrapper: RefObject<HTMLDivElement> = createRef()
     // Grid.js instance
     private readonly instance: Grid | null = null
     private tableProps: TableProps = {}


### PR DESCRIPTION
# Description
This PR fixes a build failure caused by a TypeScript error in the TableLicense.tsx component. The error occurs because the wrapper ref is defined with an explicit null in its union type, which conflicts with React's expected ref types.

# Changes
 - Modified the type definition of wrapper ref in TableLicense.tsx and Table.tsx from RefObject<HTMLDivElement | null> to RefObject<HTMLDivElement>

# Issue
Fixes: [#624](https://github.com/eclipse-sw360/sw360-frontend/issues/624)
