### PR TITLE
Revert : "fix(component): Advance Search"

### DIFF
--- a/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
@@ -60,7 +60,7 @@ function AdvancedSearch({ title = 'Advanced Search', fields }: Props): JSX.Eleme
         const currentUrl = new URL(window.location.href)
         const searchUrl = new URL(currentUrl.origin + currentUrl.pathname)
         searchUrl.searchParams.append('allDetails', 'true')
-        searchUrl.searchParams.append('luceneSearch', 'false')
+        searchUrl.searchParams.append('luceneSearch', 'true')
         Object.entries(searchParams).forEach(([key, value]: Array<string>) => {
             if (!CommonUtils.isNullEmptyOrUndefinedString(value)) {
                 searchUrl.searchParams.append(key, value)


### PR DESCRIPTION
Reverts eclipse-sw360/sw360-frontend#639
Hey @heliocastro and @VAIBHAVSING !
I think we need to revert this PR. Because the param `luceneSearch=true` is required for couple of fields (`group`, `tag` and `additionalData`) of adv search at project page.