### PR TITLE
fix(env)!: Make oauth vars server side only

### DIFF
--- a/src/app/api/auth/[...nextauth]/keycloakAuthOption.ts
+++ b/src/app/api/auth/[...nextauth]/keycloakAuthOption.ts
@@ -11,11 +11,12 @@ import KeycloakProvider from "next-auth/providers/keycloak"
 import { NextAuthOptions } from 'next-auth'
 import { jwtDecode } from 'jwt-decode'
 import { UserGroupType } from '@/object-types'
+import { SW360_KEYCLOAK_CLIENT_ID, SW360_KEYCLOAK_CLIENT_SECRET, AUTH_ISSUER } from '@/utils/env'
 
 const keycloakProvider = KeycloakProvider({
-    clientId: `${process.env.SW360_KEYCLOAK_CLIENT_ID}`,
-    clientSecret: `${process.env.SW360_KEYCLOAK_CLIENT_SECRET}`,
-    issuer: `${process.env.AUTH_ISSUER}`,
+    clientId: SW360_KEYCLOAK_CLIENT_ID,
+    clientSecret: SW360_KEYCLOAK_CLIENT_SECRET,
+    issuer: AUTH_ISSUER,
     checks: 'state',
     authorization: { params: { scope: "openid READ WRITE" } },
 })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,8 +9,13 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-export const SW360_API_URL: string | undefined  = process.env.NEXT_PUBLIC_SW360_API_URL;
-export const AUTH_TOKEN : string | undefined  = process.env.NEXT_PUBLIC_AUTH_TOKEN;
-export const SW360_REST_CLIENT_ID: string | undefined  = process.env.NEXT_PUBLIC_SW360_REST_CLIENT_ID;
-export const SW360_REST_CLIENT_SECRET: string | undefined  = process.env.NEXT_PUBLIC_SW360_REST_CLIENT_SECRET;
+// Server/Client side env
+export const SW360_API_URL: string | undefined = process.env.NEXT_PUBLIC_SW360_API_URL;
 export const AUTH_PROVIDER: string | undefined = process.env.NEXT_PUBLIC_SW360_AUTH_PROVIDER;
+
+// Server side env
+export const SW360_REST_CLIENT_ID: string | undefined = process.env.SW360_REST_CLIENT_ID;
+export const SW360_REST_CLIENT_SECRET: string | undefined = process.env.SW360_REST_CLIENT_SECRET;
+export const SW360_KEYCLOAK_CLIENT_ID = `${process.env.SW360_KEYCLOAK_CLIENT_ID}`;
+export const SW360_KEYCLOAK_CLIENT_SECRET = `${process.env.SW360_KEYCLOAK_CLIENT_SECRET}`;
+export const AUTH_ISSUER: string | undefined = process.env.AUTH_ISSUER;


### PR DESCRIPTION
!BREAKING: Update the variables `NEXT_PUBLIC_SW360_REST_CLIENT_ID` and `NEXT_PUBLIC_SW360_REST_CLIENT_SECRET` to server side variables only. This would require updating existing `.env` files.

### Example `.env` changes
From:
```ini
NEXT_PUBLIC_SW360_AUTH_PROVIDER='sw360oauth'
NEXT_PUBLIC_SW360_REST_CLIENT_ID='trusted-sw360-client'
NEXT_PUBLIC_SW360_REST_CLIENT_SECRET='sw360-secret'
```

To:
```ini
NEXT_PUBLIC_SW360_AUTH_PROVIDER='sw360oauth'
SW360_REST_CLIENT_ID='trusted-sw360-client'
SW360_REST_CLIENT_SECRET='sw360-secret'
```