### PR TITLE
fix(Release): Preserve tab selection on clicking edit release button

### DIFF
--- a/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
@@ -12,7 +12,7 @@
 
 import { signOut, getSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
-import { notFound, useRouter } from 'next/navigation'
+import { notFound, useRouter, useSearchParams } from 'next/navigation'
 import { ReactNode, useEffect, useState } from 'react'
 
 import EditAttachments from '@/components/Attachments/EditAttachments'
@@ -52,7 +52,10 @@ interface Props {
 const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props) : ReactNode => {
     const router = useRouter()
     const t = useTranslations('default')
-    const [selectedTab, setSelectedTab] = useState<string>(CommonTabIds.SUMMARY)
+    const params = useSearchParams()
+    const tabParam = params.get('tab')
+    const initialTab = !CommonUtils.isNullEmptyOrUndefinedString(tabParam) ? tabParam : CommonTabIds.SUMMARY
+    const [selectedTab, setSelectedTab] = useState<string>(initialTab)
     const [tabList, setTabList] = useState(ReleaseEditTabs.WITHOUT_COMMERCIAL_DETAILS_AND_SPDX)
     const [release, setRelease] = useState<ReleaseDetail>()
     const [componentId, setComponentId] = useState('')

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -203,7 +203,7 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     }
 
     const headerButtons = {
-        'Edit release': { link: `/components/editRelease/${releaseId}`, type: 'primary', name: t('Edit release') },
+        'Edit release': { link: `/components/editRelease/${releaseId}?tab=${selectedTab}`, type: 'primary', name: t('Edit release') },
         'Link To Project': {
             link: '',
             type: 'secondary',


### PR DESCRIPTION
When clicking "**Edit release**," users now stay on the same tab (e.g., Attachments, Clearing Details) instead of always being redirected to Summary.

Closes : #689 