### PR TITLE
fix(ECC): Removed extra data passed to ecc overview table

### DIFF
--- a/src/app/[locale]/ecc/components/ECC.tsx
+++ b/src/app/[locale]/ecc/components/ECC.tsx
@@ -82,7 +82,6 @@ export default function ECC(): ReactNode {
                     elem.eccInformation.assessorContactPerson,
                     elem.eccInformation.assessorDepartment,
                     elem.eccInformation.assessmentDate,
-                    elem.eccInformation.eccn,
                 ])
             },
             total: (data: EmbeddedECC) => (data.page ? data.page.totalElements : 0),


### PR DESCRIPTION
Removed extra data `(eccn)` passed to ecc overview table.

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/811