### PR TITLE
fix(Licenses): Added missing `License Type` at `License` detail page

### DIFF
--- a/src/app/[locale]/licenses/detail/components/Detail.tsx
+++ b/src/app/[locale]/licenses/detail/components/Detail.tsx
@@ -92,7 +92,7 @@ const Detail = ({ license, setLicense }: Props): ReactNode => {
                     </tr>
                     <tr>
                         <td>{t('Type')}:</td>
-                        <td></td>
+                        <td>{license.licenseType?.licenseType}</td>
                     </tr>
                     <tr>
                         <td>{t('OSI Approved')}:</td>

--- a/src/object-types/LicenseDetail.ts
+++ b/src/object-types/LicenseDetail.ts
@@ -1,5 +1,6 @@
 // Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
 // Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2025. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -12,7 +13,10 @@ import { Obligation } from './Obligation'
 
 export default interface LicenseDetail {
     id?: string
-    type?: string
+    licenseType?: {
+        id?: string
+        licenseType?: string
+    }
     shortName?: string
     fullName?: string
     externalLicenseLink?: string


### PR DESCRIPTION
Added missing data of `License Type` at `License` detail page

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/882