### PR TITLE
fix(npm): Fixed eslint-plugin-kit vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "pnpm": {
     "overrides": {
       "@types/react": "19.0.10",
-      "@types/react-dom": "19.1.6"
+      "@types/react-dom": "19.1.6",
+      "@eslint/plugin-kit": "^0.3.3"
     },
     "ignoredBuiltDependencies": [
       "cypress",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@types/react': 19.0.10
   '@types/react-dom': 19.1.6
+  '@eslint/plugin-kit': ^0.3.3
 
 importers:
 
@@ -343,6 +344,10 @@ packages:
     resolution: {integrity: sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@eslint/core@0.15.1':
+    resolution: {integrity: sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -359,8 +364,8 @@ packages:
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.3.1':
-    resolution: {integrity: sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==}
+  '@eslint/plugin-kit@0.3.3':
+    resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@formatjs/ecma402-abstract@2.3.4':
@@ -3629,6 +3634,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/core@0.15.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
@@ -3649,9 +3658,9 @@ snapshots:
 
   '@eslint/object-schema@2.1.6': {}
 
-  '@eslint/plugin-kit@0.3.1':
+  '@eslint/plugin-kit@0.3.3':
     dependencies:
-      '@eslint/core': 0.14.0
+      '@eslint/core': 0.15.1
       levn: 0.4.1
 
   '@formatjs/ecma402-abstract@2.3.4':
@@ -5215,7 +5224,7 @@ snapshots:
       '@eslint/core': 0.14.0
       '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.28.0
-      '@eslint/plugin-kit': 0.3.1
+      '@eslint/plugin-kit': 0.3.3
       '@humanfs/node': 0.16.6
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.2


### PR DESCRIPTION
Fixed vulnerable (High Severity) `@eslint/plugin-kit 0.3.1` --> `@eslint/plugin-kit 0.3.3` with override in `package.json` due to multiple transitive dependencies.

```
@eslint/compat 1.3.1  ...  @eslint/plugin-kit 0.3.1
@typescript-eslint/eslint-plugin 8.33.0  ...  @eslint/plugin-kit 0.3.1
@typescript-eslint/parser 8.33.0  ...  @eslint/plugin-kit 0.3.1
eslint 9.28.0  @eslint/plugin-kit 0.3.1
eslint-config-next 15.3.5  ...  @eslint/plugin-kit 0.3.1
eslint-import-resolver-typescript 4.4.3  ...  @eslint/plugin-kit 0.3.1
eslint-plugin-import 2.32.0  ...  @eslint/plugin-kit 0.3.1
eslint-plugin-prettier 5.5.1  ...  @eslint/plugin-kit 0.3.1
eslint-plugin-react 7.37.5  ...  @eslint/plugin-kit 0.3.1
eslint-plugin-simple-import-sort 12.1.1  ...  @eslint/plugin-kit 0.3.1
typescript-eslint 8.35.1  ...  @eslint/plugin-kit 0.3.1
```
Advisory Link: https://github.com/advisories/GHSA-xffm-g5w8-qvg7
