### PR TITLE
fix(linked-packages): Handle updated API response and restore table rendering UI

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
@@ -176,15 +176,10 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
     }, [])
 
     useEffect(() => {
-        fetchData(`projects/${projectId}/linkedPackages`)
+        fetchData(`projects/${projectId}/packages`)
             .then((linkedPackages: EmbeddedLinkedPackages | undefined) => {
-                if (linkedPackages === undefined) return
-
-                if (
-                    !CommonUtils.isNullOrUndefined(linkedPackages['_embedded']) &&
-                    !CommonUtils.isNullOrUndefined(linkedPackages['_embedded']['sw360:packages'])
-                ) {
-                    const data = linkedPackages['_embedded']['sw360:packages'].map((item: LinkedPackage) => [
+                if (Array.isArray(linkedPackages)) {
+                    const data = linkedPackages.map((item: LinkedPackage) => [
                         [item.vendorId ?? '', item.vendorName ?? ''],
                         [item.id, item.name, item.packageVersion],
                         [
@@ -198,6 +193,27 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
                         item.id,
                     ])
                     setTableData(data)
+                } else if (
+                    linkedPackages?._embedded?.['sw360:packages'] &&
+                    Array.isArray(linkedPackages._embedded['sw360:packages'])
+                ) {
+                    const packages = linkedPackages._embedded['sw360:packages']
+                    const data = packages.map((item: LinkedPackage) => [
+                        [item.vendorId ?? '', item.vendorName ?? ''],
+                        [item.id, item.name, item.packageVersion],
+                        [
+                            item.releaseId ?? '',
+                            item._embedded?.['sw360:release']?.name ?? '',
+                            item._embedded?.['sw360:release']?.version ?? '',
+                        ],
+                        item._embedded?.['sw360:release']?.clearingState ?? '',
+                        item.licenseIds ?? [],
+                        item.packageManager ?? '',
+                        item.id,
+                    ])
+                    setTableData(data)
+                } else {
+                    setTableData([])
                 }
             })
             .catch((err) => console.error(err))


### PR DESCRIPTION
This PR fixes the issue where linked packages were not displayed in the UI due to changes in the backend API response format.

### Changes:
- Updated `LinkedPackagesTab.tsx` to handle the updated flat array response from the backend.
- Restored the proper rendering of the linked packages table.
- Ensured backward compatibility and added basic fallback handling for unexpected response structures.

### Test:
- Verified on local dev environment.
- Linked packages now appear correctly under project details.