### PR TITLE
fix(CR): Added fix for clearing request view.

### DIFF
--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -248,6 +248,7 @@ function Project(): JSX.Element {
                 enableSorting: false,
                 cell: ({ row }) => {
                     const id = row.original['_links']['self']['href'].split('/').at(-1)
+                    const projectClearingRequestId = row.original.clearingRequestId
                     return (
                         <>
                             {id && (
@@ -260,12 +261,12 @@ function Project(): JSX.Element {
                                             <FaPencilAlt className='btn-icon' />
                                         </span>
                                     </OverlayTrigger>
-                                    {clearingRequestId !== '' ? (
+                                    {projectClearingRequestId && projectClearingRequestId !== '' ? (
                                         <OverlayTrigger overlay={<Tooltip>{t('View Clearing Request')}</Tooltip>}>
                                             <span
                                                 className='d-inline-block'
                                                 onClick={() => {
-                                                    setClearingRequestId(clearingRequestId)
+                                                    setClearingRequestId(projectClearingRequestId)
                                                     setShowViewCRModal(true)
                                                 }}
                                             >

--- a/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
@@ -10,7 +10,7 @@
 'use client'
 
 import { AccessControl } from '@/components/AccessControl/AccessControl'
-import { ClearingRequestStates, ConfigKeys, HttpStatus, UserGroupType } from '@/object-types'
+import { ConfigKeys, HttpStatus, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
 import { getSession, signOut } from 'next-auth/react'
@@ -31,14 +31,12 @@ function LicenseClearing({
     projectId,
     projectName,
     projectVersion,
-    clearingState,
     clearingRequestId,
     isCalledFromModerationRequestCurrentProject,
 }: {
     projectId: string
     projectName: string
     projectVersion: string
-    clearingState?: string
     clearingRequestId?: string
     isCalledFromModerationRequestCurrentProject?: boolean
 }): JSX.Element {
@@ -203,16 +201,16 @@ function LicenseClearing({
                                     variant='secondary'
                                     className='me-2 col-auto'
                                     onClick={
-                                        clearingState === ClearingRequestStates.OPEN
-                                            ? () => setShowCreateClearingRequestModal(true)
-                                            : () => setShowViewClearingRequestModal(true)
+                                        clearingRequestId && clearingRequestId !== ''
+                                            ? () => setShowViewClearingRequestModal(true)
+                                            : () => setShowCreateClearingRequestModal(true)
                                     }
                                 >
                                     {
                                         <>
-                                            {clearingState === ClearingRequestStates.OPEN
-                                                ? t('Create Clearing Request')
-                                                : t('View Clearing Request')}
+                                            {clearingRequestId && clearingRequestId !== ''
+                                                ? t('View Clearing Request')
+                                                : t('Create Clearing Request')}
                                         </>
                                     }
                                 </Button>

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -376,7 +376,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 projectId={projectId}
                                                 projectName={summaryData.name}
                                                 projectVersion={summaryData.version ?? ''}
-                                                clearingState={administrationData.clearingState ?? ''}
                                                 clearingRequestId={summaryData.clearingRequestId ?? ''}
                                             />
                                         )}


### PR DESCRIPTION
Closes : #960 

Currently the view CR modal is not being picked up in both License Clearing and Projects tab even if CR exists for a project.

Rebase with latest backend main for testing.

<img width="1713" height="459" alt="image" src="https://github.com/user-attachments/assets/5cf8bf1c-94e8-4d80-bcb4-9d2e3a6a2bce" />
