### PR TITLE
fix(Project): Fixed `ID` column and integrated update obligation APIs

### DIFF
--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ComponentObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ComponentObligation.tsx
@@ -239,7 +239,7 @@ export default function ComponentObligation({ projectId, actionType, payload, se
                 },
                 { status: val.status ?? '' },
                 Capitalize(val.obligationType ?? ''),
-                val.status ?? '',
+                val.id ?? '',
                 { comment: val.comment ?? '' },
             ])
         }

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -547,7 +547,7 @@ export default function LicenseObligation({
                 },
                 { status: obl.status ?? '', obligation: key, payload },
                 Capitalize(val.obligationType ?? ''),
-                '',
+                obl.id ?? '',
                 { comment: obl.comment ?? '', obligation: key, payload },
             ])
         }

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/OrganizationObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/OrganizationObligation.tsx
@@ -240,7 +240,7 @@ export default function OrganizationObligation({ projectId, actionType, payload,
                 },
                 { status: val.status ?? '' },
                 Capitalize(val.obligationType ?? ''),
-                val.status ?? '',
+                val.id ?? '',
                 { comment: val.comment ?? '' },
             ])
         }

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ProjectObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ProjectObligation.tsx
@@ -241,7 +241,7 @@ export default function ProjectObligation({ projectId, actionType, payload, setP
                 },
                 { status: val.status ?? '' },
                 Capitalize(val.obligationType ?? ''),
-                val.status ?? '',
+                val.id ?? '',
                 { comment: val.comment ?? '' },
             ])
         }


### PR DESCRIPTION
This PR adds :
- Fixed `ID` column with proper values in License, Project, Component and Org obligations
- Integrated update obligation APIs based on obligation levels

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/1010, https://github.com/eclipse-sw360/sw360-frontend/issues/1011, and https://github.com/eclipse-sw360/sw360-frontend/issues/1012 