### PR TITLE
fix(Admin): Restrict admin sub page access to non admin roles

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,7 +62,7 @@ export default function middleware(req: NextRequest): NextResponse | Promise<Nex
     const isPublicPage = publicPathnameRegex.test(req.nextUrl.pathname)
 
     const adminPathnameRegex = RegExp(
-        `^(/(${locales.join('|')}))?(${adminPages.flatMap((p) => (p === '/' ? ['', '/'] : p)).join('|')})/?$`,
+        `^(/(${locales.join('|')}))?(${adminPages.flatMap((p) => (p === '/' ? ['', '/'] : p)).join('|')})(/.*)?$`,
         'i',
     )
     const isAdminPage = adminPathnameRegex.test(req.nextUrl.pathname)


### PR DESCRIPTION
Restricted the admin sub-page access to non admin user roles

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/1038