### PR TITLE
feat(release): Enable LinkedPackagesTab in edit release and add delete package functionality

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -685,6 +685,7 @@
     "Homepage Url": "Homepage Url",
     "How it works": "How it works",
     "I could not delete the release, since it is used by another component (release) or project": "I could not delete the release, since it is used by another component (release) or project",
+    "The Package cannot be deleted, Since it is used by other project. Please unlink it before deleting.": " The Package cannot be deleted, Since it is used by other project. Please unlink it before deleting.",
     "IBM Rational Synergy": "IBM Rational Synergy",
     "INCORRECT": "Incorrect",
     "INITIAL_SCAN_REPORT": "Initial Scan Report",

--- a/src/app/[locale]/components/editRelease/[id]/components/EditLinkedPackages.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditLinkedPackages.tsx
@@ -1,0 +1,369 @@
+// Copyright (C) Siemens AG, 2025. Part of the SW360 Frontend Project.
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+'use client'
+
+import { _, Table } from '@/components/sw360'
+import LinkPackagesModal from '@/components/sw360/LinkedPackagesModal/LinkPackagesModal'
+import { LinkedPackage, LinkedPackageData, ProjectPayload, Release } from '@/object-types'
+import CommonUtils from '@/utils/common.utils'
+import { ApiUtils } from '@/utils/index'
+import { getSession, signOut } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { Alert, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
+import { FaTrashAlt } from 'react-icons/fa'
+import { StatusCodes } from 'http-status-codes'
+
+interface ExtendedRelease extends Release {
+    linkedPackages?: {
+        packageId?: string
+        name?: string
+        version?: string
+        licenseIds?: string[]
+        packageManager?: string
+        comment?: string
+    }[]
+}
+
+interface Props {
+    releaseId?: string
+    releasePayload: ExtendedRelease
+    setReleasePayload: React.Dispatch<React.SetStateAction<ExtendedRelease>>
+}
+
+type RowData = (string | string[] | { comment?: string; key?: string } | undefined)[]
+
+export default function EditLinkedPackages({ releaseId, releasePayload, setReleasePayload, }: Props) {
+    const t = useTranslations('default')
+    const [tableData, setTableData] = useState<Array<RowData>>([])
+    const [showLinkedPackagesModal, setShowLinkedPackagesModal] = useState(false)
+    const [linkedPackageMap, setLinkedPackageMap] = useState<Map<string, LinkedPackageData>>(new Map())
+    const [showModal, setShowModal] = useState(false)
+    const [selectedPkg, setSelectedPkg] = useState<{
+        id: string
+        name: string
+        version: string
+    } | null>(null)
+    const [deleting, setDeleting] = useState(false)
+    const [alert, setAlert] = useState<{
+        variant: string
+        message: ReactNode
+    } | null>(null)
+    const projectPayloadAdapter: ProjectPayload = { id: '', name: '', packageIds: {} }
+    const noopSetProjectPayload: React.Dispatch<React.SetStateAction<ProjectPayload>> = () => { }
+
+    const extractDataFromMap = (dataMap: Map<string, LinkedPackageData>): Array<RowData> => {
+        const extractedData: Array<RowData> = []
+        dataMap.forEach((value) => {
+            extractedData.push([
+                [value.name, value.packageId],
+                value.version,
+                value.licenseIds,
+                value.packageManager,
+                { comment: value.comment || '', key: value.packageId },
+                value.packageId,
+            ])
+        })
+        return extractedData
+    }
+
+    const handleComments = (packageId: string, updatedComment: string, mapData: Map<string, LinkedPackageData>) => {
+        if (mapData.has(packageId)) {
+            const updatedMap = new Map(mapData)
+            const item = updatedMap.get(packageId)
+            if (item) item.comment = updatedComment
+
+            setLinkedPackageMap(updatedMap)
+            const updatedPayload: ExtendedRelease = {
+                ...releasePayload,
+                linkedPackages: Array.from(updatedMap.values()),
+            }
+            setReleasePayload(updatedPayload)
+            setTableData(extractDataFromMap(updatedMap))
+        }
+    }
+
+    const openDeleteModal = (packageId: string) => {
+        const pkg = linkedPackageMap.get(packageId)
+        if (!pkg) return
+
+        setSelectedPkg({
+            id: pkg.packageId,
+            name: pkg.name,
+            version: pkg.version ?? '',
+        })
+        setAlert(null)
+        setShowModal(true)
+    }
+
+    const deleteLinkedPackage = () => {
+        if (!selectedPkg) return
+
+        setDeleting(true)
+        const updatedMap = new Map(linkedPackageMap)
+        updatedMap.delete(selectedPkg.id)
+
+        const updatedPayload: ExtendedRelease = {
+            ...releasePayload,
+            linkedPackages: Array.from(updatedMap.values()),
+        }
+
+        setLinkedPackageMap(updatedMap)
+        setReleasePayload(updatedPayload)
+        setTableData(extractDataFromMap(updatedMap))
+
+        setShowModal(false)
+        setSelectedPkg(null)
+        setDeleting(false)
+    }
+
+    const fetchData = useCallback(async () => {
+        if (!releaseId) return
+        const session = await getSession()
+        if (CommonUtils.isNullOrUndefined(session)) return signOut()
+
+        const response = await ApiUtils.GET(`releases/${releaseId}?embed=packages`, session.user.access_token)
+        if (response.status === StatusCodes.OK) {
+            const data = await response.json()
+            const embedded = data?._embedded?.['sw360:packages']
+            if (!embedded || embedded.length === 0) return
+
+            const updatedMap = new Map<string, LinkedPackageData>()
+            embedded.forEach((item: LinkedPackage) => {
+                updatedMap.set(item.id, {
+                    packageId: item.id,
+                    name: item.name ?? 'Unnamed',
+                    version: item.version ?? 'N/A',
+                    licenseIds: item.licenseIds ?? [],
+                    packageManager: item.packageManager ?? 'N/A',
+                    comment: releasePayload.linkedPackages?.find((p) => p.packageId === item.id)?.comment || '',
+                })
+            })
+            setLinkedPackageMap(updatedMap)
+            setTableData(extractDataFromMap(updatedMap))
+        } else if (response.status === StatusCodes.UNAUTHORIZED) {
+            signOut()
+        }
+    }, [releaseId, releasePayload.linkedPackages])
+
+    useEffect(() => {
+        fetchData().catch(console.error)
+    }, [fetchData])
+
+    useEffect(() => {
+        setTableData(extractDataFromMap(linkedPackageMap))
+    }, [linkedPackageMap])
+
+    const handleModalLinkedPackages = (newMap: Map<string, LinkedPackageData>) => {
+        const merged = new Map(linkedPackageMap)
+        newMap.forEach((v, key) => merged.set(key, v))
+        setLinkedPackageMap(merged)
+        const updatedPayload: ExtendedRelease = {
+            ...releasePayload,
+            linkedPackages: Array.from(merged.values()).map((v) => ({
+                packageId: v.packageId,
+                name: v.name,
+                version: v.version,
+                licenseIds: v.licenseIds,
+                packageManager: v.packageManager,
+                comment: v.comment ?? '',
+            })),
+        }
+        setReleasePayload(updatedPayload)
+        setTableData(extractDataFromMap(merged))
+    }
+
+    const columns = [
+        {
+            id: 'linkedPackagesData.name',
+            name: t('Package Name'),
+            sort: true,
+            formatter: ([name, packageId]: [string, string]) =>
+                _(
+                    <a
+                        href={`/packages/detail/${packageId}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                    >
+                        {name}
+                    </a>,
+                ),
+        },
+        { id: 'linkedPackagesData.version', name: t('Package Version'), sort: true },
+        { id: 'linkedPackagesData.licenses', name: t('License'), sort: true },
+        { id: 'linkedPackagesData.packageManager', name: t('Package Manager'), sort: true },
+        {
+            id: 'linkedPackagesData.comment',
+            name: t('Comments'),
+            sort: true,
+            formatter: ({ comment, key }: { comment: string; key: string }) =>
+                _(
+                    <div className='col-lg-9'>
+                        <input
+                            key={`comment-${key}-${linkedPackageMap.get(key)?.comment || comment}`}
+                            type='text'
+                            className='form-control'
+                            placeholder='Enter comment'
+                            defaultValue={linkedPackageMap.get(key)?.comment || comment}
+                            onBlur={(e) => handleComments(key, e.target.value, linkedPackageMap)}
+                        />
+                    </div>,
+                ),
+        },
+        {
+            id: 'linkedPackagesData.delete',
+            name: t('Actions'),
+            sort: false,
+            formatter: (packageId: string) =>
+                _(
+                    <OverlayTrigger overlay={<Tooltip>{t('Delete Package')}</Tooltip>}>
+                        <span className='d-inline-block'>
+                            <FaTrashAlt
+                                className='btn-icon'
+                                onClick={() => openDeleteModal(packageId)}
+                                style={{ color: 'gray', fontSize: '18px', cursor: 'pointer' }}
+                            />
+                        </span>
+                    </OverlayTrigger>,
+                ),
+        },
+    ]
+
+    return (
+        <>
+            <LinkPackagesModal
+                show={showLinkedPackagesModal}
+                setShow={setShowLinkedPackagesModal}
+                projectPayload={projectPayloadAdapter}
+                setProjectPayload={noopSetProjectPayload}
+                setLinkedPackageData={(m: Map<string, LinkedPackageData>) => handleModalLinkedPackages(m)}
+            />
+            <div className='row mb-4'>
+                <div className='row header-1'>
+                    <h6
+                        className='fw-medium'
+                        style={{ color: '#5D8EA9', paddingLeft: '0px' }}
+                    >
+                        {t('LINKED PACKAGES')}
+                        <hr
+                            className='my-2 mb-2'
+                            style={{ color: '#5D8EA9' }}
+                        />
+                    </h6>
+                </div>
+                <div style={{ paddingLeft: '0px' }}>
+                    <Table
+                        columns={columns}
+                        data={tableData}
+                        sort={false}
+                    />
+                </div>
+                <div
+                    className='row'
+                    style={{ paddingLeft: '0px', marginTop: '10px' }}
+                >
+                    <div className='col-lg-4'>
+                        <button
+                            type='button'
+                            className='btn btn-secondary'
+                            onClick={() => setShowLinkedPackagesModal(true)}
+                        >
+                            {t('Add Packages')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <Modal
+                size='lg'
+                centered
+                show={showModal}
+                onHide={() => {
+                    setShowModal(false)
+                    setSelectedPkg(null)
+                    setAlert(null)
+                    setDeleting(false)
+                }}
+                aria-labelledby='delete-linked-package-modal'
+                scrollable
+            >
+                <Modal.Header
+                    style={{ backgroundColor: '#feefef', color: '#da1414' }}
+                    closeButton
+                >
+                    <Modal.Title id='delete-linked-package-modal'>{t('Delete Package')}?</Modal.Title>
+                </Modal.Header>
+
+                <Modal.Body>
+                    {alert && (
+                        <Alert
+                            variant={alert.variant}
+                            className='mb-3'
+                        >
+                            {alert.message}
+                        </Alert>
+                    )}
+                    {!alert && selectedPkg && (
+                        <p>
+                            {t('Do you really want to delete the package')}{' '}
+                            <strong>
+                                {selectedPkg.name}
+                                {selectedPkg.version ? ` (${selectedPkg.version})` : ''}
+                            </strong>
+                            ?
+                        </p>
+                    )}
+                </Modal.Body>
+
+                <Modal.Footer>
+                    {alert ? (
+                        <button
+                            className='btn btn-dark'
+                            onClick={() => {
+                                setShowModal(false)
+                                setSelectedPkg(null)
+                                setAlert(null)
+                                setDeleting(false)
+                            }}
+                        >
+                            {t('Close')}
+                        </button>
+                    ) : (
+                        <>
+                            <button
+                                className='btn btn-dark'
+                                onClick={() => {
+                                    setShowModal(false)
+                                    setSelectedPkg(null)
+                                }}
+                                disabled={deleting}
+                            >
+                                {t('Cancel')}
+                            </button>
+                            <button
+                                className='btn btn-danger'
+                                onClick={() => deleteLinkedPackage()}
+                                disabled={deleting}
+                            >
+                                {t('Delete Package')}
+                                {deleting && (
+                                    <Spinner
+                                        size='sm'
+                                        className='ms-1 spinner'
+                                    />
+                                )}
+                            </button>
+                        </>
+                    )}
+                </Modal.Footer>
+            </Modal>
+        </>
+    )
+}

--- a/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
@@ -45,6 +45,7 @@ import { ApiUtils, CommonUtils } from '@/utils'
 import DeleteReleaseModal from '../../../detail/[id]/components/DeleteReleaseModal'
 import EditClearingDetails from './EditClearingDetails'
 import EditECCDetails from './EditECCDetails'
+import EditLinkedPackages from './EditLinkedPackages'
 import EditSPDXDocument from './EditSPDXDocument'
 import ReleaseEditSummary from './ReleaseEditSummary'
 import ReleaseEditTabs from './ReleaseEditTabs'
@@ -585,6 +586,16 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                                 <LinkedReleases
                                     actionType={ActionType.EDIT}
                                     release={release}
+                                    releasePayload={releasePayload}
+                                    setReleasePayload={setReleasePayload}
+                                />
+                            </div>
+                            <div
+                                className='row'
+                                hidden={selectedTab !== ReleaseTabIds.LINKED_PACKAGES ? true : false}
+                            >
+                                <EditLinkedPackages
+                                    releaseId={releaseId}
                                     releasePayload={releasePayload}
                                     setReleasePayload={setReleasePayload}
                                 />

--- a/src/app/[locale]/components/editRelease/[id]/components/ReleaseEditTabs.ts
+++ b/src/app/[locale]/components/editRelease/[id]/components/ReleaseEditTabs.ts
@@ -20,6 +20,10 @@ const WITHOUT_COMMERCIAL_DETAILS_AND_SPDX = [
         name: 'Linked Releases',
     },
     {
+        id: ReleaseTabIds.LINKED_PACKAGES,
+        name: 'Linked Packages',
+    },
+    {
         id: ReleaseTabIds.CLEARING_DETAILS,
         name: 'Clearing Details',
     },
@@ -49,6 +53,10 @@ const WITH_COMMERCIAL_DETAILS = [
     {
         id: ReleaseTabIds.LINKED_RELEASES,
         name: 'Linked Releases',
+    },
+    {
+        id: ReleaseTabIds.LINKED_PACKAGES,
+        name: 'Linked Packages',
     },
     {
         id: ReleaseTabIds.CLEARING_DETAILS,
@@ -90,6 +98,10 @@ const WITH_SPDX = [
         name: 'Linked Releases',
     },
     {
+        id: ReleaseTabIds.LINKED_PACKAGES,
+        name: 'Linked Packages',
+    },
+    {
         id: ReleaseTabIds.CLEARING_DETAILS,
         name: 'Clearing Details',
     },
@@ -123,6 +135,10 @@ const WITH_COMMERCIAL_DETAILS_AND_SPDX = [
     {
         id: ReleaseTabIds.LINKED_RELEASES,
         name: 'Linked Releases',
+    },
+    {
+        id: ReleaseTabIds.LINKED_PACKAGES,
+        name: 'Linked Packages',
     },
     {
         id: ReleaseTabIds.CLEARING_DETAILS,

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
@@ -9,33 +9,26 @@
 
 'use client'
 
-import {
-    ColumnDef,
-    ColumnFiltersState,
-    getCoreRowModel,
-    getFilteredRowModel,
-    getPaginationRowModel,
-    useReactTable,
-} from '@tanstack/react-table'
-import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { signOut, useSession } from 'next-auth/react'
+import { getSession, signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
-import { type JSX, useEffect, useMemo, useState } from 'react'
-import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
-import { FaPencilAlt } from 'react-icons/fa'
-import { packageManagers } from '@/app/[locale]/packages/components/PackageManagers'
-import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table } from '@/components/sw360'
-import { Embedded, ErrorDetails, FilterOption, LinkedPackage } from '@/object-types'
+import { type JSX, useCallback, useEffect, useState } from 'react'
+import { Alert, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
+import { FaPencilAlt, FaTrashAlt } from 'react-icons/fa'
+import { _, Table } from '@/components/sw360'
+import { FilterOption, LinkedPackage, Release } from '@/object-types'
 import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
 import { ApiUtils } from '@/utils/index'
+import { StatusCodes } from 'http-status-codes'
+import { packageManagers } from '@/app/[locale]/packages/components/PackageManagers'
+import { ColumnFiltersState } from '@tanstack/react-table'
 
 interface Props {
     releaseId: string
 }
 
-type EmbeddedLinkedPackages = Embedded<LinkedPackage, 'sw360:packages'>
+type RowData = (string | string[] | undefined)[]
 
 const packageManagerFilterOptions: FilterOption[] = packageManagers.map((pm: string) => ({
     tag: pm,
@@ -44,208 +37,394 @@ const packageManagerFilterOptions: FilterOption[] = packageManagers.map((pm: str
 
 export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
+    const [tableData, setTableData] = useState<Array<RowData>>([])
+    const { status } = useSession()
+    const [showModal, setShowModal] = useState(false)
+    const [selectedPkg, setSelectedPkgId] = useState<{
+        id: string
+        name: string
+        version: string
+    } | null>(null)
+    const [deleting, setDeleting] = useState(false)
+    const [alert, setAlert] = useState<{
+        variant: string
+        message: JSX.Element
+    } | null>(null)
 
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [showFilter, setShowFilter] = useState<undefined | string>()
 
     useEffect(() => {
-        if (session.status === 'unauthenticated') {
+        if (status === 'unauthenticated') {
             void signOut()
         }
     }, [
-        session,
+        status,
     ])
+    const deleteLinkedPackage = async () => {
+        if (!selectedPkg) return
+        try {
+            setDeleting(true)
+            const session = await getSession()
+            if (CommonUtils.isNullOrUndefined(session)) return signOut()
 
-    const columns = useMemo<ColumnDef<LinkedPackage>[]>(
-        () => [
-            {
-                id: 'vendor',
-                header: t('Vendor'),
-                cell: ({ row }) => (
-                    <Link
-                        href={`/vendors/${row.original.vendorId}`}
-                        className='text-link'
-                    >
-                        {row.original.vendorName}
-                    </Link>
+            const response = await ApiUtils.DELETE(`packages/${selectedPkg.id}`, session.user.access_token)
+
+            if (response.status === StatusCodes.OK || response.status === StatusCodes.NO_CONTENT) {
+                MessageService.success(t('Package deleted successfully'))
+                setTableData((prev) => prev.filter((row) => row[row.length - 1] !== selectedPkg.id))
+                setShowModal(false)
+                setAlert({
+                    variant: 'success',
+                    message: <>{t('Package deleted successfully')}</>,
+                })
+            } else if (response.status === StatusCodes.CONFLICT) {
+                setAlert({
+                    variant: 'warning',
+                    message: (<> The Package cannot be deleted, Since it is used by other project. Please unlink it before deleting. </>),
+                })
+            } else {
+                setAlert({
+                    variant: 'warning',
+                    message: <> Package cannot be deleted</>,
+                })
+            }
+        } catch (error) {
+            console.error(error)
+            setAlert({
+                variant: 'warning',
+                message: <> Package cannot be deleted </>,
+            })
+        } finally {
+            setDeleting(false)
+        }
+    }
+
+    const columns = [
+        {
+            id: 'linkedPackagesData.vendor',
+            name: t('Vendor'),
+            sort: true,
+            formatter: ([vendorId, vendorName]: Array<string>) =>
+                _(<Link href={`/vendors/${vendorId}`}>{vendorName}</Link>),
+        },
+        {
+            id: 'linkedPackagesData.packageName',
+            name: t('Package Name Version'),
+            sort: true,
+            formatter: ([packageId, packageName, packageVersion]: Array<string>) =>
+                _(<Link href={`/packages/detail/${packageId}`}>{`${packageName} (${packageVersion})`}</Link>),
+        },
+        {
+            id: 'linkedPackagesData.releaseName',
+            name: t('Release Name Version'),
+            sort: true,
+            formatter: ([relId, relName, relVersion]: Array<string>) =>
+                _(
+                    <Link href={`/components/releases/detail/${relId}`}>
+                        {relName || relVersion ? `${relName} ${relVersion ? `(${relVersion})` : ''}` : 'N/A'}
+                    </Link>,
                 ),
-                meta: {
-                    width: '20%',
-                },
-            },
-            {
-                id: 'packageName',
-                header: t('Package Name Version'),
-                cell: ({ row }) => (
-                    <Link
-                        className='text-link'
-                        href={`/packages/detail/${row.original.id}`}
-                    >{`${row.original.name} (${row.original.version})`}</Link>
-                ),
-                meta: {
-                    width: '25%',
-                },
-            },
-            {
-                id: 'licenses',
-                header: t('Licenses'),
-                cell: ({ row }) => {
-                    const { licenseIds } = row.original
-                    return (
-                        <div>
-                            {Array.isArray(licenseIds) &&
-                                licenseIds.length > 0 &&
-                                licenseIds.map((licenseId, idx) => (
-                                    <span key={licenseId}>
-                                        <Link
-                                            href={`/licenses/detail?id=${licenseId}`}
-                                            className='text-link'
-                                        >
-                                            {licenseId}
-                                        </Link>
-                                        {idx !== licenseIds.length - 1 && ', '}
-                                    </span>
-                                ))}
-                        </div>
-                    )
-                },
-                meta: {
-                    width: '25%',
-                },
-            },
-            {
-                id: 'packageManager',
-                header: () => (
-                    <div className='d-flex justify-content-between align-items-center'>
-                        <span>{t('Package Manager')}</span>
-                        <FilterComponent
-                            renderFilterOptions={packageManagerFilterOptions}
-                            setColumnFilters={setColumnFilters}
-                            columnFilters={columnFilters}
-                            id='packageManager'
-                            show={showFilter}
-                            setShow={setShowFilter}
-                            header={t('Package Manager')}
-                        />
-                    </div>
-                ),
-                accessorKey: 'packageManager',
-                enableSorting: false,
-                cell: (info) => info.getValue(),
-                meta: {
-                    width: '20%',
-                },
-            },
-            {
-                id: 'actions',
-                header: t('Actions'),
-                cell: ({ row }) => {
-                    const { id } = row.original
-                    return (
-                        <span className='d-flex justify-content-evenly'>
-                            <OverlayTrigger overlay={<Tooltip>{t('Edit Package')}</Tooltip>}>
-                                <Link
-                                    href={`/packages/edit/${id}`}
-                                    className='overlay-trigger'
-                                >
-                                    <FaPencilAlt className='btn-icon' />
-                                </Link>
+        },
+        {
+            id: 'linkedPackagesData.releaseClearingState',
+            name: t('Release Clearing State'),
+            sort: true,
+            formatter: (releaseClearingState: string) =>
+                _(
+                    <div className='text-center'>
+                        {!releaseClearingState ? (
+                            <>{t('Not Applicable')}</>
+                        ) : (
+                            <OverlayTrigger
+                                overlay={
+                                    <Tooltip>{`${t('Release Clearing State')}: ${releaseClearingState ?? ''}`}</Tooltip>
+                                }
+                            >
+                                {releaseClearingState === 'NEW_CLEARING' || releaseClearingState === 'NEW' ? (
+                                    <span className='badge bg-danger overlay-badge'>CS</span>
+                                ) : releaseClearingState === 'REPORT_AVAILABLE' ? (
+                                    <span className='badge bg-primary overlay-badge'>CS</span>
+                                ) : releaseClearingState === 'UNDER_CLEARING' ? (
+                                    <span className='badge bg-warning overlay-badge'>CS</span>
+                                ) : releaseClearingState === 'INTERNAL_USE_SCAN_AVAILABLE' ? (
+                                    <span className='badge bg-info overlay-badge'>CS</span>
+                                ) : releaseClearingState === 'SENT_TO_CLEARING_TOOL' ||
+                                    releaseClearingState === 'SCAN_AVAILABLE' ? (
+                                    <span className='badge bg-info overlay-badge'>CS</span>
+                                ) : (
+                                    <span className='badge bg-success overlay-badge'>CS</span>
+                                )}
                             </OverlayTrigger>
-                        </span>
-                    )
-                },
-                meta: {
-                    width: '10%',
-                },
-            },
-        ],
-        [
-            t,
-            columnFilters,
-            showFilter,
-        ],
-    )
+                        )}
+                    </div>,
+                ),
+        },
+        {
+            id: 'linkedPackagesData.licenses',
+            name: t('Licenses'),
+            sort: true,
+            formatter: (licenseIds: string[]) =>
+                _(
+                    <div>
+                        {Array.isArray(licenseIds) && licenseIds.length > 0 ? (
+                            licenseIds.map((licenseId, idx) => (
+                                <span key={idx}>
+                                    <Link href={`/licenses/detail?id=${licenseId}`}>{licenseId}</Link>
+                                    {idx !== licenseIds.length - 1 && ', '}
+                                </span>
+                            ))
+                        ) : (
+                            <span className='text-muted'>{t('No Licenses')}</span>
+                        )}
+                    </div>,
+                ),
+        },
+        {
+            id: 'linkedPackagesData.packageManager',
+            name: t('Package Manager'),
+            sort: true,
+        },
+        {
+            id: 'linkedPackagesData.comment',
+            name: t('Comments'),
+            sort: true,
+        },
+        {
+            id: 'linkedPackagesData.actions',
+            name: t('Actions'),
+            sort: true,
+            formatter: (
+                pkgTuple: [
+                    string,
+                    string,
+                    string,
+                ],
+            ) =>
+                _(
+                    <span className='d-flex justify-content-evenly'>
+                        <OverlayTrigger overlay={<Tooltip>{t('Edit Package')}</Tooltip>}>
+                            <Link
+                                href={`/packages/edit/${pkgTuple[0]}`}
+                                className='overlay-trigger'
+                            >
+                                <FaPencilAlt className='btn-icon' />
+                            </Link>
+                        </OverlayTrigger>
+                        <OverlayTrigger overlay={<Tooltip>{t('Delete Package')}</Tooltip>}>
+                            <span
+                                className='d-inline-block'
+                                style={{
+                                    cursor: 'pointer',
+                                }}
+                                onClick={() => {
+                                    const [id, name, version] = pkgTuple
+                                    setSelectedPkgId({
+                                        id,
+                                        name,
+                                        version,
+                                    })
+                                    setAlert(null)
+                                    setShowModal(true)
+                                }}
+                            >
+                                <FaTrashAlt
+                                    className='btn-icon'
+                                    style={{
+                                        color: 'gray',
+                                        fontSize: '18px',
+                                    }}
+                                />
+                            </span>
+                        </OverlayTrigger>
+                    </span>,
+                ),
+        },
+    ]
 
-    const [packagesData, setPackagesData] = useState<LinkedPackage[]>(() => [])
-    const memoizedData = useMemo(
-        () => packagesData,
-        [
-            packagesData,
-        ],
-    )
-    const [showProcessing, setShowProcessing] = useState(false)
+    const fetchData = useCallback(async (url: string): Promise<Release | undefined> => {
+        const session = await getSession()
+        if (CommonUtils.isNullOrUndefined(session)) {
+            void signOut()
+            return undefined
+        }
+        const response = await ApiUtils.GET(url, session.user.access_token)
+        if (response.status === StatusCodes.OK) {
+            return (await response.json()) as Release
+        } else if (response.status === StatusCodes.UNAUTHORIZED) {
+            void signOut()
+            return undefined
+        } else {
+            return undefined
+        }
+    }, [])
 
     useEffect(() => {
-        if (session.status === 'loading') return
-        const controller = new AbortController()
-        const signal = controller.signal
+        const fetchReleaseData = async () => {
+            const linkedPackages = await fetchData(`releases/${releaseId}?embed=packages`)
+            if (!linkedPackages) return
 
-        const timeLimit = packagesData.length !== 0 ? 700 : 0
-        const timeout = setTimeout(() => {
-            setShowProcessing(true)
-        }, timeLimit)
+            const releaseClearingState = linkedPackages.clearingState ?? ''
+            const packagesArray: LinkedPackage[] =
+                (
+                    linkedPackages as Release & {
+                        _embedded?: {
+                            'sw360:packages'?: LinkedPackage[]
+                        }
+                    }
+                )._embedded?.['sw360:packages'] ?? []
 
-        void (async () => {
-            try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return signOut()
-                const response = await ApiUtils.GET(`releases/${releaseId}`, session.data.user.access_token, signal)
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
-                }
+            const data: RowData[] = packagesArray.map((item) => {
+                const vendorInfo: string[] = [
+                    item.vendorId ?? '',
+                    item.vendorName ?? '',
+                ]
+                const packageInfo: string[] = [
+                    item.id ?? '',
+                    item.name ?? '',
+                    item.version ?? '',
+                ]
+                const releaseInfo: string[] = [
+                    linkedPackages.id ?? '',
+                    linkedPackages.name ?? '',
+                    linkedPackages.version ?? '',
+                ]
+                const licenseInfo: string[] = item.licenseIds ? item.licenseIds.filter((id) => id) : []
+                const comment: string =
+                    (
+                        linkedPackages as Release & {
+                            packageIds?: Record<
+                                string,
+                                {
+                                    comment?: string
+                                }
+                            >
+                        }
+                    ).packageIds?.[item.id]?.comment ?? ''
 
-                const data = (await response.json()) as EmbeddedLinkedPackages
-                setPackagesData(
-                    CommonUtils.isNullOrUndefined(data['_embedded']['sw360:packages'])
-                        ? []
-                        : data['_embedded']['sw360:packages'],
-                )
-            } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
-            } finally {
-                clearTimeout(timeout)
-                setShowProcessing(false)
-            }
-        })()
+                return [
+                    vendorInfo,
+                    packageInfo,
+                    releaseInfo,
+                    releaseClearingState,
+                    licenseInfo,
+                    item.packageManager ?? '',
+                    comment,
+                    [
+                        item.id ?? '',
+                        item.name ?? '',
+                        item.version ?? '',
+                    ],
+                ]
+            })
 
-        return () => controller.abort()
+            setTableData(data)
+        }
+
+        void fetchReleaseData()
     }, [
-        session,
+        releaseId,
+        fetchData,
     ])
 
-    const table = useReactTable({
-        data: memoizedData,
-        columns,
-        state: {
-            columnFilters,
-        },
-        getCoreRowModel: getCoreRowModel(),
-        getFilteredRowModel: getFilteredRowModel(),
-        getPaginationRowModel: getPaginationRowModel(),
-        onColumnFiltersChange: setColumnFilters,
-    })
-
     return (
-        <div className='mb-3'>
-            {table ? (
-                <>
-                    <ClientSidePageSizeSelector table={table} />
-                    <SW360Table
-                        table={table}
-                        showProcessing={showProcessing}
+        <>
+            <div className='row mb-4'>
+                <div
+                    style={{
+                        paddingLeft: '0px',
+                    }}
+                >
+                    <Table
+                        columns={columns}
+                        data={tableData}
+                        sort={false}
                     />
-                    <ClientSideTableFooter table={table} />
-                </>
-            ) : (
-                <div className='col-12 mt-1 text-center'>
-                    <Spinner className='spinner' />
                 </div>
-            )}
-        </div>
+            </div>
+
+            <Modal
+                size='lg'
+                centered
+                show={showModal}
+                onHide={() => {
+                    setShowModal(false)
+                    setSelectedPkgId(null)
+                    setAlert(null)
+                    setDeleting(false)
+                }}
+                aria-labelledby='delete-package-modal'
+                scrollable
+            >
+                <Modal.Header
+                    style={{
+                        backgroundColor: '#feefef',
+                        color: '#da1414',
+                    }}
+                    closeButton
+                >
+                    <Modal.Title id='delete-package-modal'>{t('Delete Package')}?</Modal.Title>
+                </Modal.Header>
+
+                <Modal.Body>
+                    {alert && (
+                        <Alert variant={alert.variant} className="mb-3">
+                            {alert.message}
+                        </Alert>
+                    )}
+                    {!alert && selectedPkg && (
+                        <p>
+                            {t('Do you really want to delete the package')}{' '}
+                            <strong>
+                                {selectedPkg.name}{selectedPkg.version ? ` (${selectedPkg.version})` : ''}
+                            </strong>
+                            ?
+                        </p>
+                    )}
+                </Modal.Body>
+
+                <Modal.Footer>
+                    {alert ? (
+                        <button
+                            className='btn btn-dark'
+                            onClick={() => {
+                                setShowModal(false)
+                                setSelectedPkgId(null)
+                                setAlert(null)
+                                setDeleting(false)
+                            }}
+                        >
+                            {t('Close')}
+                        </button>
+                    ) : (
+                        <>
+                            <button
+                                className='btn btn-dark'
+                                onClick={() => {
+                                    setShowModal(false)
+                                    setSelectedPkgId(null)
+                                }}
+                                disabled={deleting}
+                            >
+                                {t('Cancel')}
+                            </button>
+                            <button
+                                className='btn btn-danger'
+                                onClick={() => void deleteLinkedPackage()}
+                                disabled={deleting}
+                            >
+                                {t('Delete Package')}
+                                {deleting && (
+                                    <Spinner
+                                        size='sm'
+                                        className='ms-1 spinner'
+                                    />
+                                )}
+                            </button>
+                        </>
+                    )}
+                </Modal.Footer>
+            </Modal>
+        </>
     )
 }

--- a/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
+++ b/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
@@ -31,7 +31,7 @@ import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
-    setLinkedPackageData: React.Dispatch<React.SetStateAction<Map<string, LinkedPackageData>>>
+    setLinkedPackageData: (map: Map<string, LinkedPackageData>) => void
     projectPayload: ProjectPayload
     setProjectPayload: React.Dispatch<React.SetStateAction<ProjectPayload>>
     show: boolean
@@ -408,23 +408,23 @@ export default function LinkPackagesModal({
                 <Button
                     variant='primary'
                     onClick={() => {
-                        setLinkedPackageData((prevMap) => {
-                            const updatedMap = new Map(prevMap)
-                            linkPackages.forEach((item, key) => {
-                                if (!updatedMap.has(key)) {
-                                    updatedMap.set(key, {
-                                        packageId: key,
-                                        name: item.name,
-                                        version: item.version,
-                                        licenseIds: item.licenseIds,
-                                        packageManager: item.packageManager,
-                                    })
-                                }
-                            })
-                            return updatedMap
+                        const updatedMap = new Map<string, LinkedPackageData>()
+                        linkPackages.forEach((item, key) => {
+                            if (!updatedMap.has(key)) {
+                                updatedMap.set(key, {
+                                    packageId: key,
+                                    name: item.name,
+                                    version: item.version,
+                                    licenseIds: item.licenseIds,
+                                    packageManager: item.packageManager,
+                                })
+                            }
                         })
+                        setLinkedPackageData(updatedMap)
+                        if (projectPayload !== undefined && setProjectPayload !== undefined) {
+                            projectPayloadSetter(updatedMap)
+                        }
                         setShow(false)
-                        projectPayloadSetter(linkPackages)
                     }}
                     disabled={linkPackages.size === 0}
                 >


### PR DESCRIPTION
This PR enhances the Release Edit Page by introducing the missing LinkedPackagesTab and enabling proper linkage and deletion of packages for a release.

- Linked packages for releases can now be viewed, linked, and deleted directly from the edit page.
- Shared modal (LinkPackagesModal.tsx) works dynamically for both projects and releases.
- Deleting linked packages updates UI and payload correctly.