### PR TITLE
fix(Breadcrumb): Fix homepage redirection when using breadcrumb navigation

### DIFF
--- a/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
@@ -11,9 +11,10 @@
 
 'use client'
 
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
-import { useParams } from 'next/navigation'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import Breadcrumb from 'react-bootstrap/Breadcrumb'
 
@@ -66,7 +67,9 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         if (session.status === 'unauthenticated') {
             void signOut()
         }
-    }, [session])
+    }, [
+        session,
+    ])
 
     const fetchData = useCallback(
         async (url: string) => {
@@ -81,7 +84,9 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                 return undefined
             }
         },
-        [session],
+        [
+            session,
+        ],
     )
 
     const downloadBundle = async () => {
@@ -123,7 +128,10 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                 }
             })
             .catch((err) => console.error(err))
-    }, [componentId, fetchData])
+    }, [
+        componentId,
+        fetchData,
+    ])
 
     const getSubcribersEmail = (component: Component) => {
         return component._embedded !== undefined && component._embedded['sw360:subscribers'] !== undefined
@@ -213,7 +221,12 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         number: 0,
     })
     const [changeLogList, setChangeLogList] = useState<Changelogs[]>(() => [])
-    const memoizedData = useMemo(() => changeLogList, [changeLogList])
+    const memoizedData = useMemo(
+        () => changeLogList,
+        [
+            changeLogList,
+        ],
+    )
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
@@ -231,7 +244,12 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                 if (CommonUtils.isNullOrUndefined(session.data)) return signOut()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${componentId}`,
-                    Object.fromEntries(Object.entries(pageableQueryParam).map(([key, value]) => [key, String(value)])),
+                    Object.fromEntries(
+                        Object.entries(pageableQueryParam).map(([key, value]) => [
+                            key,
+                            String(value),
+                        ]),
+                    ),
                 )
 
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
@@ -265,7 +283,11 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         })()
 
         return () => controller.abort()
-    }, [pageableQueryParam, componentId, session])
+    }, [
+        pageableQueryParam,
+        componentId,
+        session,
+    ])
 
     const param = useParams()
     const locale = (param.locale as string) || 'en'
@@ -275,7 +297,12 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         component && (
             <>
                 <Breadcrumb className='container page-content'>
-                    <Breadcrumb.Item href={componentsPath}>{t('Components')}</Breadcrumb.Item>
+                    <Breadcrumb.Item
+                        linkAs={Link}
+                        href={componentsPath}
+                    >
+                        {t('Components')}
+                    </Breadcrumb.Item>
                     <Breadcrumb.Item active>{component.name}</Breadcrumb.Item>
                 </Breadcrumb>
                 <div className='container page-content'>
@@ -291,7 +318,9 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                         <div className='col'>
                             <div
                                 className='row'
-                                style={{ marginBottom: '20px' }}
+                                style={{
+                                    marginBottom: '20px',
+                                }}
                             >
                                 <PageButtonHeader
                                     title={component.name}
@@ -326,7 +355,10 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                                             <a
                                                 className={`nav-item nav-link ${changelogTab === 'list-change' ? 'active' : ''}`}
                                                 onClick={() => setChangelogTab('list-change')}
-                                                style={{ color: '#F7941E', fontWeight: 'bold' }}
+                                                style={{
+                                                    color: '#F7941E',
+                                                    fontWeight: 'bold',
+                                                }}
                                             >
                                                 {t('Change Log')}
                                             </a>
@@ -337,7 +369,10 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                                                         setChangelogTab('view-log')
                                                     }
                                                 }}
-                                                style={{ color: '#F7941E', fontWeight: 'bold' }}
+                                                style={{
+                                                    color: '#F7941E',
+                                                    fontWeight: 'bold',
+                                                }}
                                             >
                                                 {t('Changes')}
                                             </a>
@@ -406,7 +441,9 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                                         />
                                         <div
                                             id='cardScreen'
-                                            style={{ padding: '0px' }}
+                                            style={{
+                                                padding: '0px',
+                                            }}
                                         ></div>
                                     </div>
                                 </div>

--- a/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
@@ -11,12 +11,13 @@
 
 'use client'
 
+import Link from 'next/link'
+import { notFound, useParams, useRouter, useSearchParams } from 'next/navigation'
 import { getSession, signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
-import { notFound, useParams, useRouter, useSearchParams } from 'next/navigation'
+import { PageButtonHeader, SideBar } from 'next-sw360'
 import { ReactNode, useEffect, useState } from 'react'
 import Breadcrumb from 'react-bootstrap/Breadcrumb'
-
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import EditAttachments from '@/components/Attachments/EditAttachments'
 import AddCommercialDetails from '@/components/CommercialDetails/AddCommercialDetails'
@@ -24,8 +25,8 @@ import CreateMRCommentDialog from '@/components/CreateMRCommentDialog/CreateMRCo
 import LinkedReleases from '@/components/LinkedReleases/LinkedReleases'
 import {
     ActionType,
-    COTSDetails,
     ClearingInformation,
+    COTSDetails,
     CommonTabIds,
     Creator,
     DocumentCreationInformation,
@@ -41,7 +42,6 @@ import {
 } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
-import { PageButtonHeader, SideBar } from 'next-sw360'
 import DeleteReleaseModal from '../../../detail/[id]/components/DeleteReleaseModal'
 import EditClearingDetails from './EditClearingDetails'
 import EditECCDetails from './EditECCDetails'
@@ -73,7 +73,9 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
         if (status === 'unauthenticated') {
             signOut()
         }
-    }, [status])
+    }, [
+        status,
+    ])
 
     const [SPDXPayload, setSPDXPayload] = useState<SPDX>({
         spdxDocument: null,
@@ -205,7 +207,9 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                             if (licenseId !== undefined) result[licenseId] = item.fullName ?? ''
                             return result
                         },
-                        {} as { [k: string]: string },
+                        {} as {
+                            [k: string]: string
+                        },
                     )
                     setMainLicenses(mainLicenses)
                 }
@@ -217,7 +221,9 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                             if (licenseId !== undefined) result[licenseId] = item.fullName ?? ''
                             return result
                         },
-                        {} as { [k: string]: string },
+                        {} as {
+                            [k: string]: string
+                        },
                     )
                     setOtherLicenses(otherLicenses)
                 }
@@ -230,7 +236,9 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                 console.error(e)
             }
         })()
-    }, [releaseId])
+    }, [
+        releaseId,
+    ])
 
     const [releasePayload, setReleasePayload] = useState<Release>({
         name: '',
@@ -315,11 +323,17 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
         fullName: '',
     })
 
-    const [mainLicenses, setMainLicenses] = useState<{ [k: string]: string }>({})
+    const [mainLicenses, setMainLicenses] = useState<{
+        [k: string]: string
+    }>({})
 
-    const [otherLicenses, setOtherLicenses] = useState<{ [k: string]: string }>({})
+    const [otherLicenses, setOtherLicenses] = useState<{
+        [k: string]: string
+    }>({})
 
-    const [cotsResponsible, setCotsResponsible] = useState<{ [k: string]: string }>({})
+    const [cotsResponsible, setCotsResponsible] = useState<{
+        [k: string]: string
+    }>({})
 
     const [errorLicenseIdentifier, setErrorLicenseIdentifier] = useState(false)
     const [errorExtractedText, setErrorExtractedText] = useState(false)
@@ -457,14 +471,23 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
     }
 
     const headerButtons = {
-        'Update Release': { link: '', type: 'primary', onClick: checkPreRequisite, name: t('Update Release') },
+        'Update Release': {
+            link: '',
+            type: 'primary',
+            onClick: checkPreRequisite,
+            name: t('Update Release'),
+        },
         'Delete Release': {
             link: '',
             type: 'danger',
             onClick: handleDeleteRelease,
             name: t('Delete Release'),
         },
-        Cancel: { link: '/components/releases/detail/' + releaseId, type: 'secondary', name: t('Cancel') },
+        Cancel: {
+            link: '/components/releases/detail/' + releaseId,
+            type: 'secondary',
+            name: t('Cancel'),
+        },
     }
 
     const param = useParams()
@@ -475,8 +498,18 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
         release && (
             <>
                 <Breadcrumb className='container page-content'>
-                    <Breadcrumb.Item href={componentsPath}>{t('Components')}</Breadcrumb.Item>
-                    <Breadcrumb.Item href={`${componentsPath}/detail/${componentId}`}>{release.name}</Breadcrumb.Item>
+                    <Breadcrumb.Item
+                        linkAs={Link}
+                        href={componentsPath}
+                    >
+                        {t('Components')}
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item
+                        linkAs={Link}
+                        href={`${componentsPath}/detail/${componentId}`}
+                    >
+                        {release.name}
+                    </Breadcrumb.Item>
                     <Breadcrumb.Item active>{`${release.name} (${release.version})`}</Breadcrumb.Item>
                 </Breadcrumb>
                 <CreateMRCommentDialog<Release>
@@ -497,7 +530,9 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                         <div className='col'>
                             <div
                                 className='row'
-                                style={{ marginBottom: '20px' }}
+                                style={{
+                                    marginBottom: '20px',
+                                }}
                             >
                                 <PageButtonHeader
                                     buttons={headerButtons}
@@ -613,4 +648,6 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
 }
 
 // Pass notAllowedUserGroups to AccessControl to restrict access
-export default AccessControl(EditRelease, [UserGroupType.SECURITY_USER])
+export default AccessControl(EditRelease, [
+    UserGroupType.SECURITY_USER,
+])

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -11,10 +11,10 @@
 
 'use client'
 
-import { signOut, useSession } from 'next-auth/react'
-import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { notFound, useParams } from 'next/navigation'
+import { signOut, useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Dropdown } from 'react-bootstrap'
 import Breadcrumb from 'react-bootstrap/Breadcrumb'
@@ -89,7 +89,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
         if (session.status === 'unauthenticated') {
             void signOut()
         }
-    }, [session])
+    }, [
+        session,
+    ])
 
     const fetchData = useCallback(
         async (url: string) => {
@@ -107,7 +109,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 return undefined
             }
         },
-        [session],
+        [
+            session,
+        ],
     )
 
     const getSubcribersEmail = (release: ReleaseDetail) => {
@@ -180,7 +184,11 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 }
             })
             .catch((err) => console.error(err))
-    }, [fetchData, releaseId, session])
+    }, [
+        fetchData,
+        releaseId,
+        session,
+    ])
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -194,7 +202,12 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
         number: 0,
     })
     const [changeLogList, setChangeLogList] = useState<Changelogs[]>(() => [])
-    const memoizedData = useMemo(() => changeLogList, [changeLogList])
+    const memoizedData = useMemo(
+        () => changeLogList,
+        [
+            changeLogList,
+        ],
+    )
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
@@ -212,7 +225,12 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 if (CommonUtils.isNullOrUndefined(session.data)) return signOut()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${releaseId}`,
-                    Object.fromEntries(Object.entries(pageableQueryParam).map(([key, value]) => [key, String(value)])),
+                    Object.fromEntries(
+                        Object.entries(pageableQueryParam).map(([key, value]) => [
+                            key,
+                            String(value),
+                        ]),
+                    ),
                 )
 
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
@@ -246,7 +264,11 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
         })()
 
         return () => controller.abort()
-    }, [pageableQueryParam, releaseId, session])
+    }, [
+        pageableQueryParam,
+        releaseId,
+        session,
+    ])
 
     const downloadBundle = async () => {
         if (CommonUtils.isNullOrUndefined(session)) return signOut()
@@ -314,8 +336,14 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
         release && (
             <>
                 <Breadcrumb className='container page-content'>
-                    <Breadcrumb.Item href={componentsPath}>{t('Components')}</Breadcrumb.Item>
                     <Breadcrumb.Item
+                        linkAs={Link}
+                        href={componentsPath}
+                    >
+                        {t('Components')}
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item
+                        linkAs={Link}
                         href={`${componentsPath}/detail/${release._links['sw360:component'].href.split('/').at(-1)}`}
                     >
                         {componentName}
@@ -336,7 +364,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                         <div className='col'>
                             <div
                                 className='row'
-                                style={{ marginBottom: '20px' }}
+                                style={{
+                                    marginBottom: '20px',
+                                }}
                             >
                                 <div
                                     className='col-auto pe-0 btn-group'
@@ -351,7 +381,10 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                         </Dropdown.Toggle>
                                         <Dropdown.Menu>
                                             {Object.entries(releasesSameComponent).map(
-                                                ([index, item]: [string, ReleaseLink]) => (
+                                                ([index, item]: [
+                                                    string,
+                                                    ReleaseLink,
+                                                ]) => (
                                                     <Dropdown.Item
                                                         key={index}
                                                         className={styles['dropdown-item']}
@@ -404,7 +437,10 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                                 <a
                                                     className={`nav-item nav-link ${changelogTab === 'list-change' ? 'active' : ''}`}
                                                     onClick={() => setChangelogTab('list-change')}
-                                                    style={{ color: '#F7941E', fontWeight: 'bold' }}
+                                                    style={{
+                                                        color: '#F7941E',
+                                                        fontWeight: 'bold',
+                                                    }}
                                                 >
                                                     {t('Change Log')}
                                                 </a>
@@ -415,7 +451,10 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                                             setChangelogTab('view-log')
                                                         }
                                                     }}
-                                                    style={{ color: '#F7941E', fontWeight: 'bold' }}
+                                                    style={{
+                                                        color: '#F7941E',
+                                                        fontWeight: 'bold',
+                                                    }}
                                                 >
                                                     {t('Changes')}
                                                 </a>
@@ -519,7 +558,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                         />
                                         <div
                                             id='cardScreen'
-                                            style={{ padding: '0px' }}
+                                            style={{
+                                                padding: '0px',
+                                            }}
                                         ></div>
                                     </div>
                                 </div>

--- a/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
+++ b/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
@@ -9,15 +9,16 @@
 
 'use client'
 
+import Link from 'next/link'
+import { notFound, useParams, useRouter } from 'next/navigation'
+import { signOut, useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { ReactNode, useEffect, useState } from 'react'
+import { Breadcrumb, ListGroup, Spinner, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { HttpStatus, Package, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
-import { signOut, useSession } from 'next-auth/react'
-import { useTranslations } from 'next-intl'
-import { notFound, useParams, useRouter } from 'next/navigation'
-import { ReactNode, useEffect, useState } from 'react'
-import { Breadcrumb, ListGroup, Spinner, Tab } from 'react-bootstrap'
 import ChangeLog from './Changelog'
 import Summary from './Summary'
 
@@ -34,7 +35,9 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
         if (status === 'unauthenticated') {
             signOut()
         }
-    }, [status])
+    }, [
+        status,
+    ])
 
     useEffect(() => {
         if (status !== 'authenticated') return
@@ -53,14 +56,21 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
 
                 const data = (await response.json()) as Package
 
-                setSummaryData({ id: packageId, ...data })
+                setSummaryData({
+                    id: packageId,
+                    ...data,
+                })
             } catch (e) {
                 console.error(e)
             }
         })()
 
         return () => controller.abort()
-    }, [packageId, session, status])
+    }, [
+        packageId,
+        session,
+        status,
+    ])
 
     const handleEditPackage = () => {
         if (CommonUtils.isNullOrUndefined(session)) return signOut()
@@ -76,7 +86,12 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
     return (
         <>
             <Breadcrumb className='container page-content'>
-                <Breadcrumb.Item href={packagesPath}>{t('Packages')}</Breadcrumb.Item>
+                <Breadcrumb.Item
+                    linkAs={Link}
+                    href={packagesPath}
+                >
+                    {t('Packages')}
+                </Breadcrumb.Item>
                 <Breadcrumb.Item active>
                     {summaryData ? `${summaryData.name} (${summaryData.version})` : packageId}
                 </Breadcrumb.Item>
@@ -123,7 +138,9 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
                                         {!summaryData ? (
                                             <div
                                                 className='col-12'
-                                                style={{ textAlign: 'center' }}
+                                                style={{
+                                                    textAlign: 'center',
+                                                }}
                                             >
                                                 <Spinner className='spinner' />
                                             </div>
@@ -145,4 +162,6 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
 }
 
 // Pass notAllowedUserGroups to AccessControl to restrict access
-export default AccessControl(PackageDetailTab, [UserGroupType.SECURITY_USER])
+export default AccessControl(PackageDetailTab, [
+    UserGroupType.SECURITY_USER,
+])

--- a/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestDetail.tsx
+++ b/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestDetail.tsx
@@ -9,18 +9,18 @@
 
 'use client'
 
+import dynamic from 'next/dynamic'
+import Link from 'next/link'
+import { notFound, useParams, useRouter } from 'next/navigation'
+import { getSession, signOut, useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { ShowInfoOnHover } from 'next-sw360'
+import { ReactNode, useEffect, useRef, useState } from 'react'
+import { Breadcrumb, Button, Card, Col, Collapse, Row, Tab } from 'react-bootstrap'
 import styles from '@/app/[locale]/requests/requestDetail.module.css'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ClearingRequestDetails, HttpStatus, UserGroupType } from '@/object-types'
 import { ApiUtils, CommonUtils } from '@/utils/index'
-import { getSession, signOut, useSession } from 'next-auth/react'
-import { useTranslations } from 'next-intl'
-import { ShowInfoOnHover } from 'next-sw360'
-import dynamic from 'next/dynamic'
-import Link from 'next/link'
-import { notFound, useParams, useRouter } from 'next/navigation'
-import { ReactNode, useEffect, useRef, useState } from 'react'
-import { Breadcrumb, Button, Card, Col, Collapse, Row, Tab } from 'react-bootstrap'
 import ReopenClosedClearingRequestModal from '../../../edit/[id]/components/ReopenClosedClearingRequestModal'
 import ClearingDecision from './ClearingDecision'
 import ClearingRequestInfo from './ClearingRequestInfo'
@@ -43,7 +43,9 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
         if (status === 'unauthenticated') {
             signOut()
         }
-    }, [status])
+    }, [
+        status,
+    ])
 
     const ClearingComments = dynamic(() => import('./ClearingComments'), {
         ssr: false,
@@ -82,7 +84,9 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                 setClearingRequestData(clearingRequestDetails)
             },
         )
-    }, [clearingRequestId])
+    }, [
+        clearingRequestId,
+    ])
 
     const handleEditClearingRequest = (requestId: string | undefined) => {
         router.push(`/requests/clearingRequest/edit/${requestId}`)
@@ -99,7 +103,12 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                 setShow={setShowReopenClearingRequestModal}
             />
             <Breadcrumb className='container page-content'>
-                <Breadcrumb.Item href={requestsPath}>{t('Requests')}</Breadcrumb.Item>
+                <Breadcrumb.Item
+                    linkAs={Link}
+                    href={requestsPath}
+                >
+                    {t('Requests')}
+                </Breadcrumb.Item>
                 <Breadcrumb.Item active>{clearingRequestData?.id || clearingRequestId}</Breadcrumb.Item>
             </Breadcrumb>
             <div className='ms-5 mt-2'>
@@ -138,7 +147,10 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                                 <Card className={`${styles['card']}`}>
                                     <div
                                         onClick={() => toggleCollapse(0)}
-                                        style={{ cursor: 'pointer', padding: '0' }}
+                                        style={{
+                                            cursor: 'pointer',
+                                            padding: '0',
+                                        }}
                                     >
                                         <Card.Header
                                             className={`
@@ -192,7 +204,10 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
                                 <Card className={`${styles['card']}`}>
                                     <div
                                         onClick={() => toggleCollapse(1)}
-                                        style={{ cursor: 'pointer', padding: '0' }}
+                                        style={{
+                                            cursor: 'pointer',
+                                            padding: '0',
+                                        }}
                                     >
                                         <Card.Header
                                             className={`
@@ -237,4 +252,6 @@ function ClearingRequestDetail({ clearingRequestId }: { clearingRequestId: strin
 }
 
 // Pass notAllowedUserGroups to AccessControl to restrict access
-export default AccessControl(ClearingRequestDetail, [UserGroupType.SECURITY_USER])
+export default AccessControl(ClearingRequestDetail, [
+    UserGroupType.SECURITY_USER,
+])

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/ModerationRequestDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/ModerationRequestDetail.tsx
@@ -9,22 +9,23 @@
 
 'use client'
 
+import Link from 'next/link'
+import { notFound, useParams, useRouter } from 'next/navigation'
+import { getSession, signOut, useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { ReactNode, useEffect, useRef, useState } from 'react'
+import { Breadcrumb, Button, Card, Col, Collapse, Row, Tab } from 'react-bootstrap'
 import styles from '@/app/[locale]/requests/requestDetail.module.css'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { HttpStatus, ModerationRequestDetails, ModerationRequestPayload, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
-import { getSession, signOut, useSession } from 'next-auth/react'
-import { useTranslations } from 'next-intl'
-import { notFound, useParams, useRouter } from 'next/navigation'
-import { ReactNode, useEffect, useRef, useState } from 'react'
-import { Breadcrumb, Button, Card, Col, Collapse, Row, Tab } from 'react-bootstrap'
-import ModerationDecision from './ModerationDecision'
-import ModerationRequestInfo from './ModerationRequestInfo'
-import ProposedChanges from './ProposedChanges'
 import CurrentComponentDetail from './currentComponent/CurrentComponentDetail'
 import CurrentProjectDetail from './currentProject/CurrentProjectDetail'
 import CurrentReleaseDetail from './currentRelease/CurrentReleaseDetail'
+import ModerationDecision from './ModerationDecision'
+import ModerationRequestInfo from './ModerationRequestInfo'
+import ProposedChanges from './ProposedChanges'
 
 function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId: string }): ReactNode | undefined {
     const t = useTranslations('default')
@@ -72,7 +73,9 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
         if (status === 'unauthenticated') {
             signOut()
         }
-    }, [status])
+    }, [
+        status,
+    ])
 
     const fetchData = async (url: string) => {
         const session = await getSession()
@@ -254,7 +257,12 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
     return (
         <>
             <Breadcrumb className='container page-content'>
-                <Breadcrumb.Item href={requestsPath}>{t('Requests')}</Breadcrumb.Item>
+                <Breadcrumb.Item
+                    linkAs={Link}
+                    href={requestsPath}
+                >
+                    {t('Requests')}
+                </Breadcrumb.Item>
                 <Breadcrumb.Item active>
                     {moderationRequestData &&
                     (moderationRequestData.documentType === 'COMPONENT' ||
@@ -327,7 +335,10 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
                                 <Card className={`${styles['card']}`}>
                                     <div
                                         onClick={() => toggleCollapse(0)}
-                                        style={{ cursor: 'pointer', padding: '0' }}
+                                        style={{
+                                            cursor: 'pointer',
+                                            padding: '0',
+                                        }}
                                     >
                                         <Card.Header
                                             className={`
@@ -370,7 +381,10 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
                                 <Card className={`${styles['card']}`}>
                                     <div
                                         onClick={() => toggleCollapse(1)}
-                                        style={{ cursor: 'pointer', padding: '0' }}
+                                        style={{
+                                            cursor: 'pointer',
+                                            padding: '0',
+                                        }}
                                     >
                                         <Card.Header
                                             className={`
@@ -408,7 +422,10 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
                                 <Card className={`${styles['card']}`}>
                                     <div
                                         onClick={() => toggleCollapse(2)}
-                                        style={{ cursor: 'pointer', padding: '0' }}
+                                        style={{
+                                            cursor: 'pointer',
+                                            padding: '0',
+                                        }}
                                     >
                                         <Card.Header
                                             className={`
@@ -466,4 +483,6 @@ function ModerationRequestDetail({ moderationRequestId }: { moderationRequestId:
 }
 
 // Pass notAllowedUserGroups to AccessControl to restrict access
-export default AccessControl(ModerationRequestDetail, [UserGroupType.SECURITY_USER])
+export default AccessControl(ModerationRequestDetail, [
+    UserGroupType.SECURITY_USER,
+])

--- a/src/app/[locale]/vulnerabilities/detail/[id]/components/VulnerabilityDetailsTab.tsx
+++ b/src/app/[locale]/vulnerabilities/detail/[id]/components/VulnerabilityDetailsTab.tsx
@@ -9,14 +9,15 @@
 
 'use client'
 
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+import { getSession, signOut, useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import { ReactNode, useEffect, useState } from 'react'
+import { Breadcrumb, Col, ListGroup, Row, Spinner, Tab } from 'react-bootstrap'
 import { ErrorDetails, HttpStatus, Vulnerability } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
-import { getSession, signOut, useSession } from 'next-auth/react'
-import { useTranslations } from 'next-intl'
-import { useParams } from 'next/navigation'
-import { ReactNode, useEffect, useState } from 'react'
-import { Breadcrumb, Col, ListGroup, Row, Spinner, Tab } from 'react-bootstrap'
 import MetaData from './MetaData'
 import References from './References'
 import Summary from './Summary'
@@ -33,7 +34,9 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
         if (status === 'unauthenticated') {
             signOut()
         }
-    }, [status])
+    }, [
+        status,
+    ])
 
     useEffect(() => {
         const controller = new AbortController()
@@ -68,12 +71,19 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
         })()
 
         return () => controller.abort()
-    }, [vulnerabilityId])
+    }, [
+        vulnerabilityId,
+    ])
 
     return (
         <>
             <Breadcrumb className='container page-content'>
-                <Breadcrumb.Item href={vulnerabilitiesPath}>{t('Vulnerabilities')}</Breadcrumb.Item>
+                <Breadcrumb.Item
+                    linkAs={Link}
+                    href={vulnerabilitiesPath}
+                >
+                    {t('Vulnerabilities')}
+                </Breadcrumb.Item>
                 <Breadcrumb.Item active>{summaryData ? summaryData.externalId : vulnerabilityId}</Breadcrumb.Item>
             </Breadcrumb>
             <div className='ms-5 mt-2'>
@@ -112,7 +122,9 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
                                         {!summaryData ? (
                                             <div
                                                 className='col-12'
-                                                style={{ textAlign: 'center' }}
+                                                style={{
+                                                    textAlign: 'center',
+                                                }}
                                             >
                                                 <Spinner className='spinner' />
                                             </div>
@@ -124,7 +136,9 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
                                         {!summaryData ? (
                                             <div
                                                 className='col-12'
-                                                style={{ textAlign: 'center' }}
+                                                style={{
+                                                    textAlign: 'center',
+                                                }}
                                             >
                                                 <Spinner className='spinner' />
                                             </div>
@@ -136,7 +150,9 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
                                         {!summaryData ? (
                                             <div
                                                 className='col-12'
-                                                style={{ textAlign: 'center' }}
+                                                style={{
+                                                    textAlign: 'center',
+                                                }}
                                             >
                                                 <Spinner className='spinner' />
                                             </div>


### PR DESCRIPTION
Replaces breadcrumb using `href` prop which is triggering full page reload causing redirect to homepage with  `Link from 'next/link `This ensures in‑app navigation without unexpected authentication callback redirects. 