### PR TITLE
style(attachments): highlight disabled Upload button to match active state

### DIFF
--- a/src/components/Attachments/SelectAttachment/SelectAttachment.tsx
+++ b/src/components/Attachments/SelectAttachment/SelectAttachment.tsx
@@ -188,6 +188,7 @@ function SelectAttachment({ show, setShow, attachmentsData, setAttachmentsData }
                     <Button
                         type='button'
                         variant='primary'
+                        className='upload-btn'
                         disabled={files.length === 0}
                         onClick={() => void handleUploadFiles()}
                     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -252,6 +252,14 @@ body {
     color: var(--sw360-primary-color) !important;
 }
 
+.upload-btn:disabled {
+    background-color: var(--sw360-primary-color) !important;
+    border-color: var(--sw360-primary-color) !important;
+    color: #fff !important;
+    opacity: 0.8 !important;
+    cursor: not-allowed !important;
+}
+
 .btn-info {
     background-color: #2e5aac !important;
     border-color: #2e5aac !important;


### PR DESCRIPTION
This PR updates the global button styling to visually highlight disabled primary buttons.
-  Such as the “Upload” button in the attachment modal, ensuring they match the active SW360 theme color.

<img width="815" height="381" alt="image" src="https://github.com/user-attachments/assets/f4959a4b-63dc-4507-90c3-8f38331603ca" />
