### PR TITLE
Fix/copy to clipboard in Project page

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -310,6 +310,7 @@
     "Contributor": "Beitrag",
     "Contributors": "Beiträge",
     "Copy to Clipboard": "Kopie an Clipboard",
+    "Copied": "Kopiert",
     "Count of Security Vulnerabilities": "Anzahl der Sicherheitslücken",
     "Create": "Erstellen",
     "Create Account": "Konto erstellen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -310,6 +310,7 @@
     "Contributor": "Contributor",
     "Contributors": "Contributors",
     "Copy to Clipboard": "Copy to Clipboard",
+    "Copied": "Copied",
     "Count of Security Vulnerabilities": "Count of Security Vulnerabilities",
     "Create": "Create",
     "Create Account": "Create Account",

--- a/messages/es.json
+++ b/messages/es.json
@@ -310,6 +310,7 @@
     "Contributor": "Contributor",
     "Contributors": "Distribuidores",
     "Copy to Clipboard": "Copiado para el tablero",
+    "Copied": "Copiado",
     "Count of Security Vulnerabilities": "Cuenta de vulnerabilidades de seguridad",
     "Create": "Crear",
     "Create Account": "Crear cuenta",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -310,6 +310,7 @@
     "Contributor": "Contributeur",
     "Contributors": "Contributeurs",
     "Copy to Clipboard": "Copier dans Clipboard",
+    "Copied": "Copié",
     "Count of Security Vulnerabilities": "Nombre de vulnérabilités en matière de sécurité",
     "Create": "Créer",
     "Create Account": "Créer un compte",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -310,6 +310,7 @@
     "Contributor": "投稿者",
     "Contributors": "貢献者",
     "Copy to Clipboard": "Copy to Clipboard",
+    "Copied": "Copied",
     "Count of Security Vulnerabilities": "Count of Security Vulnerabilities",
     "Create": "作成する",
     "Create Account": "アカウントの作成",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -310,6 +310,7 @@
     "Contributor": "회사 소개",
     "Contributors": "회사 소개",
     "Copy to Clipboard": "클립보드에 복사",
+    "Copied": "복사됨",
     "Count of Security Vulnerabilities": "보안 취약점 조사",
     "Create": "만들다",
     "Create Account": "계정 만들기",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -310,6 +310,7 @@
     "Contributor": "Colaborador",
     "Contributors": "Colaboradores",
     "Copy to Clipboard": "Copiar para a área de transferência",
+    "Copied": "Copiado",
     "Count of Security Vulnerabilities": "Contagem de vulnerabilidades de segurança",
     "Create": "Criar",
     "Create Account": "Criar Conta",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -310,6 +310,7 @@
     "Contributor": "Người đóng góp",
     "Contributors": "Người đóng góp",
     "Copy to Clipboard": "Sao chép vào clipboard",
+    "Copied": "Đã sao chép",
     "Count of Security Vulnerabilities": "Số lượng lỗ hổng bảo mật",
     "Create": "Tạo",
     "Create Account": "Tạo tài khoản",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -310,6 +310,7 @@
     "Contributor": "贡献者",
     "Contributors": "贡献者",
     "Copy to Clipboard": "复制到剪贴板",
+    "Copied": "已复制",
     "Count of Security Vulnerabilities": "安全漏洞数量",
     "Create": "创造",
     "Create Account": "创建账户",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -310,6 +310,7 @@
     "Contributor": "撰稿人",
     "Contributors": "贡献者",
     "Copy to Clipboard": "复制到剪貼簿",
+    "Copied": "已複製",
     "Count of Security Vulnerabilities": "安全脆弱性",
     "Create": "創造",
     "Create Account": "建立帳號",

--- a/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
@@ -38,18 +38,28 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
     }, [status])
 
     const Clipboard = ({ text }: { text: string }) => {
+        const [copied, setCopied] = useState(false)
+
+        async function handleCopy() {
+            try {
+                await navigator.clipboard.writeText(text)
+                setCopied(true)
+            } catch (e) {
+                console.error(e)
+            }
+        }
         return (
-            <>
-                <OverlayTrigger overlay={<Tooltip>{t('Copy to Clipboard')}</Tooltip>}>
-                    <span className='d-inline-block'>
-                        <BiClipboard
-                            onClick={() => {
-                                void navigator.clipboard.writeText(text)
-                            }}
-                        />
-                    </span>
-                </OverlayTrigger>
-            </>
+            <OverlayTrigger trigger={['hover', 'focus']} placement="top" overlay={(props) => (<Tooltip{...props}>{copied ? t('Copied') : t('Copy to Clipboard')}</Tooltip>)}
+                onToggle={(show) => {
+                    if (show) setCopied(false)
+                }}
+            >
+                <span className='d-inline-block'>
+                    <BiClipboard
+                        onClick={handleCopy}
+                    />
+                </span>
+            </OverlayTrigger>
         )
     }
 
@@ -254,7 +264,7 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
                                         {elem.fullName}
                                     </Link>
                                     {summaryData._embedded?.['sw360:moderators']?.length !== undefined &&
-                                    i === summaryData._embedded['sw360:moderators'].length - 1
+                                        i === summaryData._embedded['sw360:moderators'].length - 1
                                         ? ''
                                         : ','}{' '}
                                 </li>
@@ -277,7 +287,7 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
                                         {elem.fullName}
                                     </Link>
                                     {summaryData._embedded?.['sw360:contributors']?.length !== undefined &&
-                                    i === summaryData._embedded['sw360:contributors'].length - 1
+                                        i === summaryData._embedded['sw360:contributors'].length - 1
                                         ? ''
                                         : ','}{' '}
                                 </li>
@@ -300,7 +310,7 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
                                         {elem.fullName}
                                     </Link>
                                     {summaryData._embedded?.securityResponsibles?.length !== undefined &&
-                                    i === summaryData._embedded.securityResponsibles.length - 1
+                                        i === summaryData._embedded.securityResponsibles.length - 1
                                         ? ''
                                         : ','}{' '}
                                 </li>


### PR DESCRIPTION
Fixed the issue where the “Copy to Clipboard” tooltip didn’t change to “Copied” when clicked.
The tooltip now properly updates to “Copied” on click.