### PR TITLE
fix(CR): Clearing Request creation is disabled wrongly for all projects

### DIFF
--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -214,6 +214,7 @@ function Project(): JSX.Element {
                         row.original.businessUnit ?? '',
                         row.original.clearingState ?? '',
                         clearingRequestDisabledGroups,
+                        row.original.visibility,
                     )
                     return (
                         <>

--- a/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
@@ -41,6 +41,7 @@ function LicenseClearing({
     isCalledFromModerationRequestCurrentProject,
     businessUnit,
     clearingState,
+    visibility,
 }: {
     projectId: string
     projectName: string
@@ -49,6 +50,7 @@ function LicenseClearing({
     isCalledFromModerationRequestCurrentProject?: boolean
     businessUnit: string
     clearingState: string
+    visibility?: string
 }): JSX.Element {
     const t = useTranslations('default')
     const [key, setKey] = useState('tree-view')
@@ -62,8 +64,8 @@ function LicenseClearing({
     const clearingRequestDisabledGroups = useConfigValue(
         UIConfigKeys.UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP,
     ) as string[] | null
-    const crIsAllowed = CommonUtils.isCrAllowed(businessUnit, clearingState, clearingRequestDisabledGroups)
-    const disableCrButton = !(clearingRequestId !== undefined && clearingRequestId !== '') || !crIsAllowed
+    const crIsAllowed = CommonUtils.isCrAllowed(businessUnit, clearingState, clearingRequestDisabledGroups, visibility)
+    const disableCrButton = !crIsAllowed
 
     useEffect(() => {
         if (status === 'unauthenticated') {

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -441,6 +441,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 clearingRequestId={summaryData.clearingRequestId ?? ''}
                                                 businessUnit={summaryData.businessUnit ?? ''}
                                                 clearingState={summaryData.clearingState ?? ''}
+                                                visibility={summaryData.visibility}
                                             />
                                         )}
                                     </Tab.Pane>

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentProject/CurrentProjectDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentProject/CurrentProjectDetail.tsx
@@ -178,6 +178,7 @@ export default function CurrentProjectDetail({
                                             isCalledFromModerationRequestCurrentProject={true}
                                             businessUnit={summaryData.businessUnit ?? ''}
                                             clearingState={summaryData.clearingState ?? ''}
+                                            visibility={summaryData.visibility}
                                         />
                                     )}
                                 </Tab.Pane>

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -304,11 +304,16 @@ const extractEmailsAndFullNamesFromUsers = (
 
 const nullToEmptyString = (item: string | null | undefined): string => (item != null ? item : '')
 
-const isCrAllowed = (businessUnit: string, clearingState: string, clearingRequestDisabledGroups: string[] | null) => {
+const isCrAllowed = (
+    businessUnit: string,
+    clearingState: string,
+    clearingRequestDisabledGroups: string[] | null,
+    visibility?: string,
+) => {
     return (
+        visibility?.toUpperCase() !== 'PRIVATE' &&
         clearingState.toLowerCase() !== 'closed' &&
-        clearingRequestDisabledGroups !== null &&
-        !(businessUnit in clearingRequestDisabledGroups)
+        (clearingRequestDisabledGroups === null || !clearingRequestDisabledGroups.includes(businessUnit))
     )
 }
 


### PR DESCRIPTION
Clearing request creation was blocked for all projects due to bug in the `isCrAllowed` function. Also added check for visibility of project.

<img width="673" height="330" alt="image" src="https://github.com/user-attachments/assets/53141b5a-1450-47a8-8cd5-d61a2f0a24c8" />
