### PR TITLE
fix(vuln): Fix advance search in vulnerabilities

### DIFF
--- a/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
+++ b/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
@@ -72,14 +72,14 @@ function Vulnerabilities(): ReactNode {
 
     const advancedSearch = [
         {
-            fieldName: 'CVE ID',
+            fieldName: 'External Id or Title',
             value: '',
-            paramName: 'externalId',
+            paramName: 'search',
         },
         {
-            fieldName: 'Vulnerable Configuration',
+            fieldName: 'CVE ID',
             value: '',
-            paramName: 'vulnerableConfiguration',
+            paramName: 'cveId',
         },
     ]
 
@@ -362,11 +362,10 @@ function Vulnerabilities(): ReactNode {
             <div className='container page-content'>
                 <div className='row'>
                     <div className='col-lg-2 sidebar'>
-                        <QuickFilter id='vunerabilities.quickSearch' />
-                        <br />
                         <AdvancedSearch
                             title='Advanced Filter'
                             fields={advancedSearch}
+                            enableExactMatch={false}
                         />
                     </div>
                     <div className='col-lg-10'>

--- a/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
@@ -10,13 +10,12 @@
 
 'use client'
 
-import { useTranslations } from 'next-intl'
 import { useRouter, useSearchParams } from 'next/navigation'
-import React, { useEffect, useState, type JSX } from 'react'
-import { Button, Form } from 'react-bootstrap'
-
-import CommonUtils from '@/utils/common.utils'
+import { useTranslations } from 'next-intl'
 import { ShowInfoOnHover } from 'next-sw360'
+import React, { type JSX, useEffect, useState } from 'react'
+import { Button, Form } from 'react-bootstrap'
+import CommonUtils from '@/utils/common.utils'
 
 interface Option {
     key: string
@@ -32,13 +31,14 @@ interface Field {
 interface Props {
     title: string
     fields?: Array<Field>
+    enableExactMatch?: boolean
 }
 
 interface SearchParams {
     [k: string]: string
 }
 
-function AdvancedSearch({ title = 'Advanced Search', fields }: Props): JSX.Element {
+function AdvancedSearch({ title = 'Advanced Search', fields, enableExactMatch = true }: Props): JSX.Element {
     const router = useRouter()
     const t = useTranslations('default')
     const params = Object.fromEntries(useSearchParams())
@@ -229,31 +229,33 @@ function AdvancedSearch({ title = 'Advanced Search', fields }: Props): JSX.Eleme
                     <Form onSubmit={handleSubmit}>
                         {fields?.map((field) => renderField(field))}
 
-                        <Form.Group
-                            className='mb-3'
-                            hidden={isUsersPage}
-                        >
-                            <Form.Check
-                                type='checkbox'
-                                label={t('Exact Match')}
-                                id='exactMatch'
-                                checked={searchParams.exactMatch === 'true'}
-                                onChange={(e) => {
-                                    setIsExactMatch(e.target.checked)
-                                    setSearchParam((prev) => ({
-                                        ...prev,
-                                        exactMatch: e.target.checked ? 'true' : '',
-                                    }))
-                                }}
-                                style={{
-                                    fontWeight: 'bold',
-                                    fontSize: '14px',
-                                    display: 'inline-block',
-                                    marginRight: '5px',
-                                }}
-                            />
-                            <ShowInfoOnHover text={t('Exact_Match_Info')} />
-                        </Form.Group>
+                        {enableExactMatch && (
+                            <Form.Group
+                                className='mb-3'
+                                hidden={isUsersPage}
+                            >
+                                <Form.Check
+                                    type='checkbox'
+                                    label={t('Exact Match')}
+                                    id='exactMatch'
+                                    checked={searchParams.exactMatch === 'true'}
+                                    onChange={(e) => {
+                                        setIsExactMatch(e.target.checked)
+                                        setSearchParam((prev) => ({
+                                            ...prev,
+                                            exactMatch: e.target.checked ? 'true' : '',
+                                        }))
+                                    }}
+                                    style={{
+                                        fontWeight: 'bold',
+                                        fontSize: '14px',
+                                        display: 'inline-block',
+                                        marginRight: '5px',
+                                    }}
+                                />
+                                <ShowInfoOnHover text={t('Exact_Match_Info')} />
+                            </Form.Group>
+                        )}
                         <Form.Group
                             className='mb-3'
                             hidden={!isPackagesPage}


### PR DESCRIPTION
1. Fix Advance search in vulnerabilities page.
2. Allow configuring "Exact Match" in AdvancedSearch component.

Closes #827

This PR depends on backend: https://github.com/eclipse-sw360/sw360/pull/3496