### PR TITLE
Fix bug in license table

### DIFF
--- a/src/app/[locale]/licenses/components/LicensePage.tsx
+++ b/src/app/[locale]/licenses/components/LicensePage.tsx
@@ -118,7 +118,7 @@ function LicensePage(): ReactNode {
             {
                 id: 'licenseType',
                 header: t('License Type'),
-                cell: ({ row }) => <>{row.original.licenseType ?? '--'}</>,
+                cell: ({ row }) => <>{row.original.licenseType?.licenseType ?? '--'}</>,
                 meta: {
                     width: '10%',
                 },


### PR DESCRIPTION
Table not rendering because one field was not correctly accessed