### PR TITLE
feat(css): Add more classes to disabled cursors

### DIFF
--- a/src/components/ProjectAddSummary/component/Summary/GeneralInformation.tsx
+++ b/src/components/ProjectAddSummary/component/Summary/GeneralInformation.tsx
@@ -276,6 +276,7 @@ export default function GeneralInformation({
                             {projectDomains &&
                                 projectDomains.map((domain) => (
                                     <option
+                                        key={domain}
                                         value={domain}
                                         selected={projectPayload.domain === domain}
                                     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -736,7 +736,9 @@ body {
 }
 
 .form-check-input[disabled] ~ .form-check-label,
-.form-check-input:disabled ~ .form-check-label {
+.form-check-input:disabled ~ .form-check-label,
+.form-control[readonly],
+.form-control[disabled] {
     cursor: not-allowed !important;
 }
 


### PR DESCRIPTION
Add `.form-control[readonly]` and `.form-control[disabled]` to list of elements where `cursor: not-allowed`