### PR TITLE
fix(linked-packages): Add missing delete action and confirmation modal

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "Die folgenden doppelten Identifikatoren wurden gefunden.",
     "The license type cannot be deleted": "Der Lizenztyp <strong> {Name} </strong> kann nicht gelöscht werden, da er in <strong> {usageCount} </strong> Lizenz (en) verwendet wird. \nBitte widerrufen die Lizenz zuerst.",
     "The new Component and new Release will be created, do you want to import?": "Die neue Komponente und neue Version werden erstellt, wollen Sie importieren?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "Das Paket kann nicht gelöscht werden, da es von einem anderen Projekt verwendet wird. Bitte trennen Sie die Verknüpfung, bevor Sie es löschen.",
     "The project cannot be deleted": "Das Projekt kann nicht gelöscht werden, da es von einem anderen Projekt verwendet wird!",
     "The projects have been successfully linked to project": "Die Projekte sind erfolgreich mit dem Projekt verbunden",
     "The release has been successfully linked to project": "Die Veröffentlichung <strong>(ReleaseName)</strong> wurde erfolgreich mit dem Projekt verbunden <strong>(Projektname)</strong>",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "The following duplicate identifiers were found.",
     "The license type cannot be deleted": "The license type <strong>{name}</strong> cannot be deleted, since it is being used in <strong>{usageCount}</strong> license(s). Please revoke the license first.",
     "The new Component and new Release will be created, do you want to import?": "The new Component and new Release will be created, do you want to import?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "The Package cannot be deleted, Since it is used by other project. Please unlink it before deleting.",
     "The project cannot be deleted": "The project cannot be deleted, since it is used by another project!",
     "The projects have been successfully linked to project": "The projects have been successfully linked to project",
     "The release has been successfully linked to project": "The release <strong>{releaseName}</strong> has been successfully linked to project <strong>{projectName}</strong>",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "Se encontraron los siguientes identificadores duplicados.",
     "The license type cannot be deleted": "El tipo de licencia <strong> {name} </strong> no se puede eliminar, ya que se está utilizando en <strong> {usageCount} </strong> licencia (s). \nRevoca la licencia primero.",
     "The new Component and new Release will be created, do you want to import?": "Se creará el nuevo componente y nueva versión, ¿quieres importar?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "El paquete no se puede eliminar porque está siendo utilizado por otro proyecto. Desvincúlelo antes de eliminarlo.",
     "The project cannot be deleted": "¡El proyecto no se puede eliminar, ya que es utilizado por otro proyecto!",
     "The projects have been successfully linked to project": "Los proyectos se han relacionado con éxito con el proyecto",
     "The release has been successfully linked to project": "La liberación <strong>{releaseName}</strong> has been successfully linked to project <strong>{proyectoName}</strong>",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "Les identifiants en double suivants ont été trouvés.",
     "The license type cannot be deleted": "Le type de licence <strong> {name} </strong> ne peut pas être supprimé, car il est utilisé dans <strong> {UsageCount} </strong> licence (s). \nVeuillez d'abord révoquer la licence.",
     "The new Component and new Release will be created, do you want to import?": "Le nouveau composant et la nouvelle version seront créés, voulez-vous importer?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "Le paquet ne peut pas être supprimé car il est utilisé par un autre projet. Veuillez le dissocier avant de le supprimer.",
     "The project cannot be deleted": "Le projet ne peut pas être supprimé, car il est utilisé par un autre projet!",
     "The projects have been successfully linked to project": "Les projets ont été liés avec succès au projet",
     "The release has been successfully linked to project": "La libération <strong>{releaseName}</strong> a été lié avec succès au projet <strong>{nom du projet}</strong>",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "次の重複した識別子が見つかりました。",
     "The license type cannot be deleted": "ライセンスタイプ<strong> {name} </strong>は、<strong> {usagecount} </strong>ライセンスで使用されているため、削除できません。\n最初にライセンスを取り消してください。",
     "The new Component and new Release will be created, do you want to import?": "The new Component and new Release will be created, do you want to import?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "このパッケージは別のプロジェクトで使用されているため削除できません。削除する前にリンクを解除してください.",
     "The project cannot be deleted": "別のプロジェクトで使用されているため、プロジェクトは削除することはできません！",
     "The projects have been successfully linked to project": "The projects have been successfully linked to project",
     "The release has been successfully linked to project": "The release <strong>{releaseName}</strong> has been successfully linked to project <strong>{projectName}</strong>",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "다음과 같은 중복 식별자가 발견되었습니다.",
     "The license type cannot be deleted": "라이센스 유형 <strong> {name} </strong>는 <strong> {UsageCount} </strong> 라이센스에 사용되므로 삭제할 수 없습니다. \n라이센스를 먼저 취소하십시오.",
     "The new Component and new Release will be created, do you want to import?": "새로운 구성 요소와 새로운 릴리스를 만들 것입니다, 당신은 가져올 원?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "이 패키지는 다른 프로젝트에서 사용 중이므로 삭제할 수 없습니다. 삭제하기 전에 연결을 해제하십시오.",
     "The project cannot be deleted": "프로젝트는 다른 프로젝트에서 사용되므로 삭제할 수 없습니다!",
     "The projects have been successfully linked to project": "프로젝트는 성공적으로 프로젝트에 연결되었습니다.",
     "The release has been successfully linked to project": "공지사항 <strong>이름 *</strong> 프로젝트에 성공적으로 연결되었습니다. <strong>프로젝트 이름</strong>",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "Os seguintes identificadores duplicados foram encontrados.",
     "The license type cannot be deleted": "O tipo de licença <strong> {nome} </strong> não pode ser excluído, pois está sendo usado em <strong> {useGecount} </strong> licença (s). \nPor favor, revoge a licença primeiro.",
     "The new Component and new Release will be created, do you want to import?": "O novo Componente e a nova Versão serão criados, deseja importar?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "O pacote não pode ser excluído, pois está sendo usado por outro projeto. Desvincule-o antes de excluí-lo.",
     "The project cannot be deleted": "O projeto não pode ser excluído, pois é usado por outro projeto!",
     "The projects have been successfully linked to project": "Os projetos foram vinculados com sucesso ao projeto",
     "The release has been successfully linked to project": "A versão <strong>{releaseName}</strong> foi vinculada com sucesso ao projeto <strong>{projectName}</strong>",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "Đã tìm thấy các số nhận dạng trùng lặp sau đây.",
     "The license type cannot be deleted": "Loại giấy phép <strong> {name} </strong> không thể bị xóa, vì nó đang được sử dụng trong <strong> {UsageCount} </strong> Giấy phép (s). \nVui lòng thu hồi giấy phép trước.",
     "The new Component and new Release will be created, do you want to import?": "Thành phần mới và Bản phát hành mới sẽ được tạo, bạn có muốn nhập không?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "Không thể xóa gói vì nó đang được sử dụng bởi dự án khác. Vui lòng hủy liên kết trước khi xóa.",
     "The project cannot be deleted": "Dự án không thể bị xóa, vì nó được sử dụng bởi một dự án khác!",
     "The projects have been successfully linked to project": "Các dự án đã được liên kết thành công với dự án",
     "The release has been successfully linked to project": "Bản phát hành <strong>{releaseName}</strong> đã được liên kết thành công với dự án <strong>{projectName}</strong>",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "发现以下重复标识符。",
     "The license type cannot be deleted": "许可类型<strong> {name} </strong>无法删除，因为它在<strong> {usageCount} </strong> license中使用。\n请先撤销许可证。",
     "The new Component and new Release will be created, do you want to import?": "将创建新的组件和新的版本，是否要导入？",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "该软件包无法删除，因为它正被其他项目使用。请在删除前取消关联。",
     "The project cannot be deleted": "由于另一个项目使用该项目，因此无法删除该项目！",
     "The projects have been successfully linked to project": "项目已成功链接至项目",
     "The release has been successfully linked to project": "版本<strong>{releaseName}</strong>已成功链接到项目<strong>{projectName}</strong>",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1345,6 +1345,7 @@
     "The following duplicate identifiers were found": "發現以下重複標識符。",
     "The license type cannot be deleted": "許可類型<strong> {name} </strong>無法刪除，因為它在<strong> {usageCount} </strong> license中使用。請先撤銷許可證。",
     "The new Component and new Release will be created, do you want to import?": "您要匯入嗎 ?",
+    "The Package cannot be deleted, Since it is used by other project Please unlink it before deleting": "無法刪除此套件，因為它正被其他專案使用。請在刪除前解除關聯。",
     "The project cannot be deleted": "由於另一個項目使用該項目，因此無法刪除該項目！",
     "The projects have been successfully linked to project": "專案已成功連結到專案",
     "The release has been successfully linked to project": "釋放 <strong>{放出Name</strong> 已成功連結到專案 <strong>{專案名稱}</strong>",


### PR DESCRIPTION
-  Restored delete functionality for linked packages
- Added confirmation modal and alert messages
- Integrated API DELETE call for removing unlinked packages
- Updated translations for conflict message


<img width="821" height="223" alt="image" src="https://github.com/user-attachments/assets/8cf5e07e-3588-4611-b8a3-f648cc50addb" />

<img width="819" height="248" alt="image" src="https://github.com/user-attachments/assets/3ea5838b-0305-4e5d-be41-cd0e014cb125" />
