### PR TITLE
fix(auth): Use POST and form data for token request

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -41,15 +41,22 @@ const generateToken = async (userData: UserCredentialInfo): Promise<null | AuthT
         credentials = Buffer.from(`${oAuthClient.client_id}:${oAuthClient.client_secret}`, `binary`).toString('base64')
 
         opts.headers['Authorization'] = `Basic ${credentials}`
-        const authorizationURL: string =
-            SW360_API_URL +
-            '/authorization/oauth/token?grant_type=password&username=' +
-            userData.username +
-            '&password=' +
-            userData.password
+        opts.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+
+        const authorizationURL: string = SW360_API_URL + '/authorization/oauth/token'
+
+        const tokenRequestBody = new URLSearchParams({
+            grant_type: 'password',
+            username: userData.username,
+            password: userData.password,
+        })
 
         let sw360token: AuthToken | null = null
-        const tokenResponse = await fetch(authorizationURL, opts)
+        const tokenResponse = await fetch(authorizationURL, {
+            method: 'POST',
+            headers: opts.headers,
+            body: tokenRequestBody,
+        })
         if (tokenResponse.status == StatusCodes.OK) {
             sw360token = (await tokenResponse.json()) as AuthToken
         }


### PR DESCRIPTION

[Screencast from 2026-01-09 19-33-33.webm](https://github.com/user-attachments/assets/b8a57106-67cc-41f5-bf76-0e8ae56f1e4e)
fixes: #1322

## Summary

This PR fixes a **critical security vulnerability** where user credentials (username and password) were being transmitted via URL query parameters during OAuth token requests.

This is a security risk because URL query parameters can be exposed in:
- **Server logs** - Web servers, proxies, and load balancers typically log full URLs
- **Browser history** - URLs with query parameters are stored in browser history
- **Network monitoring** - Query parameters are visible in network inspection tools
- **HTTP Referrer headers** - URLs may leak via Referrer headers when navigating externally
- **Proxy caches** - URLs may be cached by intermediate proxies or CDNs

## Testing

- [x] Manual login test to verify authentication still works
- [x] Verify network requests show credentials in body, not URL
