### PR TITLE
Fix: License updates not creating/showing moderation requests (#275) 

### DIFF
--- a/src/app/[locale]/licenses/edit/components/EditLicense.tsx
+++ b/src/app/[locale]/licenses/edit/components/EditLicense.tsx
@@ -118,17 +118,26 @@ function EditLicense({ licenseId }: Props): ReactNode {
             MessageService.error(t('Session has expired'))
             return signOut()
         }
-        const response = await ApiUtils.PATCH(`licenses/${licenseId}`, licensePayload, session.user.access_token)
-        const responseMessage = await response.text()
-        if (response.status == StatusCodes.OK) {
-            const data = (await response.json()) as LicensePayload
-            MessageService.success(t('License updated successfully'))
-            router.push(`/licenses/detail?id=${data.shortName}`)
-        } else {
-            MessageService.error(responseMessage)
+
+        try {
+            const response = await ApiUtils.PATCH(`licenses/${licenseId}`, licensePayload, session.user.access_token)
+
+            if (response.status === StatusCodes.OK) {
+                const data = (await response.json()) as LicensePayload
+                MessageService.success(t('License updated successfully'))
+                router.push(`/licenses/detail?id=${data.shortName}`)
+            } else if (response.status === StatusCodes.ACCEPTED) {
+                MessageService.success(t('License update sent for moderation'))
+                router.push(`/licenses/detail?id=${licensePayload.shortName}`)
+            } else {
+                const responseMessage = await response.text()
+                MessageService.error(responseMessage)
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            MessageService.error(message)
         }
     }
-
     const deleteLicense = () => {
         setDeleteDialogOpen(true)
     }


### PR DESCRIPTION
- Fixed response body being read twice (text then json)
- Added handling for HTTP 202 ACCEPTED status code
- Added proper try-catch error handling for license updates
- Now shows appropriate messages for both direct updates and moderation requests

Fixes #275