### PR TITLE
Fix: Prevent tabs from disappearing on Export/Import SBOM click

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -419,14 +419,15 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                             </Dropdown.Toggle>
                                             <Dropdown.Menu>
                                                 <Dropdown.Item
-                                                    onClick={() =>
+                                                    onClick={(e) => {
+                                                        e.stopPropagation()
                                                         setImportSBOMMetadata({
                                                             importType: 'CycloneDx',
                                                             show: true,
                                                             projectId: projectId,
                                                             doNotReplace: false,
                                                         })
-                                                    }
+                                                    }}
                                                 >
                                                     <span
                                                         style={{
@@ -444,14 +445,15 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                     </span>
                                                 </Dropdown.Item>
                                                 <Dropdown.Item
-                                                    onClick={() =>
+                                                    onClick={(e) => {
+                                                        e.stopPropagation()
                                                         setImportSBOMMetadata({
                                                             importType: 'CycloneDx',
                                                             show: true,
                                                             projectId: projectId,
                                                             doNotReplace: true,
                                                         })
-                                                    }
+                                                    }}
                                                 >
                                                     <span
                                                         style={{
@@ -483,7 +485,12 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 {t('Export SBOM')}
                                             </Dropdown.Toggle>
                                             <Dropdown.Menu>
-                                                <Dropdown.Item onClick={() => setShowExportProjectSbomModal(true)}>
+                                                <Dropdown.Item
+                                                    onClick={(e) => {
+                                                        e.stopPropagation()
+                                                        setShowExportProjectSbomModal(true)
+                                                    }}
+                                                >
                                                     {t('CycloneDX')}
                                                 </Dropdown.Item>
                                             </Dropdown.Menu>


### PR DESCRIPTION
## Description
Fixes the issue where tabs disappear and show a blank screen when clicking Export/Import SBOM buttons in the Projects Detail page.

## Problem
When users clicked on Import SBOM or Export SBOM dropdown options, the click events were bubbling up to the Tab.Container component, causing it to lose track of the active tab and display a blank screen.

## Solution
Added `e.stopPropagation()` to all three dropdown item onClick handlers:
1. Import SBOM → "replace existing releases and packages"
2. Import SBOM → "Add new releases and packages"  
3. Export SBOM → "CycloneDX"

This prevents the click events from propagating to parent elements, keeping the current tab active while the modal opens.


## Before Fix
- ❌ Tabs disappeared when clicking SBOM buttons
- ❌ Blank screen shown while modal was open

## After Fix
- ✅ Tabs remain visible when clicking SBOM buttons
- ✅ Modal opens on top of existing tab content
- ✅ All tab navigation continues to work properly

## Related Issues
Fixes #1343
