### PR TITLE
Fix: Visually distinguish disabled Clearing Request icon

### DIFF
--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -272,12 +272,7 @@ function Project(): JSX.Element {
                                             <span className={'d-inline-block'}>
                                                 <BsCheck2Square
                                                     size={20}
-                                                    style={{
-                                                        opacity: 0.4,
-                                                        cursor: 'not-allowed',
-                                                        color: '#6c757d',
-                                                    }}
-                                                    className='btn-icon overlay-trigger'
+                                                    className='btn-icon overlay-trigger icon-disabled'
                                                 />
                                             </span>
                                         </OverlayTrigger>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -389,6 +389,12 @@ body {
     color: var(--sw360-primary-color) !important;
 }
 
+.icon-disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    color: #6c757d;
+}
+
 .btn-light {
     background-color: #f1f2f5 !important;
     border-color: #f1f2f5 !important;


### PR DESCRIPTION
### What this PR does
- Adds a clear visual distinction for the disabled "Create Clearing Request" icon
- Uses reduced opacity and disabled cursor to indicate non-interactive state
- Keeps tooltip explanation for better UX

### Issue
Fixes #1340

