### PR TITLE
fix(navbar): route SW360 logo to localized home page

### DIFF
--- a/src/components/sw360/Navbar/Navbar.tsx
+++ b/src/components/sw360/Navbar/Navbar.tsx
@@ -10,6 +10,7 @@
 
 'use client'
 
+import Link from 'next/link'
 import { useParams, useRouter, useSelectedLayoutSegment } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { LocaleSwitcher, Logo, ProfileDropdown } from 'next-sw360'
@@ -106,7 +107,10 @@ function Navbar(): JSX.Element {
                 className='bg-body-tertiary'
             >
                 <Container fluid>
-                    <BSNavbar.Brand href='/'>
+                    <BSNavbar.Brand
+                        as={Link}
+                        href={`/${locale ?? 'en'}`}
+                    >
                         <Logo
                             src={process.env.NEXT_PUBLIC_CUSTOM_LOGO ?? undefined}
                             alt='SW360 Logo'


### PR DESCRIPTION
The SW360 logo in the navbar was opening the wrong page.

## What changed
- Updated the SW360 navbar logo link to navigate to the localized home route (e.g. /en, /de).

This change makes the logo go to the home page for the current language.

Fixes #1338