### PR TITLE
fix(attachments): Make expand and collapse controls functional

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1579,6 +1579,14 @@ input[checked] + .slider:before {
     color: var(--sw360-primary-hover-color);
 }
 
+.btn-reset {
+    padding: 0;
+    border: 0;
+    background: none;
+    cursor: pointer;
+    font: inherit;
+}
+
 .filter-button {
     .btn {
         color: inherit !important;


### PR DESCRIPTION

### Fix expand/collapse controls in Attachment Usages table
Fixes #1346 

This PR fixes the Expand next level  and Collapse all controls in the Attachment Usages table on the Project Detail page so they actually work.

#### Problem

The expand and collapse options were shown as links but didn’t have any click handling, so clicking them did nothing. Users couldn’t expand or collapse the attachment hierarchy.

#### Changes

- The links were replaced with buttons and wired to the table’s expansion state.
- Expand next level now expands one level at a time
- Collapse all collapses the entire table
- The logic uses TanStack Table’s row IDs so it works correctly even with filters applied

#### Files changed

* `src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx`