### PR TITLE
fix(navbar): redirect logo to home when logged in and  sign-in when logged out

### DIFF
--- a/src/components/sw360/Navbar/Navbar.tsx
+++ b/src/components/sw360/Navbar/Navbar.tsx
@@ -23,7 +23,7 @@ function Navbar(): JSX.Element {
     const param = useParams()
     const locale = (param.locale as string) || 'en'
 
-    const { data: session } = useSession()
+    const { data: session, status } = useSession()
     const [show, setShow] = useState(false)
     const selectedLayoutSegment = useSelectedLayoutSegment()
     const pathname = selectedLayoutSegment !== null ? `/${selectedLayoutSegment}` : '/'
@@ -109,7 +109,7 @@ function Navbar(): JSX.Element {
                 <Container fluid>
                     <BSNavbar.Brand
                         as={Link}
-                        href={`/${locale ?? 'en'}`}
+                        href={status === 'authenticated' ? `/${locale ?? 'en'}/home` : `/${locale ?? 'en'}`}
                     >
                         <Logo
                             src={process.env.NEXT_PUBLIC_CUSTOM_LOGO ?? undefined}


### PR DESCRIPTION
### Fix navbar logo redirect

fixes #1338 

Updated the SW360 navbar logo link so that-

- Logged-in users are redirected to the localized home page (home)
- Logged-out users keep the existing behavior (sign-in page)

