### PR TITLE
fix(requests): Fixed redirection to edit closed CR

### DIFF
--- a/src/app/[locale]/requests/components/ClearingRequest.tsx
+++ b/src/app/[locale]/requests/components/ClearingRequest.tsx
@@ -290,7 +290,7 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                 },
             },
             {
-                id: 'ctions',
+                id: 'actions',
                 header: t('Actions'),
                 cell: ({ row }) => {
                     return (
@@ -306,7 +306,7 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                                     }
                                 >
                                     <Link
-                                        href={`/requests/clearingRequest/edit/${row.original.id}`}
+                                        href={`/requests/clearingRequest/detail/${row.original.id}`}
                                         className='overlay-trigger'
                                     >
                                         <BsPencil


### PR DESCRIPTION
Fixes the redirection of closed CR on click of `Edit CR` button.

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/1371