### PR TITLE
fix(component): Display and enable editing of VCS/Repository URL

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "Der Benutzer mit der gleichen E -Mail gibt es bereits!",
     "Users": "Benutzer",
     "VALUE": "Wert",
+    "VCS/Repository URL": "VCS-/Repository-URL",
     "VCS URLs were redirected": "VCS -URLs wurden umgeleitet",
     "VENDORS": "VENDOREN",
     "VIEWER": "Zuschauer",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "User with the same email already exists!",
     "Users": "Users",
     "VALUE": "value",
+    "VCS/Repository URL": "VCS/Repository URL",
     "VCS URLs were redirected": "VCS URLs were redirected",
     "VENDORS": "VENDORS",
     "VIEWER": "Viewer",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "¡El usuario con el mismo correo electrónico ya existe!",
     "Users": "Usuarios",
     "VALUE": "valor",
+    "VCS/Repository URL": "URL del repositorio VCS",
     "VCS URLs were redirected": "Las URL de VCS fueron redirigidas",
     "VENDORS": "VENDORS",
     "VIEWER": "Espectador",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "L'utilisateur avec le même e-mail existe déjà!",
     "Users": "Utilisateur",
     "VALUE": "valeur",
+    "VCS/Repository URL": "URL du dépôt VCS",
     "VCS URLs were redirected": "Les URL VCS ont été redirigées",
     "VENDORS": "VENDEURS",
     "VIEWER": "Téléspectateur",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "同じメールを持つユーザーはすでに存在しています！",
     "Users": "Users",
     "VALUE": "価値",
+    "VCS/Repository URL": "VCS／リポジトリ URL",
     "VCS URLs were redirected": "VCS URLがリダイレクトされました",
     "VENDORS": "VENDORS",
     "VIEWER": "視聴者",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "동일한 이메일을 가진 사용자가 이미 존재합니다!",
     "Users": "이름 *",
     "VALUE": "제품정보",
+    "VCS/Repository URL": "VCS/리포지토리 URL",
     "VCS URLs were redirected": "VCS URL을 리디렉션했습니다",
     "VENDORS": "회사연혁",
     "VIEWER": "뷰어",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "Usuário com o mesmo email já existe!",
     "Users": "Usuários",
     "VALUE": "Valor",
+    "VCS/Repository URL": "URL do repositório VCS",
     "VCS URLs were redirected": "URLs de VCS foram redirecionados",
     "VENDORS": "VENDORS",
     "VIEWER": "Espectador",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "Người dùng có cùng một email đã tồn tại!",
     "Users": "Người dùng",
     "VALUE": "giá trị",
+    "VCS/Repository URL": "URL kho mã nguồn VCS",
     "VCS URLs were redirected": "URL VCS đã được chuyển hướng",
     "VENDORS": "VENDORS",
     "VIEWER": "Người xem",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "使用相同电子邮件的用户已经存在！",
     "Users": "用户",
     "VALUE": "价值",
+    "VCS/Repository URL": "VCS/代码仓库 URL",
     "VCS URLs were redirected": "VCS URL被重定向",
     "VENDORS": "VENDORS",
     "VIEWER": "观众",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1467,6 +1467,7 @@
     "User with the same email already exists": "使用相同電子郵件的用戶已經存在！",
     "Users": "使用者",
     "VALUE": "值",
+    "VCS/Repository URL": "VCS/程式碼儲存庫 URL",
     "VCS URLs were redirected": "VCS URL被重定向",
     "VENDORS": "选民",
     "VIEWER": "觀眾",

--- a/src/app/[locale]/components/detail/[id]/components/ComponentGeneral.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ComponentGeneral.tsx
@@ -141,22 +141,21 @@ const ComponentGeneral = ({ component, componentId }: Props): ReactNode => {
                     </td>
                 </tr>
                 <tr>
-                    <td>{t('VCS / Repository URL')}:</td>
+                    <td>{t('VCS/Repository URL')}:</td>
                     <td>
-                        {!CommonUtils.isNullEmptyOrUndefinedString(component.vcsUrl) ? (
+                        {!CommonUtils.isNullEmptyOrUndefinedString(component.vcs) && (
                             <Link
                                 className='text-link'
-                                href={component.vcsUrl}
+                                href={component.vcs}
                                 target='_blank'
                                 rel='noopener noreferrer'
                             >
-                                {component.vcsUrl}
+                                {component.vcs}
                             </Link>
-                        ) : (
-                            '-'
                         )}
                     </td>
                 </tr>
+
                 <tr>
                     <td>{t('Blog')}:</td>
                     <td>

--- a/src/app/[locale]/components/edit/[id]/components/ComponentEditSummary.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/ComponentEditSummary.tsx
@@ -153,6 +153,7 @@ export default function ComponentEditSummary({
                 defaultVendorId: component.defaultVendorId,
                 categories: component.categories,
                 homepage: component.homepage,
+                vcs: component.vcs,
                 mailinglist: component.mailinglist,
                 wiki: component.wiki,
                 blog: component.blog,

--- a/src/components/GeneralInfoComponent/GeneralInfoComponent.tsx
+++ b/src/components/GeneralInfoComponent/GeneralInfoComponent.tsx
@@ -250,6 +250,24 @@ const GeneralInfoComponent = ({ componentPayload, setComponentPayload, vendor, s
                                 value={componentPayload.homepage ?? ''}
                             />
                         </div>
+                        <div className='col-lg-4'>
+                            <label
+                                htmlFor='vcs_url'
+                                className='form-label fw-bold'
+                            >
+                                {t('VCS/Repository URL')}
+                            </label>
+                            <input
+                                type='URL'
+                                className='form-control'
+                                placeholder={t('Enter VCS URL')}
+                                id='vcs_url'
+                                aria-describedby='vcs_url'
+                                name='vcs'
+                                onChange={updateField}
+                                value={componentPayload.vcs ?? ''}
+                            />
+                        </div>
                     </div>
                     <div className='row with-divider pt-2 pb-2'>
                         <div className='col-lg-4'>

--- a/src/object-types/Component.ts
+++ b/src/object-types/Component.ts
@@ -23,7 +23,6 @@ interface Component {
     ownerAccountingUnit?: string
     ownerGroup?: string
     ownerCountry?: string
-    vcsUrl?: string
     visbility?: string
     externalIds?: {
         [k: string]: string
@@ -39,6 +38,7 @@ interface Component {
     softwarePlatforms?: Array<string>
     operatingSystems?: Array<string>
     homepage?: string
+    vcs?: string
     mailinglist?: string
     wiki?: string
     blog?: string

--- a/src/object-types/ComponentPayLoad.ts
+++ b/src/object-types/ComponentPayLoad.ts
@@ -34,6 +34,7 @@ export default interface ComponentPayload {
     defaultVendorId?: string
     categories?: Array<string> | null
     homepage?: string
+    vcs?: string
     mailinglist?: string
     wiki?: string
     blog?: string


### PR DESCRIPTION
This PR restores the VCS/Repository URL field in the UI.

- Added the VCS/Repository URL field to the Component Summary page so it is visible to users.
- Enabled editing of the VCS/Repository URL field on the Component Edit page.