### PR TITLE
Fix/obligation pill color remains red

### DIFF
--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -772,11 +772,7 @@ function EditProject({
                                                         <span className='me-2'>{t('Obligations')}</span>
                                                         <span
                                                             id='obligationsCount'
-                                                            className={
-                                                                obligationsNonOpenCount === 0
-                                                                    ? 'badge obligations-badge--danger'
-                                                                    : 'obligations-badge'
-                                                            }
+                                                            className='badge obligations-badge--danger'
                                                             aria-live='polite'
                                                         >
                                                             {`${obligationsNonOpenCount} / ${obligationsTotal}`}


### PR DESCRIPTION
## Description
Fixes #1361 - The obligation pill now remains red at all times as required.

## Problem
The obligation pill was changing from red to white when obligation statuses were updated. The requirement is for the pill to always stay red.

## Solution
Removed the conditional className logic and set the pill to always use `'badge obligations-badge--danger'`, ensuring it remains red regardless of obligation status changes.

## Changes
- Removed conditional logic for pill color
- Pill now always has red color class

## Related Issues
Fixes #1361