### PR TITLE
fix(CR): Add tag field in CR tables

### DIFF
--- a/src/app/[locale]/requests/components/ClearingRequest.tsx
+++ b/src/app/[locale]/requests/components/ClearingRequest.tsx
@@ -77,7 +77,17 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                 header: t('BA-BL/Group'),
                 cell: ({ row }) => <>{row.original.projectBU ?? t('Not Available')}</>,
             },
-
+            {
+                id: 'tag',
+                header: t('Tag'),
+                cell: ({ row }) => {
+                    if (!Object.hasOwn(row.original, 'projectId')) {
+                        return <>{t('Not Available')}</>
+                    } else {
+                        return <>{row.original._embedded?.['sw360:projectDTOs']?.[0]?.tag ?? t('Not Available')}</>
+                    }
+                },
+            },
             {
                 id: 'project',
                 header: t('Project'),
@@ -101,9 +111,9 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                 header: t('Open Releases'),
                 cell: ({ row }) => {
                     if (!Object.hasOwn(row.original, 'projectId')) {
-                        return <>{t('Project Deleted')}</>
+                        return <>{t('Not Available')}</>
                     } else {
-                        return <>{row.original._embedded?.openRelease}</>
+                        return <>{row.original._embedded?.openRelease ?? t('Not Available')}</>
                     }
                 },
             },


### PR DESCRIPTION
Closes: #1382

Added `tag` field back in the open and closed clearing requests table.

<img width="931" height="330" alt="Screenshot from 2026-01-16 15-09-23" src="https://github.com/user-attachments/assets/b00d7593-de38-4982-a4ab-1a68b7df7a1f" />
 