### PR TITLE
refactor: Add Centralized Error Handling to API Utils

### DIFF
--- a/src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx
+++ b/src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx
@@ -17,8 +17,7 @@ import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { ErrorDetails, SearchDuplicatesResponse } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 export default function DatabaseSanitation(): JSX.Element {
     const t = useTranslations('default')
@@ -46,16 +45,14 @@ export default function DatabaseSanitation(): JSX.Element {
             const response = await ApiUtils.GET('databaseSanitation/searchDuplicate', session.data.user.access_token)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
             const data = (await response.json()) as SearchDuplicatesResponse
             setDuplicates(data)
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
+++ b/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
@@ -21,8 +21,7 @@ import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import { ErrorDetails } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import SecondaryDepartments from './SecondaryDepartments'
 
 const SecondaryDepartmentsTable = (): JSX.Element => {
@@ -121,17 +120,15 @@ const SecondaryDepartmentsTable = (): JSX.Element => {
                 const response = await ApiUtils.GET('departments/members', session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as SecondaryDepartments
                 setSecondaryDepartments(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/admin/fossology/components/FossologyOverview.tsx
+++ b/src/app/[locale]/admin/fossology/components/FossologyOverview.tsx
@@ -75,11 +75,7 @@ export default function FossologyOverview(): ReactNode {
                 }
             })
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
             .finally(() => {
                 setLoading(false)
@@ -98,11 +94,7 @@ export default function FossologyOverview(): ReactNode {
                 }
             })
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
     }, [
         fetchData,

--- a/src/app/[locale]/admin/licenseTypes/add/components/AddLicenseTypes.tsx
+++ b/src/app/[locale]/admin/licenseTypes/add/components/AddLicenseTypes.tsx
@@ -51,11 +51,7 @@ export default function AddLicenseTypes(): JSX.Element {
                 MessageService.error(t('Something went wrong'))
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/licenseTypes/components/DeleteLicenseTypesModal.tsx
+++ b/src/app/[locale]/admin/licenseTypes/components/DeleteLicenseTypesModal.tsx
@@ -73,11 +73,7 @@ export default function DeleteLicenseTypesModal({ licenseTypeId, licenseTypeName
                 }
             })
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
             .finally(() => {
                 setLoading(false)
@@ -102,8 +98,7 @@ export default function DeleteLicenseTypesModal({ licenseTypeId, licenseTypeName
                 MessageService.error(t('Error when processing'))
             }
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx
+++ b/src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx
@@ -18,7 +18,7 @@ import { FaRegQuestionCircle } from 'react-icons/fa'
 import { ErrorDetails } from '@/object-types'
 import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
-import { ApiUtils } from '@/utils'
+import { ApiError, ApiUtils } from '@/utils'
 import DeleteAllLicenseInformationModal from './DeleteAllLicenseInformationModal'
 
 type ModalType = 'OSADL' | 'SPDX' | undefined
@@ -90,11 +90,7 @@ function ConfirmationModal({ type, setType }: { type: ModalType; setType: Dispat
                 ),
             })
         } catch (error: unknown) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 
@@ -208,14 +204,12 @@ export default function LicenseAdministration(): ReactNode {
                 MessageService.success(t('Licenses uploaded successfully'))
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 
@@ -224,11 +218,7 @@ export default function LicenseAdministration(): ReactNode {
             if (!session.data) return signOut()
             void DownloadService.download('licenses/downloadLicenses', session.data, `LicensesBackup.lics`)
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
@@ -18,8 +18,7 @@ import { Nav, Tab } from 'react-bootstrap'
 import ChangeLogDetail from '@/components/ChangeLog/ChangeLogDetail/ChangeLogDetail'
 import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
 import { Changelogs, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type EmbeddedChangeLogs = Embedded<Changelogs, 'sw360:changeLogs'>
 
@@ -84,7 +83,9 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const responseText = await response.text()
                 if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
@@ -100,11 +101,7 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
                     )
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
+++ b/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
@@ -18,7 +18,7 @@ import { JSX, useEffect } from 'react'
 import { useConfigValue } from '@/contexts'
 import { ErrorDetails, UIConfigKeys } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 import { ScheduleItem } from './ScheduleItem'
 
 export default function VendorsList(): JSX.Element {
@@ -47,14 +47,12 @@ export default function VendorsList(): JSX.Element {
                 return signOut()
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error: unknown) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 
@@ -83,14 +81,12 @@ export default function VendorsList(): JSX.Element {
                 return signOut()
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error: unknown) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/users/components/UserAdministration.tsx
+++ b/src/app/[locale]/admin/users/components/UserAdministration.tsx
@@ -23,7 +23,7 @@ import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, User } from
 import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 import EditSecondaryDepartmentAndRolesModal from './EditSecondaryDepartmentsAndRolesModal'
 
 type EmbeddedUsers = Embedded<User, 'sw360:users'>
@@ -60,11 +60,7 @@ export default function UserAdminstration(): JSX.Element {
                 })
             })
             .catch((error: unknown) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
     }
 
@@ -94,11 +90,7 @@ export default function UserAdminstration(): JSX.Element {
                 }
             })
             .catch((error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
     }, [])
 
@@ -300,7 +292,9 @@ export default function UserAdminstration(): JSX.Element {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedUsers
@@ -312,11 +306,7 @@ export default function UserAdminstration(): JSX.Element {
                         : data['_embedded']['sw360:users'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/admin/vendors/edit/[id]/components/EditVendor.tsx
+++ b/src/app/[locale]/admin/vendors/edit/[id]/components/EditVendor.tsx
@@ -18,7 +18,7 @@ import { ReactNode, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, Release, Vendor } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import VendorDetailForm from '../../../components/VendorDetailForm'
 
 type EmbeddedReleases = Embedded<Release, 'sw360:releases'>
@@ -65,19 +65,21 @@ export default function EditVendor({ id }: { id: string }): ReactNode {
                         setReleases([])
                     } else {
                         const err = (await releasesResponse.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: releasesResponse.status,
+                        })
                     }
                 } else {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
+                ApiUtils.reportError(error)
+                if (error instanceof ApiError && !error.isAborted) {
+                    router.push('/admin/vendors')
                 }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
-                router.push('/admin/vendors')
             }
         })()
 
@@ -104,14 +106,12 @@ export default function EditVendor({ id }: { id: string }): ReactNode {
                 return signOut()
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 
@@ -125,14 +125,12 @@ export default function EditVendor({ id }: { id: string }): ReactNode {
                 router.push('/admin/vendors')
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/admin/vendors/merge/[id]/components/MergeOverview.tsx
+++ b/src/app/[locale]/admin/vendors/merge/[id]/components/MergeOverview.tsx
@@ -16,8 +16,7 @@ import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { ErrorDetails, MergeOrSplitActionType, Vendor } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import MergeVendor from './MergeData'
 import VendorTable from './VendorsTable'
 
@@ -81,14 +80,12 @@ export default function MergeOverview({
                 router.push(`/admin/vendors`)
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 
@@ -109,15 +106,15 @@ export default function MergeOverview({
                     setTargetVendor(vendor)
                 } else {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
+                ApiUtils.reportError(error)
+                if (error instanceof ApiError && !error.isAborted) {
+                    router.push(`/admin/vendors`)
                 }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
-                router.push(`/admin/vendors`)
             }
         })()
 

--- a/src/app/[locale]/components/detail/[id]/components/DeleteReleaseModal.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/DeleteReleaseModal.tsx
@@ -18,7 +18,6 @@ import { useTranslations } from 'next-intl'
 import { ChangeEvent, ReactNode, useCallback, useEffect, useState } from 'react'
 import { Alert, Button, Form, Modal } from 'react-bootstrap'
 import { ActionType, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
@@ -154,11 +153,7 @@ const DeleteReleaseModal = ({ componentId, actionType, releaseId, show, setShow 
         const controller = new AbortController()
         const signal = controller.signal
         fetchData(signal).catch((error) => {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         })
 
         return () => {

--- a/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
@@ -40,8 +40,7 @@ import {
     UserGroupType,
 } from '@/object-types'
 import DownloadService from '@/services/download.service'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ReleaseOverview from './ReleaseOverview'
 import Summary from './Summary'
 
@@ -256,7 +255,9 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const responseText = await response.text()
                 if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
@@ -272,11 +273,7 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                     )
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -26,8 +26,7 @@ import fossologyIcon from '@/assets/images/fossology.svg'
 import LinkReleaseToProjectModal from '@/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal'
 import FossologyClearing from '@/components/sw360/FossologyClearing/FossologyClearing'
 import { Embedded, ErrorDetails, ReleaseLink, UserGroupType } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import DeleteReleaseModal from './DeleteReleaseModal'
 
 type EmbeddedLinkedReleases = Embedded<ReleaseLink, 'sw360:releaseLinks'>
@@ -217,7 +216,9 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedLinkedReleases
@@ -227,11 +228,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                         : data['_embedded']['sw360:releaseLinks'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/edit/[id]/components/Releases.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/Releases.tsx
@@ -21,8 +21,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { SW360Table } from '@/components/sw360'
 import { Embedded, ErrorDetails, LinkedRelease, ReleaseLink } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     componentId: string
@@ -108,7 +107,9 @@ const Releases = ({ componentId }: Props): ReactNode => {
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedLinkedReleases
@@ -118,11 +119,7 @@ const Releases = ({ componentId }: Props): ReactNode => {
                         : data['_embedded']['sw360:releaseLinks'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -44,8 +44,7 @@ import {
     UserGroupType,
 } from '@/object-types'
 import DownloadService from '@/services/download.service'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 import ClearingDetails from './ClearingDetails'
 import CommercialDetails from './CommercialDetails'
@@ -236,7 +235,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const responseText = await response.text()
                 if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
@@ -252,11 +253,7 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                     )
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
@@ -20,8 +20,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { PaddedCell, SW360Table } from '@/components/sw360'
 import { Embedded, ErrorDetails, NestedRows, ReleaseLink } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type EmbeddedReleaseLinks = Embedded<ReleaseLink, 'sw360:releaseLinks'>
 interface Props {
@@ -84,7 +83,9 @@ const LinkedReleases = ({ releaseId }: Props): ReactNode => {
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const releaseData = (await response.json()) as EmbeddedReleaseLinks
@@ -99,11 +100,7 @@ const LinkedReleases = ({ releaseId }: Props): ReactNode => {
                 })
                 setData(convertedTreeData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
@@ -20,8 +20,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Alert, Button, Spinner } from 'react-bootstrap'
 import { BsExclamationTriangle } from 'react-icons/bs'
 import { Attachment, AttachmentTypes, Embedded, ErrorDetails } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import SPDXLicenseView from './SPDXLicenseView'
 
 interface Props {
@@ -188,7 +187,9 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
             )
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
             setTableData((prev) => {
                 return prev.map((t) => {
@@ -207,11 +208,7 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
                 })
             })
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }
@@ -227,7 +224,9 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
             )
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as LicenseInfo
@@ -245,11 +244,7 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
                 })
             })
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }
@@ -279,7 +274,9 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Embedded<Attachment, 'sw360:attachments'>
@@ -314,11 +311,7 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
 
                 setTableData(tableData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/components/releases/detail/[id]/components/SPDXLicenseView.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/SPDXLicenseView.tsx
@@ -19,8 +19,7 @@ import Button from 'react-bootstrap/Button'
 import Modal from 'react-bootstrap/Modal'
 import { BsInfoCircle } from 'react-icons/bs'
 import { ErrorDetails } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface LicenseInfo {
     license: string
@@ -78,17 +77,15 @@ const SPDXLicenseView = ({ isISR, attachmentName, attachmentId, releaseId, licen
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const fileData = (await response.json()) as SrcFileList
                 setFileList(fileData.data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 

--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
@@ -13,9 +13,8 @@ import { StatusCodes } from 'http-status-codes'
 import { signOut, useSession } from 'next-auth/react'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 import { Attachment, ErrorDetails, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 import AdditionalDataSection from './AdditionalDataSection'
 import ExternalIdsSection from './ExternalIdsSection'
 import GeneralSection from './GeneralSection'
@@ -57,18 +56,16 @@ export default function MergeReleaseDataCheck({
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ReleaseDetail
 
                 setSourceReleaseDetail(CommonUtils.isNullOrUndefined(data) ? null : data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 

--- a/src/app/[locale]/ecc/components/ECC.tsx
+++ b/src/app/[locale]/ecc/components/ECC.tsx
@@ -25,8 +25,7 @@ import {
     PaginationMeta,
     UserGroupType,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 
 type EmbeddedECC = Embedded<ECCInterface, 'sw360:releases'>
 
@@ -158,7 +157,9 @@ function ECC(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedECC
@@ -169,11 +170,7 @@ function ECC(): ReactNode {
                         : data['_embedded']['sw360:releases'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/home/components/MyComponentsWidget.tsx
+++ b/src/app/[locale]/home/components/MyComponentsWidget.tsx
@@ -16,8 +16,7 @@ import { SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Component, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import HomeTableHeader from './HomeTableHeader'
 
 type EmbeddedComponents = Embedded<Component, 'sw360:components'>
@@ -109,7 +108,9 @@ export default function MyComponentsWidget(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedComponents
@@ -120,11 +121,7 @@ export default function MyComponentsWidget(): ReactNode {
                         : data['_embedded']['sw360:components'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/home/components/MyProjectsWidget.tsx
+++ b/src/app/[locale]/home/components/MyProjectsWidget.tsx
@@ -18,8 +18,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import LicenseClearing from '@/components/LicenseClearing'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Project } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import HomeTableHeader from './HomeTableHeader'
 
 type EmbeddedProjects = Embedded<Project, 'sw360:projects'>
@@ -124,7 +123,9 @@ export default function MyProjectsWidget(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedProjects
@@ -135,11 +136,7 @@ export default function MyProjectsWidget(): ReactNode {
                         : data['_embedded']['sw360:projects'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
+++ b/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
@@ -17,7 +17,6 @@ import { useTranslations } from 'next-intl'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Component, Embedded, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
 import HomeTableHeader from './HomeTableHeader'
 
@@ -73,11 +72,7 @@ function MySubscriptionsWidget(): ReactNode {
                 }
             })
             .catch((error: Error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
             .finally(() => {
                 setLoading(false)

--- a/src/app/[locale]/home/components/MyTaskSubmissionsWidget.tsx
+++ b/src/app/[locale]/home/components/MyTaskSubmissionsWidget.tsx
@@ -18,8 +18,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsFillTrashFill } from 'react-icons/bs'
 import type { Embedded, ErrorDetails, ModerationRequest, PageableQueryParam, PaginationMeta } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 import HomeTableHeader from './HomeTableHeader'
 
 type EmbeddedTaskSubmissions = Embedded<ModerationRequest, 'sw360:moderationRequests'>
@@ -148,7 +147,9 @@ function MyTaskSubmissionsWidget(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedTaskSubmissions
@@ -159,11 +160,7 @@ function MyTaskSubmissionsWidget(): ReactNode {
                         : data['_embedded']['sw360:moderationRequests'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/home/components/RecentComponentsWidget.tsx
+++ b/src/app/[locale]/home/components/RecentComponentsWidget.tsx
@@ -18,7 +18,6 @@ import { useTranslations } from 'next-intl'
 import { type JSX, ReactNode, useCallback, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Component, Embedded } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
 import HomeTableHeader from './HomeTableHeader'
 
@@ -75,11 +74,7 @@ function RecentComponentsWidget(): ReactNode {
                 }
             })
             .catch((error: Error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
             .finally(() => {
                 setLoading(false)

--- a/src/app/[locale]/home/components/RecentReleasesWidget.tsx
+++ b/src/app/[locale]/home/components/RecentReleasesWidget.tsx
@@ -18,7 +18,6 @@ import { useTranslations } from 'next-intl'
 import { type JSX, ReactNode, useCallback, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Embedded, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
 import HomeTableHeader from './HomeTableHeader'
 
@@ -77,11 +76,7 @@ function RecentReleasesWidget(): ReactNode {
                 }
             })
             .catch((error: Error) => {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             })
             .finally(() => {
                 setLoading(false)

--- a/src/app/[locale]/licenses/edit/components/EditLicense.tsx
+++ b/src/app/[locale]/licenses/edit/components/EditLicense.tsx
@@ -81,11 +81,7 @@ function EditLicense({ licenseId }: Props): ReactNode {
                 const license = (await response.json()) as LicenseDetail
                 setLicensePayload(license)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
         return () => controller.abort()
@@ -134,8 +130,7 @@ function EditLicense({ licenseId }: Props): ReactNode {
                 MessageService.error(responseMessage)
             }
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
     const deleteLicense = () => {

--- a/src/app/[locale]/licenses/edit/components/EditLicenseDetail.tsx
+++ b/src/app/[locale]/licenses/edit/components/EditLicenseDetail.tsx
@@ -17,8 +17,7 @@ import { signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Embedded, ErrorDetails, LicensePayload, LicenseType } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 
 interface Props {
     inputValid: boolean
@@ -77,16 +76,14 @@ const EditLicenseDetail = ({
                 const response = await ApiUtils.GET(`licenseTypes`, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const licenses = (await response.json()) as EmbeddedLicenseTypes
                 setLicenseTypes(licenses._embedded?.['sw360:licenseTypes'] ?? [])
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
         return () => controller.abort()

--- a/src/app/[locale]/packages/components/AddReleaseModal.tsx
+++ b/src/app/[locale]/packages/components/AddReleaseModal.tsx
@@ -18,7 +18,6 @@ import { SW360Table } from 'next-sw360'
 import { type JSX, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import { Alert, Button, Form, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, Package, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
 import { ApiUtils } from '@/utils/index'
 
@@ -130,11 +129,7 @@ export default function AddReleaseModal({
             setReleaseData(tableData)
             setLoading(false)
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setLoading(false)
         }

--- a/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
+++ b/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
@@ -17,8 +17,7 @@ import { ShowInfoOnHover } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 import { BsXCircle } from 'react-icons/bs'
 import { ErrorDetails, Package } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 import AddMainLicenseModal from './AddMainLicenseModal'
 import AddReleaseModal from './AddReleaseModal'
 import DeletePackageModal from './DeletePackageModal'
@@ -118,18 +117,16 @@ export default function CreateOrEditPackage({
                     const response = await ApiUtils.GET(`packages/${packageId}/usage`, session.data.user.access_token)
                     if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
                         const err = (await response.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: response.status,
+                        })
                     }
                     if (response.status !== StatusCodes.NO_CONTENT) {
                         const data = (await response.json()) as IsPackageUsed
                         setIsPackageUsed(data.isUsed)
                     }
                 } catch (error) {
-                    if (error instanceof DOMException && error.name === 'AbortError') {
-                        return
-                    }
-                    const message = error instanceof Error ? error.message : String(error)
-                    MessageService.error(message)
+                    ApiUtils.reportError(error)
                 }
             })()
         }

--- a/src/app/[locale]/packages/components/Packages.tsx
+++ b/src/app/[locale]/packages/components/Packages.tsx
@@ -22,7 +22,7 @@ import { BsFillTrashFill, BsPencil } from 'react-icons/bs'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { Embedded, ErrorDetails, Package, PageableQueryParam, PaginationMeta, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import DeletePackageModal from './DeletePackageModal'
 import { packageManagers } from './PackageManagers'
 
@@ -284,7 +284,9 @@ function Packages(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedPackages
@@ -341,9 +343,7 @@ function Packages(): ReactNode {
 
                 setPackageData(pkgsWithRelease)
             } catch (error) {
-                if (!(error instanceof DOMException && error.name === 'AbortError')) {
-                    MessageService.error(error instanceof Error ? error.message : String(error))
-                }
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
+++ b/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
@@ -19,7 +19,7 @@ import { Breadcrumb, ListGroup, Spinner, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ErrorDetails, Package, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ChangeLog from './Changelog'
 import Summary from './Summary'
 
@@ -51,7 +51,9 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
                 const response = await ApiUtils.GET(`packages/${packageId}`, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Package
@@ -61,11 +63,7 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
                     ...data,
                 })
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 

--- a/src/app/[locale]/preferences/components/UserAccessToken.tsx
+++ b/src/app/[locale]/preferences/components/UserAccessToken.tsx
@@ -19,8 +19,7 @@ import React, { ReactNode, useEffect, useState } from 'react'
 import { Form } from 'react-bootstrap'
 import { useConfigValue } from '@/contexts'
 import { ErrorDetails, UIConfigKeys } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 
 import TokensTable from './TokensTable'
 
@@ -78,14 +77,12 @@ const UserAccessToken = (): ReactNode => {
                     })
                 } else {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         }
     }

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -27,8 +27,7 @@ import {
     PageableQueryParam,
     PaginationMeta,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import { ObligationLevels } from '../../../../../../object-types/Obligation'
 import CompareObligation from '../CompareObligation'
 import { ExpandableList } from './ExpandableComponents'
@@ -467,7 +466,9 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ObligationResponse
@@ -491,11 +492,7 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                     ),
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)
@@ -524,17 +521,15 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ObligationResponse
                 setSelectedProjectObligationData(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setShowProcessing(false)
             }

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
@@ -27,9 +27,8 @@ import {
     PageableQueryParam,
     PaginationMeta,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 import { ObligationLevels } from '../../../../../../object-types/Obligation'
 import UpdateCommentModal from './UpdateCommentModal'
 
@@ -334,7 +333,9 @@ export default function ObligationTab({
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ObligationResponse
@@ -358,11 +359,7 @@ export default function ObligationTab({
                     ),
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
@@ -167,11 +167,7 @@ export default function ReleaseView({
                 }
                 setRowData(tableData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/AddLicenseInfoToReleaseModal.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AddLicenseInfoToReleaseModal.tsx
@@ -71,11 +71,7 @@ function AddLicenseInfoToReleaseModal({ projectId, show, setShow }: Props): JSX.
                 MessageService.error(t('Error occurred while processing license information for linked releases'))
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setIsLoading(false)
         }

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -41,7 +41,7 @@ import {
     UserGroupType,
 } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -279,17 +279,15 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const linkedProjectsData = (await response.json()) as LinkedProjects
                 setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessingLinkedProjects(false)
@@ -322,7 +320,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const usages = (await response.json()) as AttachmentUsages
@@ -373,11 +373,7 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 }
                 setSaveUsagesPayload(saveUsages)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessingAttachmentUsages(false)

--- a/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
@@ -16,7 +16,7 @@ import { ChangeEvent, Dispatch, type JSX, SetStateAction, useEffect, useState } 
 import { Alert, Button, Modal } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import { ErrorDetails, VulnerabilityRatingAndActionPayload } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface AlertData {
     variant: string
@@ -90,13 +90,16 @@ export default function ChangeVulnerabilityModal({
                 return signOut()
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
+            if (error instanceof ApiError && error.isAborted) {
                 return
             }
-            const message = error instanceof Error ? error.message : String(error)
+            const message =
+                error instanceof ApiError ? error.message : error instanceof Error ? error.message : String(error)
             setAlert({
                 variant: 'danger',
                 message: (

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
@@ -27,8 +27,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import { ErrorDetails, FilterOption } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ClearingStateBadge from './ClearingStateBadge'
 
 interface ListViewData {
@@ -465,17 +464,15 @@ const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
 
                 if (listViewResponse.status !== StatusCodes.OK) {
                     const err = (await listViewResponse.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: listViewResponse.status,
+                    })
                 }
 
                 const listViewData = (await listViewResponse.json()) as Array<ListViewData>
                 setListViewData(listViewData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
@@ -29,9 +29,8 @@ import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import ExpandableTextList from '@/components/ExpandableList/ExpandableTextLink'
 import { Attachment, ErrorDetails, FilterOption, NestedRows, TypedEntity } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 
 interface Props {
     projectId: string
@@ -564,17 +563,15 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ProjectClearingState
                 setProjectClearingState(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setShowProcessing(false)
             }

--- a/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
@@ -20,8 +20,7 @@ import { Button, Spinner } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ECCInterface, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, UserGroupType } from '@/object-types'
 import DownloadService from '@/services/download.service'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type EmbeddedProjectReleaseEcc = Embedded<ECCInterface, 'sw360:releases'>
 
@@ -169,7 +168,9 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedProjectReleaseEcc
@@ -180,11 +181,7 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
                         : data['_embedded']['sw360:releases'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/ExportProjectSbomModal.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ExportProjectSbomModal.tsx
@@ -15,8 +15,7 @@ import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 import { Alert, Form, Modal, Spinner } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import DownloadService from '@/services/download.service'
-import MessageService from '@/services/message.service'
-import CommonUtils from '@/utils/common.utils'
+import { ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     show: boolean
@@ -89,11 +88,7 @@ export default function ExportProjectSbomModal({
             const endTime = Date.now()
             setExportTime(parseFloat(((endTime - start) / 1000).toFixed(2)))
         } catch (error: unknown) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setLoading(false)
         }

--- a/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
@@ -27,9 +27,8 @@ import { BsPencil } from 'react-icons/bs'
 import { packageManagers } from '@/app/[locale]/packages/components/PackageManagers'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table } from '@/components/sw360'
 import { ErrorDetails, FilterOption, Package, Project, ReleaseClearingStateMapping } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 
 interface Props {
     projectId: string
@@ -334,17 +333,15 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Package[]
                 setPackagesData(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowPackagesProcessing(false)
@@ -373,17 +370,15 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
                 const response = await ApiUtils.GET(`projects/${projectId}`, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Project
                 setProjectData(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProjectProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -25,7 +25,7 @@ import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { FaFile, FaPencilAlt } from 'react-icons/fa'
 import { Embedded, ErrorDetails, FilterOption, LicenseClearing, Project, Release, TypedEntity } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Attachment {
     attachmentType: string
@@ -677,16 +677,14 @@ export default function ListView({
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const licenseClearingData = (await response.json()) as LicenseClearing
                 setLicenseClearing(licenseClearingData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)
@@ -718,16 +716,14 @@ export default function ListView({
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const linkedProjectsData = (await response.json()) as LinkedProjects
                 setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -26,7 +26,7 @@ import {
     UserGroupType,
 } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ImportSBOMMetadata from '../../../../../../object-types/cyclonedx/ImportSBOMMetadata'
 import ImportSBOMModal from '../../../components/ImportSBOMModal'
 import LinkProjects from '../../../components/LinkProjects'
@@ -97,7 +97,9 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as SummaryDataType | AdministrationDataType
@@ -105,11 +107,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 setSummaryData(data as SummaryDataType)
                 setAdministrationData(data as AdministrationDataType)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 
@@ -134,16 +132,14 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const data = (await response.json()) as ClearingDetailsCount
                 setClearingDetailCount(data)
             } catch (error: unknown) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
         return () => controller.abort()
@@ -200,7 +196,9 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 }
 
                 if (resp.status !== StatusCodes.OK) {
-                    throw new Error(body?.message ?? body?.error ?? `Status ${resp.status}`)
+                    throw new ApiError(body?.message ?? body?.error ?? `Status ${resp.status}`, {
+                        status: resp.status,
+                    })
                 }
 
                 const obligations = body?.obligations ?? {}
@@ -216,8 +214,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 setObligationsTotal(total)
                 setObligationsNonOpenCount(nonOpen)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') return
-                MessageService.error(error instanceof Error ? error.message : String(error))
+                ApiUtils.reportError(error)
             } finally {
                 setObligationsLoading(false)
             }

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectVulnerabilities.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectVulnerabilities.tsx
@@ -15,7 +15,6 @@ import { signOut, useSession } from 'next-auth/react'
 import { type JSX, useEffect, useState } from 'react'
 import { Tab, Tabs } from 'react-bootstrap'
 import { Embedded, Project, ProjectData, ProjectVulnerabilityTabType } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
 import VulnerabilityTab from './VulnerabilityTab'
 
@@ -75,11 +74,7 @@ export default function ProjectVulnerabilities({ projectData }: { projectData: P
                 extractLinkedProjects(data._embedded['sw360:projects'], d)
                 setData(d)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -39,7 +39,7 @@ import {
     UIConfigKeys,
     UserGroupType,
 } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import AddLicenseInfoToReleaseModal from './AddLicenseInfoToReleaseModal'
 
 const Capitalize = (text: string) =>
@@ -788,17 +788,15 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const licenseClearingData = (await response.json()) as LicenseClearing
                 setLicenseClearing(licenseClearingData)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setIsLoadingLicenseClearing(false)
             }
@@ -829,17 +827,15 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const linkedProjectsData = (await response.json()) as LinkedProjects
                 setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                throw new Error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setIsLoadingLinkedProjects(false)
             }

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
@@ -27,8 +27,7 @@ import {
     ProjectVulnerabilityTabType,
     VulnerabilityRatingAndActionPayload,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ChangeVulnerabilityModal from './ChangeVulnerabilityModal'
 
 const Capitalize = (text: string) =>
@@ -241,7 +240,9 @@ export default function VulnerabilityTab({
                     const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                     if (response.status !== StatusCodes.OK) {
                         const err = (await response.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: response.status,
+                        })
                     }
 
                     const data = (await response.json()) as EmbeddedProjectVulnerabilitySummary
@@ -265,7 +266,9 @@ export default function VulnerabilityTab({
                     const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                     if (response.status !== StatusCodes.OK) {
                         const err = (await response.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: response.status,
+                        })
                     }
 
                     const data = (await response.json()) as EmbeddedProjectVulnerabilities
@@ -278,11 +281,7 @@ export default function VulnerabilityTab({
                     )
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
@@ -25,8 +25,7 @@ import {
     ProjectVulnerabilityTrackingStatus,
     VulnerabilityTrackingStatus,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 export default function VulnerabilityTrackingStatusComponent({
     projectData,
@@ -133,18 +132,16 @@ export default function VulnerabilityTrackingStatusComponent({
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as ProjectVulnerabilityTrackingStatus
                 setPaginationMeta(data.page)
                 setVulnerabilityData(data.vulnerabilityTrackingStatus ?? [])
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -666,11 +666,7 @@ function EditProject({
                 )
             }
         } catch (error: unknown) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -32,8 +32,7 @@ import {
     TypedEntity,
     UserGroupType,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import DownloadLicenseInfoModal from './DownloadLicenseInfoModal'
 import LicenseInfoDownloadConfirmationModal from './LicenseInfoDownloadConfirmation'
 
@@ -771,7 +770,9 @@ function GenerateLicenseInfo({
                 responses.map(async (r) => {
                     if (r.status !== StatusCodes.OK) {
                         const err = (await r.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: r.status,
+                        })
                     }
                 })
 
@@ -805,7 +806,9 @@ function GenerateLicenseInfo({
                 licenseResponses.map(async (r) => {
                     if (r.status !== StatusCodes.OK) {
                         const err = (await r.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: r.status,
+                        })
                     }
                 })
                 const _licenses = licenseResponses.map(async (licRes) => (await licRes.json()) as License[])
@@ -869,11 +872,7 @@ function GenerateLicenseInfo({
                 }
                 setSaveUsagesPayload(saveUsages)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
+++ b/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/object-types'
 import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -189,7 +189,9 @@ function GenerateSourceCodeBundle({
                 responses.map(async (r) => {
                     if (r.status !== StatusCodes.OK) {
                         const err = (await r.json()) as ErrorDetails
-                        throw new Error(err.message)
+                        throw new ApiError(err.message, {
+                            status: r.status,
+                        })
                     }
                 })
 
@@ -232,11 +234,7 @@ function GenerateSourceCodeBundle({
                 }
                 setSaveUsagesPayload(saveUsages)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/requests/components/OpenModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/OpenModerationRequest.tsx
@@ -19,8 +19,7 @@ import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table } from 'n
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, ModerationRequest } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils/index'
 import BulkDeclineModerationRequestModal from './BulkDeclineModerationRequestModal'
 import ExpandingModeratorCell from './ExpandingModeratorCell'
 
@@ -193,7 +192,9 @@ function OpenModerationRequest(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedModerationRequest
@@ -206,11 +207,7 @@ function OpenModerationRequest(): ReactNode {
                       )
                 setModerationRequestData(openModerationRequests)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/requests/components/Requests.tsx
+++ b/src/app/[locale]/requests/components/Requests.tsx
@@ -18,7 +18,6 @@ import { ReactNode, useEffect, useState } from 'react'
 import { Col, ListGroup, Row, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ClearingRequest, Embedded, ModerationRequest, RequestType, UserGroupType } from '@/object-types'
-import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils/index'
 import ClearingRequestComponent from './ClearingRequest'
 import ClosedModerationRequest from './ClosedModerationRequest'
@@ -199,11 +198,7 @@ function Requests(): ReactNode | undefined {
                 setOpenClearingRequestCount(openCRCount)
                 setClosedClearingRequestCount(closedCRCount)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
         return () => {

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
@@ -17,9 +17,8 @@ import { SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { Attachment, ErrorDetails, ModerationRequestDetails, RequestDocumentTypes } from '@/object-types'
-import MessageService from '@/services/message.service'
 import CommonUtils from '@/utils/common.utils'
-import { ApiUtils } from '@/utils/index'
+import { ApiError, ApiUtils } from '@/utils/index'
 import TableHeader from './TableHeader'
 
 type RowValue =
@@ -410,7 +409,9 @@ export default function ProposedChanges({
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 let additions: Record<string, RowValue> = {},
@@ -432,11 +433,7 @@ export default function ProposedChanges({
 
                 populateTableData(additions, deletions, data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setShowProcessing(false)
             }

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
@@ -34,8 +34,7 @@ import {
     ReleaseDetail,
     ReleaseTabIds,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 type EmbeddedChangelogs = Embedded<Changelogs, 'sw360:changeLogs'>
 
@@ -145,7 +144,9 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
                 const responseText = await response.text()
                 if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
@@ -161,11 +162,7 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
                     )
                 }
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/vulnerabilities/add/components/AddVulnerability.tsx
+++ b/src/app/[locale]/vulnerabilities/add/components/AddVulnerability.tsx
@@ -18,7 +18,7 @@ import { ReactNode, useEffect, useState } from 'react'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ErrorDetails, InputKeyValue, UserGroupType, Vulnerability } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import AddValues from '../../components/AddValues'
 import CVEReferences from '../../components/CVEReferences'
 import AddVendorAdvisory from '../../components/VendorAdvisories'
@@ -94,14 +94,12 @@ function AddVulnerability(): ReactNode {
                 router.push('/vulnerabilities/detail/' + data.externalId)
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/app/[locale]/vulnerabilities/components/DeleteVulnerabilityModal.tsx
+++ b/src/app/[locale]/vulnerabilities/components/DeleteVulnerabilityModal.tsx
@@ -17,7 +17,7 @@ import { Dispatch, type JSX, ReactNode, SetStateAction, useEffect, useState } fr
 import { Alert, Button, Modal } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface AlertData {
     variant: string
@@ -92,13 +92,17 @@ export default function DeleteVulnerabilityModal({
                         })
                     }
                 } else {
-                    throw new Error(t('Error when removing vulnerability'))
+                    throw new ApiError(t('Error when removing vulnerability'), {
+                        status: response.status,
+                    })
                 }
             } else {
-                throw new Error(t('Error when removing vulnerability'))
+                throw new ApiError(t('Error when removing vulnerability'), {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
+            if (error instanceof ApiError && error.isAborted) {
                 return
             }
             if (isEditPage) {

--- a/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
+++ b/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
@@ -27,8 +27,7 @@ import {
     UserGroupType,
     Vulnerability,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import DeleteVulnerabilityModal from './DeleteVulnerabilityModal'
 
 type EmbeddedVulnerabilities = Embedded<Vulnerability, 'sw360:vulnerabilityApiDTOes'>
@@ -249,7 +248,9 @@ function Vulnerabilities(): ReactNode {
                 const response = await ApiUtils.GET(queryUrl, session.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedVulnerabilities
@@ -261,11 +262,7 @@ function Vulnerabilities(): ReactNode {
                         : data['_embedded']['sw360:vulnerabilityApiDTOes'],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/app/[locale]/vulnerabilities/detail/[id]/components/VulnerabilityDetailsTab.tsx
+++ b/src/app/[locale]/vulnerabilities/detail/[id]/components/VulnerabilityDetailsTab.tsx
@@ -17,8 +17,7 @@ import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Breadcrumb, Col, ListGroup, Row, Spinner, Tab } from 'react-bootstrap'
 import { ErrorDetails, Vulnerability } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import MetaData from './MetaData'
 import References from './References'
 import Summary from './Summary'
@@ -56,18 +55,16 @@ export default function VulnerabilityDetailsTab({ vulnerabilityId }: { vulnerabi
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Vulnerability
 
                 setSummaryData(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 

--- a/src/app/[locale]/vulnerabilities/edit/[id]/components/EditVulnerability.tsx
+++ b/src/app/[locale]/vulnerabilities/edit/[id]/components/EditVulnerability.tsx
@@ -19,7 +19,7 @@ import { Spinner } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ErrorDetails, UserGroupType, Vulnerability } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import AddValues from '../../../components/AddValues'
 import CVEReferences from '../../../components/CVEReferences'
 import DeleteVulnerabilityModal from '../../../components/DeleteVulnerabilityModal'
@@ -84,7 +84,9 @@ function EditVulnerability({ vulnerabilityId }: { vulnerabilityId: string }): Re
 
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Vulnerability
@@ -130,11 +132,7 @@ function EditVulnerability({ vulnerabilityId }: { vulnerabilityId: string }): Re
                     vulnerableConfiguration: data.vulnerableConfiguration ?? {},
                 })
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
 
@@ -199,14 +197,12 @@ function EditVulnerability({ vulnerabilityId }: { vulnerabilityId: string }): Re
                 router.push('/vulnerabilities/detail/' + vulnerabilityId)
             } else {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/components/LicenseClearing.tsx
+++ b/src/components/LicenseClearing.tsx
@@ -14,8 +14,7 @@ import { getSession, signOut } from 'next-auth/react'
 import { ReactNode, useEffect, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { ErrorDetails } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface LicenseClearingData {
     'Release Count': number
@@ -39,18 +38,16 @@ export default function LicenseClearing({ projectId }: { projectId: string }): R
                 )
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as LicenseClearingData
 
                 setLcData(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             }
         })()
         return () => controller.abort()

--- a/src/components/ResourcesUsing/ResourcesUsing.tsx
+++ b/src/components/ResourcesUsing/ResourcesUsing.tsx
@@ -13,8 +13,7 @@ import { StatusCodes } from 'http-status-codes'
 import { signOut, useSession } from 'next-auth/react'
 import { type JSX, useEffect, useState } from 'react'
 import { DocumentTypes, ErrorDetails, Resources } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ComponentsUsing from './ComponentsUsing'
 import ProjectsUsing from './ProjectsUsing'
 
@@ -57,17 +56,15 @@ const ResourcesUsing = ({ documentId, documentType, documentName }: Props): JSX.
                 }
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as Resources
                 setResourceUsing(data)
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 setShowProcessing(false)
             }

--- a/src/components/sw360/DeleteItemWarning/DeleteItemWarning.tsx
+++ b/src/components/sw360/DeleteItemWarning/DeleteItemWarning.tsx
@@ -14,7 +14,7 @@ import React, { type JSX } from 'react'
 import { Modal } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import { AddtionalDataType, RolesType } from '@/object-types'
-import MessageService from '@/services/message.service'
+import { ApiUtils } from '@/utils'
 
 interface Input {
     key: string
@@ -66,11 +66,7 @@ const DeleteItemWarning = ({
             }
             setIsDeleteItem(false)
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         }
     }
 

--- a/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
+++ b/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
@@ -27,8 +27,7 @@ import {
     PaginationMeta,
     ProjectPayload,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     projectPayload: ProjectPayload
@@ -236,7 +235,9 @@ export default function LinkPackagesModal({ projectPayload, setProjectPayload, s
             const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedPackages
@@ -247,11 +248,7 @@ export default function LinkPackagesModal({ projectPayload, setProjectPayload, s
                     : data['_embedded']['sw360:packages'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }

--- a/src/components/sw360/LinkedReleasesModal/LinkedReleasesModal.tsx
+++ b/src/components/sw360/LinkedReleasesModal/LinkedReleasesModal.tsx
@@ -27,8 +27,7 @@ import {
     ProjectPayload,
     ReleaseDetail,
 } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     projectPayload: ProjectPayload
@@ -248,7 +247,9 @@ export default function LinkedReleasesModal({ projectPayload, setProjectPayload,
             const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedReleases
@@ -259,11 +260,7 @@ export default function LinkedReleasesModal({ projectPayload, setProjectPayload,
                     : data['_embedded']['sw360:releases'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }

--- a/src/components/sw360/SearchLicensesDialog/LicensesDialog.tsx
+++ b/src/components/sw360/SearchLicensesDialog/LicensesDialog.tsx
@@ -17,8 +17,7 @@ import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Button, Form, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, LicenseDetail, PageableQueryParam, PaginationMeta } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import { PageSizeSelector, SW360Table, TableFooter } from '../Table/Components'
 
 interface Props {
@@ -135,7 +134,9 @@ const LicensesDialog = ({ show, setShow, selectLicenses, releaseLicenses }: Prop
             const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedLicenses
@@ -146,11 +147,7 @@ const LicensesDialog = ({ show, setShow, selectLicenses, releaseLicenses }: Prop
                     : data['_embedded']['sw360:licenses'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }

--- a/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
+++ b/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
@@ -20,8 +20,7 @@ import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, Spinner } from 'react-bootstrap'
 import { BsCheck2Square } from 'react-icons/bs'
 import { Embedded, ErrorDetails, LicensePayload, NestedRows, Obligation } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     show: boolean
@@ -201,7 +200,9 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
                 const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
-                    throw new Error(err.message)
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
                 }
 
                 const data = (await response.json()) as EmbeddedObligations
@@ -221,11 +222,7 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
                         : [],
                 )
             } catch (error) {
-                if (error instanceof DOMException && error.name === 'AbortError') {
-                    return
-                }
-                const message = error instanceof Error ? error.message : String(error)
-                MessageService.error(message)
+                ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
                 setShowProcessing(false)

--- a/src/components/sw360/SearchReleasesModal/SearchReleasesModal.tsx
+++ b/src/components/sw360/SearchReleasesModal/SearchReleasesModal.tsx
@@ -26,8 +26,7 @@ import React, { type JSX, useEffect, useMemo, useState } from 'react'
 import { Button, Col, Form, Modal, Row, Spinner } from 'react-bootstrap'
 import { BsInfoCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseDetail } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 interface Props {
     projectId?: string | undefined
@@ -258,7 +257,9 @@ const SearchReleasesModal = ({ projectId, show, setShow, setSelectedReleases }: 
             const response = await ApiUtils.GET(queryUrl, session.data.user.access_token, signal)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedReleases
@@ -269,11 +270,7 @@ const SearchReleasesModal = ({ projectId, show, setShow, setSelectedReleases }: 
                     : data['_embedded']['sw360:releases'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }
@@ -291,7 +288,9 @@ const SearchReleasesModal = ({ projectId, show, setShow, setSelectedReleases }: 
             )
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedReleases
@@ -301,11 +300,7 @@ const SearchReleasesModal = ({ projectId, show, setShow, setSelectedReleases }: 
                     : data['_embedded']['sw360:releases'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }

--- a/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+++ b/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
@@ -18,8 +18,7 @@ import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useMemo, useState } from 'react'
 import { Button, Form, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Vendor } from '@/object-types'
-import MessageService from '@/services/message.service'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import AddVendorDialog from './AddVendor'
 
 interface Props {
@@ -138,7 +137,9 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
             const response = await ApiUtils.GET(queryUrl, session.data.user.access_token)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
-                throw new Error(err.message)
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
             }
 
             const data = (await response.json()) as EmbeddedVendors
@@ -149,11 +150,7 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
                     : data['_embedded']['sw360:vendors'],
             )
         } catch (error) {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-                return
-            }
-            const message = error instanceof Error ? error.message : String(error)
-            MessageService.error(message)
+            ApiUtils.reportError(error)
         } finally {
             setShowProcessing(false)
         }

--- a/src/services/download.service.ts
+++ b/src/services/download.service.ts
@@ -12,7 +12,6 @@
 import { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
 import { ApiUtils, CommonUtils } from '@/utils'
-import MessageService from './message.service'
 
 const download = async (
     url: string,
@@ -39,11 +38,7 @@ const download = async (
         setTimeout(() => window.URL.revokeObjectURL(objectURL), 0)
         return response.status
     } catch (error: unknown) {
-        if (error instanceof DOMException && error.name === 'AbortError') {
-            return
-        }
-        const message = error instanceof Error ? error.message : String(error)
-        MessageService.error(message)
+        ApiUtils.reportError(error)
     }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-import ApiUtils from './api/api.util'
+import ApiUtils, { ApiError } from './api/api.util'
 import CommonUtils from './common.utils'
 
-export { ApiUtils, CommonUtils }
+export { ApiUtils, ApiError, CommonUtils }


### PR DESCRIPTION
## Related

- Closes #1375

## Summary

This PR addresses [Issue #1375](https://github.com/eclipse-sw360/sw360-frontend/issues/1375) by implementing centralized error handling in the API utility functions.

## Changes Made

### 1. Enhanced `ApiError` Class (`src/utils/api/api.util.ts`)

- Added `isAborted` flag to distinguish between user-initiated aborts and actual errors
- Changed default timeout to `0` (no timeout) as per team decision
- Retry logic only triggers on gateway errors (502, 503, 504)
- Added `ApiUtils.reportError()` method that:
  - Converts errors to `ApiError` instances
  - Silently ignores aborted requests (user navigation, component unmount)
  - Reports actual errors via `MessageService.error()`

```typescript
export class ApiError extends Error {
    public status?: number
    public code: string
    public isRetryable: boolean
    public isAborted: boolean  // NEW: Distinguishes abort from real errors
    public cause?: unknown
}
```

### 2. Updated Error Handling Pattern Across Codebase

**Before:**
```typescript
} catch (error) {
    if (error instanceof DOMException && error.name === 'AbortError') {
        return
    }
    const message = error instanceof Error ? error.message : String(error)
    MessageService.error(message)
}
```

**After:**
```typescript
} catch (error) {
    ApiUtils.reportError(error)
}
```

### 3. Consistent Error Throwing

**Before:**
```typescript
throw new Error(err.message)
```

**After:**
```typescript
throw new ApiError(err.message, {
    status: response.status,
})
```

## Files Modified

### Core API Utils
- `src/utils/api/api.util.ts` - Enhanced ApiError class and added reportError method
- `src/utils/index.ts` - Export ApiError

### Admin Components
- `src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx`
- `src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx`
- `src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx`
- `src/app/[locale]/admin/importexport/components/ImportExport.tsx`
- `src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx`
- `src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx`
- `src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx`
- `src/app/[locale]/admin/obligations/components/Obligations.tsx`
- `src/app/[locale]/admin/users/components/UserAdministration.tsx`
- `src/app/[locale]/admin/vendors/components/VendorsList.tsx`
- `src/app/[locale]/admin/vendors/edit/[id]/components/EditVendor.tsx`
- `src/app/[locale]/admin/vendors/merge/[id]/components/MergeOverview.tsx`
- `src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx`

### Component Pages
- `src/app/[locale]/components/components/ComponentsTable.tsx`
- `src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx`
- `src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx`
- `src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx`
- `src/app/[locale]/components/detail/[id]/merge/components/MergeOverview.tsx`
- `src/app/[locale]/components/detail/[id]/split/components/SplitOverview.tsx`
- `src/app/[locale]/components/edit/[id]/components/Releases.tsx`
- `src/app/[locale]/components/releases/detail/[id]/components/*` (multiple files)

### Project Pages
- `src/app/[locale]/projects/components/LinkProjects.tsx`
- `src/app/[locale]/projects/components/Obligations/ObligationsView/*.tsx`
- `src/app/[locale]/projects/detail/[id]/components/*.tsx` (multiple files)

### Other Pages
- `src/app/[locale]/ecc/components/ECC.tsx`
- `src/app/[locale]/home/components/My*Widget.tsx` (multiple files)
- `src/app/[locale]/licenses/**/*.tsx` (multiple files)
- `src/app/[locale]/packages/**/*.tsx` (multiple files)
- `src/app/[locale]/preferences/components/*.tsx`
- `src/app/[locale]/requests/**/*.tsx` (multiple files)
- `src/app/[locale]/search/components/KeywordSearch.tsx`
- `src/app/[locale]/vulnerabilities/**/*.tsx` (multiple files)

### Shared Components
- `src/components/Attachments/Attachments.tsx`
- `src/components/LicenseClearing.tsx`
- `src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx`
- `src/components/ProjectAddSummary/Roles/DepartmentModal.tsx`
- `src/components/ResourcesUsing/ResourcesUsing.tsx`
- `src/components/sw360/**/*.tsx` (multiple modal and dialog components)

## Key Decisions

1. **No frontend timeout**: Team decided not to implement request timeouts on frontend as some queries (like license clearing for huge projects) can take 50+ seconds

2. **Retry on gateway errors only**: Retry logic triggers on 502, 503, 504 status codes (gateway/server issues)

3. **Silent abort handling**: Aborted requests (from user navigation or component unmount) are silently ignored and don't show error messages

4. **Centralized error reporting**: All API errors go through `ApiUtils.reportError()` for consistent handling

## Testing

- Verified error messages display correctly for API failures
- Verified no error messages appear when navigating away from pages (abort scenario)
- Verified retry logic works for gateway errors


