### PR TITLE
fix: Resolve license clearing table issues

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -23,7 +23,8 @@ import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
-import { FaFile, FaPencilAlt } from 'react-icons/fa'
+import { BsPencil } from 'react-icons/bs'
+import { FaFile } from 'react-icons/fa'
 import { Embedded, ErrorDetails, FilterOption, LicenseClearing, Project, Release, TypedEntity } from '@/object-types'
 import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
@@ -606,7 +607,7 @@ export default function ListView({
                                     href={url}
                                     className='overlay-trigger'
                                 >
-                                    <FaPencilAlt className='btn-icon' />
+                                    <BsPencil className='btn-icon' />
                                 </Link>
                             </OverlayTrigger>
                             {row.original.type === 'release' && (
@@ -696,7 +697,6 @@ export default function ListView({
         projectId,
         session,
         columnFilters,
-        memoizedLicenseClearing,
     ])
 
     useEffect(() => {
@@ -778,15 +778,22 @@ export default function ListView({
                 </Modal.Header>
                 <Modal.Body>
                     {licenseFiles.length > 0 ? (
-                        <ul>
-                            {licenseFiles.map((file, index) => (
-                                <li key={index}>{file}</li>
+                        <ul className='list-unstyled'>
+                            {licenseFiles.map((file) => (
+                                <li
+                                    key={file}
+                                    className='d-flex align-items-center mb-2'
+                                >
+                                    <FaFile className='me-2 text-secondary' />
+                                    <span>{file}</span>
+                                </li>
                             ))}
                         </ul>
                     ) : (
-                        <p>{t('No license files available')}</p>
+                        <p className='text-muted'>{t('No license files available')}</p>
                     )}
                 </Modal.Body>
+
                 <Modal.Footer>
                     <Button
                         variant='secondary'


### PR DESCRIPTION
## Changes
- ✅ Replace FaPencilAlt with BsPencil icon 
- ✅ Fix render loop caused by memoizedLicenseClearing in dependency array  
- ✅ Add file icons to license file list items
- ✅ Use text-muted class for empty state message

## Fixes
Addresses feedback 
- Icon usage (BsPencil instead of FaPencilAlt)
- Render loop issue causing constant processing state
- Modal UI improvements as suggested

Closes #918