### PR TITLE
fix(search): double encoding for search parameters

### DIFF
--- a/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
+++ b/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
@@ -81,8 +81,7 @@ function AdvancedSearch({ title = 'Advanced Search', fields }: Props): JSX.Eleme
                 searchUrl.searchParams.append(key, value)
             }
         })
-        const encodedUrl = encodeURI(searchUrl.toString().replace(/%40/g, '@'))
-        router.push(encodedUrl)
+        router.push(searchUrl.toString())
     }
 
     const handleSubmit = (e: React.FormEvent) => {


### PR DESCRIPTION
Issue: #1416 

Now, the parameters will no longer be double-encoded.