### PR TITLE
Fix license table empty shortName and broken detail link

### DIFF
--- a/src/app/[locale]/licenses/components/LicensePage.tsx
+++ b/src/app/[locale]/licenses/components/LicensePage.tsx
@@ -81,15 +81,20 @@ function LicensePage(): ReactNode {
         () => [
             {
                 id: 'shortName',
+                accessorKey: 'shortName',
                 header: t('License Shortname'),
                 cell: ({ row }) => {
-                    const { shortName } = row.original
+                    const { shortName, _links } = row.original
+                    const licenseId = _links?.self?.href?.split('/').filter(Boolean).at(-1)
+                    if (!licenseId) {
+                        return <>{shortName || '--'}</>
+                    }
                     return (
                         <Link
-                            href={`/licenses/detail?id=${shortName}`}
+                            href={`/licenses/detail?id=${encodeURIComponent(licenseId)}`}
                             className='link'
                         >
-                            {shortName}
+                            {shortName || licenseId || '--'}
                         </Link>
                     )
                 },


### PR DESCRIPTION
## Summary                                                                                                                            
  - License table showed blank text when shortName was empty or missing                                                                 
  - Clicking a license row did not navigate to the detail page correctly because the link was built from shortName instead of the actual license ID                                                                                                                           
                                                                                                                                        
  ## Changes                                                                                                                            
  - Extract license ID from `_links.self.href` instead of relying on shortName for the detail link                                      
  - Added `accessorKey` to the shortName column                                                                                         
  - Added fallback display so the cell never shows blank text                                                                           
  - Used `encodeURIComponent` on the link parameter                                                                                     
                                                                                                                                        
  Closes #1318                                      