### PR TITLE
fix(licensClearing): Use camelCase for license clearing count props

### DIFF
--- a/src/components/LicenseClearing.tsx
+++ b/src/components/LicenseClearing.tsx
@@ -17,8 +17,8 @@ import { ErrorDetails } from '@/object-types'
 import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 
 export interface LicenseClearingData {
-    'Release Count': number
-    'Approved Count': number
+    releaseCount: number
+    approvedCount: number
 }
 
 interface LicenseClearingProps {
@@ -70,7 +70,7 @@ export default function LicenseClearing({ projectId, data }: LicenseClearingProp
     return (
         <>
             {lcData ? (
-                <div className='text-center'>{`${lcData['Approved Count']}/${lcData['Release Count']}`}</div>
+                <div className='text-center'>{`${lcData.approvedCount}/${lcData.releaseCount}`}</div>
             ) : (
                 <div className='col-12 text-center'>
                     <Spinner


### PR DESCRIPTION
Fixes : #1417 

Changes the license clearing count properties to adapt to new camelCase payload.

Please test this after merging : https://github.com/eclipse-sw360/sw360/pull/3638