### PR TITLE
fix(navbar): Hide toggle on auth page

### DIFF
--- a/src/components/sw360/Navbar/Navbar.tsx
+++ b/src/components/sw360/Navbar/Navbar.tsx
@@ -116,7 +116,7 @@ function Navbar(): JSX.Element {
                             alt='SW360 Logo'
                         />
                     </BSNavbar.Brand>
-                    <BSNavbar.Toggle aria-controls='navbarScroll' />
+                    {pathname != '/' && <BSNavbar.Toggle aria-controls='navbarScroll' />}
                     <BSNavbar.Collapse id='navbarScroll'>
                         {pathname != '/' && (
                             <Nav


### PR DESCRIPTION
fix #1437

On mobile view, the navbar toggle (hamburger) was visible on the auth page even though there were no nav items to show. This fix hides the toggle on the auth/login page to improve UX.


### After:
[Screencast from 2026-02-03 02-02-28.webm](https://github.com/user-attachments/assets/178e2e44-679a-4cce-a274-ce0715a23b17)
