### PR TITLE
fix(UI): Add logic to delete open clearing requests from request tab, when the project has deleted.

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "Möchten Sie diesen Kunden wirklich löschen?",
     "Do you really want to delete this item": "Möchten Sie diesen Artikel wirklich löschen?",
     "Do you really want to delete this obligation": "Möchten Sie diese Verpflichtung wirklich löschen?",
+    "Project has open clearing requests": "Das Projekt hat offene Clearing-Anfragen",
     "Do you really want to export SBOM": "Möchten Sie SBOM wirklich für das Projekt <strong> {ProjectName} </strong> (<strong> {ProjectVersion} </strong>) exportieren?",
     "Do you really want to import all OSADL license obligations": "Möchten Sie wirklich alle OSADL -Lizenzverpflichtungen importieren?",
     "Do you really want to import all SPDX all licenses": "Möchten Sie wirklich alle SPDX alle Lizenzen importieren",

--- a/messages/en.json
+++ b/messages/en.json
@@ -454,6 +454,7 @@
     "Do you really want to delete the vulnerability?": "Do you really want to delete the vulnerability <strong>{id}</strong>?",
     "Do you really want to delete this client": "Do you really want to delete this client",
     "Do you really want to delete this item": "Do you really want to delete this item?",
+    "Project has open clearing requests": "Project has open clearing requests",
     "Do you really want to delete this obligation": "Do you really want to delete this obligation",
     "Do you really want to export SBOM": "Do you really want to export SBOM for the project <strong>{projectName}</strong> (<strong>{projectVersion}</strong>)?",
     "Do you really want to import all OSADL license obligations": "Do you really want to import all OSADL license obligations",

--- a/messages/es.json
+++ b/messages/es.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "¿De verdad quieres eliminar este cliente?",
     "Do you really want to delete this item": "¿Realmente quieres eliminar este artículo?",
     "Do you really want to delete this obligation": "¿De verdad quieres eliminar esta obligación?",
+    "Project has open clearing requests": "El proyecto tiene solicitudes de clearing abiertas",
     "Do you really want to export SBOM": "¿Realmente quieres exportar SBOM para el proyecto <strong> {ProjectName} </strong> (<strong> {ProjectVersion} </strong>)?",
     "Do you really want to import all OSADL license obligations": "¿Realmente quieres importar todas las obligaciones de licencia de OSADL?",
     "Do you really want to import all SPDX all licenses": "¿Realmente quieres importar todas las licencias SPDX?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "Voulez-vous vraiment supprimer ce client",
     "Do you really want to delete this item": "Voulez-vous vraiment supprimer cet article?",
     "Do you really want to delete this obligation": "Voulez-vous vraiment supprimer cette obligation",
+    "Project has open clearing requests": "Le projet a des demandes de clearing ouvertes",
     "Do you really want to export SBOM": "Voulez-vous vraiment exporter SBOM pour le projet <strong> {projectName} </strong> (<strong> {projectVersion} </strong>)?",
     "Do you really want to import all OSADL license obligations": "Voulez-vous vraiment importer toutes les obligations de licence OSADL",
     "Do you really want to import all SPDX all licenses": "Voulez-vous vraiment importer toutes les licences SPDX toutes",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "本当にこのクライアントを削除したいですか",
     "Do you really want to delete this item": "本当にこのアイテムを削除したいですか？",
     "Do you really want to delete this obligation": "あなたは本当にこの義務を削除したいですか？",
+    "Project has open clearing requests": "プロジェクトにはオープンなクリアリングリクエストがあります",
     "Do you really want to export SBOM": "プロジェクトのためにSBOMを本当にエクスポートしたいですか<strong> {ProjectName} </strong>（<strong> {Projectersion} </strong>）？",
     "Do you really want to import all OSADL license obligations": "すべてのOSADLライセンス義務を本当に輸入したいですか",
     "Do you really want to import all SPDX all licenses": "あなたは本当にすべてのSPDXすべてのライセンスをインポートしたいですか",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "이 클라이언트를 정말로 삭제하고 싶습니까?",
     "Do you really want to delete this item": "이 항목을 정말로 삭제하고 싶습니까?",
     "Do you really want to delete this obligation": "이 의무를 삭제하고 싶습니까?",
+    "Project has open clearing requests": "프로젝트에 열린 클리어링 요청이 있습니다",
     "Do you really want to export SBOM": "프로젝트 <strong> {projectName} </strong> (<strong> {projectVersion} </strong>)에 대해 SBOM을 내보내고 싶습니까?",
     "Do you really want to import all OSADL license obligations": "모든 OSADL 라이센스 의무를 가져오고 싶습니까?",
     "Do you really want to import all SPDX all licenses": "모든 SPDX 모든 라이센스를 가져오고 싶습니까?",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "Você realmente quer excluir este cliente",
     "Do you really want to delete this item": "Você realmente deseja excluir este item?",
     "Do you really want to delete this obligation": "Você realmente quer excluir esta obrigação",
+    "Project has open clearing requests": "O projeto tem solicitações de clearing abertas",
     "Do you really want to export SBOM": "Deseja realmente exportar o SBOM para o projeto <strong> {ProjectName} </strong> (<strong> {ProjectVersion} </strong>)?",
     "Do you really want to import all OSADL license obligations": "Você realmente quer importar todas as obrigações de licença OSADL",
     "Do you really want to import all SPDX all licenses": "Você realmente quer importar todas as licenças SPDX todas as",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "Bạn có thực sự muốn xóa máy khách này không",
     "Do you really want to delete this item": "Bạn có thực sự muốn xóa mục này?",
     "Do you really want to delete this obligation": "Bạn có thực sự muốn xóa nghĩa vụ này không",
+    "Project has open clearing requests": "Dự án có các yêu cầu clearing đang mở",
     "Do you really want to export SBOM": "Bạn có thực sự muốn xuất SBOM cho dự án <strong> {ProjectName} </strong> (<strong> {chiếu} </strong>)?",
     "Do you really want to import all OSADL license obligations": "Bạn có thực sự muốn nhập tất cả các nghĩa vụ giấy phép OSADL",
     "Do you really want to import all SPDX all licenses": "Bạn có thực sự muốn nhập tất cả SPDX tất cả các giấy phép",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "您真的想删除这个客户吗",
     "Do you really want to delete this item": "您真的想删除此项目吗？",
     "Do you really want to delete this obligation": "您真的想删除这项义务吗",
+    "Project has open clearing requests": "项目有未完成的清理请求",
     "Do you really want to export SBOM": "您是否真的想为项目<strong> {projectName} </strong>（<strong> {projectversion} </strong>）导出SBOM？",
     "Do you really want to import all OSADL license obligations": "您真的想进口所有OSADL许可证义务吗",
     "Do you really want to import all SPDX all licenses": "您真的想导入所有SPDX所有许可证吗",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -455,6 +455,7 @@
     "Do you really want to delete this client": "您真的想刪除這個客戶嗎",
     "Do you really want to delete this item": "您真的想刪除此項目嗎？",
     "Do you really want to delete this obligation": "您真的想刪除這項義務嗎",
+    "Project has open clearing requests": "項目有未完成的清理請求",
     "Do you really want to export SBOM": "您是否真的想為項目<strong> {projectName} </strong>（<strong> {projectversion} </strong>）導出SBOM？",
     "Do you really want to import all OSADL license obligations": "您真的想進口所有OSADL許可證義務嗎",
     "Do you really want to import all SPDX all licenses": "您真的想導入所有SPDX所有許可證嗎",

--- a/src/app/[locale]/projects/components/DeleteProjectDialog.tsx
+++ b/src/app/[locale]/projects/components/DeleteProjectDialog.tsx
@@ -30,9 +30,10 @@ interface Props {
     projectId: string
     show: boolean
     setShow: React.Dispatch<React.SetStateAction<boolean>>
+    hasClearingRequest?: boolean
 }
 
-function DeleteProjectDialog({ projectId, show, setShow }: Props): JSX.Element {
+function DeleteProjectDialog({ projectId, show, setShow, hasClearingRequest = false }: Props): JSX.Element {
     const t = useTranslations('default')
     const router = useRouter()
     const [project, setProject] = useState<Project>()
@@ -214,6 +215,14 @@ function DeleteProjectDialog({ projectId, show, setShow }: Props): JSX.Element {
                                         })}
                                     </Form.Label>
                                     <br />
+                                    {hasClearingRequest && (
+                                        <Alert
+                                            variant='warning'
+                                            className='mb-3'
+                                        >
+                                            <strong>{t('Warning')}:</strong> {t('Project has open clearing requests')}
+                                        </Alert>
+                                    )}
                                     <Form.Label
                                         className='mb-1'
                                         visuallyHidden={visuallyHideLinkedData}

--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -52,6 +52,7 @@ function Project(): JSX.Element {
     const router = useRouter()
     const [deleteProjectId, setDeleteProjectId] = useState<string>('')
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+    const [hasClearingRequest, setHasClearingRequest] = useState(false)
     const [importSBOMMetadata, setImportSBOMMetadata] = useState<ImportSBOMMetadata>({
         show: false,
         importType: 'SPDX',
@@ -77,8 +78,10 @@ function Project(): JSX.Element {
         status,
     ])
 
-    const handleDeleteProject = (projectId: string) => {
+    const handleDeleteProject = (projectId: string, clearingRequestId?: string, clearingState?: string) => {
         setDeleteProjectId(projectId)
+        const hasOpenCR = clearingRequestId && (clearingState === 'OPEN' || clearingState === 'IN_PROGRESS')
+        setHasClearingRequest(!!hasOpenCR)
         setDeleteDialogOpen(true)
     }
 
@@ -305,7 +308,13 @@ function Project(): JSX.Element {
                                             <BsFillTrashFill
                                                 className='btn-icon'
                                                 size={20}
-                                                onClick={() => handleDeleteProject(id)}
+                                                onClick={() => {
+                                                    if (projectClearingRequestId && projectClearingRequestId !== '') {
+                                                        handleDeleteProject(id, projectClearingRequestId, clearingState)
+                                                    } else {
+                                                        handleDeleteProject(id)
+                                                    }
+                                                }}
                                             />
                                         </span>
                                     </OverlayTrigger>
@@ -676,6 +685,7 @@ function Project(): JSX.Element {
                     projectId={deleteProjectId}
                     show={deleteDialogOpen}
                     setShow={setDeleteDialogOpen}
+                    hasClearingRequest={hasClearingRequest}
                 />
             )}
             <Breadcrumb name={t('Projects')} />

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -73,6 +73,7 @@ function EditProject({
 
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
     const [isLoading, setIsLoading] = useState(true)
+    const [hasClearingRequest, setHasClearingRequest] = useState(false)
 
     const session = useSession()
 
@@ -356,6 +357,14 @@ function EditProject({
                     return notFound()
                 }
                 const project = (await response.json()) as Project
+
+                // Check if project has open clearing request using clearingState from project response
+                if (project.clearingRequestId && project.clearingRequestId !== '') {
+                    const clearingState = project.clearingState?.toUpperCase()
+                    const hasOpenCR = clearingState === 'OPEN' || clearingState === 'IN_PROGRESS'
+                    setHasClearingRequest(hasOpenCR)
+                }
+
                 if (project.externalIds !== undefined) {
                     setExternalIds(CommonUtils.convertObjectToMap(project.externalIds))
                 }
@@ -710,6 +719,7 @@ function EditProject({
                                 projectId={projectId}
                                 show={deleteDialogOpen}
                                 setShow={setDeleteDialogOpen}
+                                hasClearingRequest={hasClearingRequest}
                             />
                         )}
                         {projectId && (


### PR DESCRIPTION
issue: closes #1453 

Test Scenario 1: Delete Project with Open Clearing Request
1:Navigate to Projects page
2: Create a new test project or select an existing project
3: Create a clearing request for this project (if not already present)
4: Verify the clearing request appears in the "Clearing Requests" tab/page
5: Delete the project from the Projects page
6: Navigate to the "Clearing Requests" tab
Expected Result: The clearing request associated with the deleted project should be automatically removed from the list

Test Scenario 2: Verify No Impact on Other Clearing Requests

1:Create multiple projects with clearing requests
2: Delete only one project
3: Expected Result: Only the clearing request(s) for the deleted project should be removed; other clearing requests should remain intact