### PR TITLE
fix(UI): Report end point urls updation

### DIFF
--- a/src/components/sw360/Footer/Footer.tsx
+++ b/src/components/sw360/Footer/Footer.tsx
@@ -58,7 +58,7 @@ function Footer(): JSX.Element {
                     |
                     <Link
                         className='footer-href'
-                        href='/resource/mkdocs/index.html'
+                        href='https://www.eclipse.org/sw360/docs/'
                         rel='noopener noreferrer'
                         target='_blank'
                     >
@@ -68,7 +68,7 @@ function Footer(): JSX.Element {
                     |
                     <Link
                         className='footer-href'
-                        href='/resource/docs/api-guide.html'
+                        href={`${SW360_API_URL}/resource/swagger-ui/index.html#/`}
                         rel='noopener noreferrer'
                         target='_blank'
                     >


### PR DESCRIPTION
## Summary
Restore SW360 documentation links to their original state.

## Related Issue
Fixes REST API and SW360 documentation URL issue in Footer component

## Changes
- Updated correct URL for documentation.

## Testing
- Click on the links as in Screenshot - New tabs should be opened and respective documentation also should be available

<img width="1760" height="1012" alt="image" src="https://github.com/user-attachments/assets/83222aca-65ba-4e71-b3ce-139c3006e053" />
