### PR TITLE
fix(requests): Show error message on edit Clearing Request failure

### DIFF
--- a/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequest.tsx
+++ b/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequest.tsx
@@ -107,6 +107,9 @@ function EditClearingRequest({ clearingRequestId }: { clearingRequestId: string 
                 router.push(`/requests/clearingRequest/detail/${clearingRequestData?.id}`)
             } else if (response.status == StatusCodes.UNAUTHORIZED) {
                 await signOut()
+            } else {
+                const data = await response.json()
+                MessageService.error(data.message)
             }
         } catch (err) {
             console.error(err)


### PR DESCRIPTION
 ## Summary
  - Show backend error message to user when updating a Clearing Request fails
  - Previously, non-OK responses (e.g. 400 "Invalid agreed clearing date requested") were silently caught with no UI feedback
  - Added `else` branch to display `MessageService.error(data.message)`, same pattern as EditComponent and EditRelease

  Fixes #1492 