### PR TITLE
fix(release): Fixed missing data at release edit and detail page

### DIFF
--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -26,6 +26,7 @@ import { Attachment, Embedded, ErrorDetails, NestedRows, UserGroupType } from '@
 import DownloadService from '@/services/download.service'
 import { ApiError, ApiUtils, CommonUtils } from '@/utils'
 import ImportSummary from '../../object-types/cyclonedx/ImportSummary'
+import ReleaseCheckStates from '../../object-types/enums/ReleaseCheckStates'
 
 type EmbeddedAttachments = Embedded<Attachment, 'sw360:attachments'>
 
@@ -176,7 +177,11 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
                 header: t('Reviewer Group'),
                 cell: ({ row }) => {
                     if (row.depth > 0) return
-                    return <p className='text-center'>{row.original.node.checkedTeam ?? ''}</p>
+                    if (row.original.node.checkStatus === ReleaseCheckStates.ACCEPTED) {
+                        return <p className='text-center text-success'>{row.original.node.checkedTeam ?? ''}</p>
+                    } else if (row.original.node.checkStatus === ReleaseCheckStates.REJECTED) {
+                        return <p className='text-center text-danger'>{row.original.node.checkedTeam ?? ''}</p>
+                    }
                 },
             },
             {
@@ -184,14 +189,25 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
                 header: t('Checked By'),
                 cell: ({ row }) => {
                     if (row.depth > 0) return
-                    return (
-                        <Link
-                            href={`mailto:${row.original.node.checkedBy ?? ''}`}
-                            className='text-link w-100 text-center'
-                        >
-                            {row.original.node.checkedBy ?? ''}
-                        </Link>
-                    )
+                    if (row.original.node.checkStatus === ReleaseCheckStates.ACCEPTED) {
+                        return (
+                            <Link
+                                href={`mailto:${row.original.node.checkedBy ?? ''}`}
+                                className='text-link text-center text-success'
+                            >
+                                {row.original.node.checkedBy ?? ''}
+                            </Link>
+                        )
+                    } else if (row.original.node.checkStatus === ReleaseCheckStates.REJECTED) {
+                        return (
+                            <Link
+                                href={`mailto:${row.original.node.checkedBy ?? ''}`}
+                                className='text-link w-100 text-center text-danger'
+                            >
+                                {row.original.node.checkedBy ?? ''}
+                            </Link>
+                        )
+                    }
                 },
             },
             {

--- a/src/components/Attachments/TableAttachment/TableAttachment.tsx
+++ b/src/components/Attachments/TableAttachment/TableAttachment.tsx
@@ -163,6 +163,7 @@ function TableAttachment({
                                     name='attachmentType'
                                     className='attachmentType toplabelledInput form-control'
                                     onChange={(e) => handleInputChange(e, index)}
+                                    value={attachment.attachmentType}
                                 >
                                     {Object.keys(AttachmentTypes).map((type: string) => (
                                         <option

--- a/src/object-types/enums/ReleaseCheckStates.ts
+++ b/src/object-types/enums/ReleaseCheckStates.ts
@@ -1,0 +1,16 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+enum ReleaseCheckStates {
+    NOTCHECKED = 'NOTCHECKED',
+    ACCEPTED = 'ACCEPTED',
+    REJECTED = 'REJECTED',
+}
+
+export default ReleaseCheckStates


### PR DESCRIPTION
Fixes :

- Missing attachment type of existing attachments under `Attachments` tab at `Edit Release` page
- Color coding based on the check status for the `Checking User Group` and `Checking User Email` 

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/1512 