### PR TITLE
fix(project): Update ClearingTeam to simple string

### DIFF
--- a/src/app/[locale]/projects/add/page.tsx
+++ b/src/app/[locale]/projects/add/page.tsx
@@ -156,7 +156,14 @@ function AddProjects(): JSX.Element {
         if (CommonUtils.isNullOrUndefined(session)) return signOut()
         const createUrl = isDependencyNetworkFeatureEnabled === true ? `projects/network` : 'projects'
         try {
-            const response = await ApiUtils.POST(createUrl, projectPayload, session.user.access_token)
+            // Ensure we send the latest input value even if state update hasn't re-rendered yet.
+            const clearingTeamInput = document.getElementById('addProjects.clearingTeam') as HTMLInputElement | null
+            const clearingTeamValue = clearingTeamInput?.value?.trim()
+            const payloadToCreate = {
+                ...projectPayload,
+                clearingTeam: clearingTeamValue ?? projectPayload.clearingTeam,
+            }
+            const response = await ApiUtils.POST(createUrl, payloadToCreate, session.user.access_token)
 
             if (response.status == StatusCodes.CREATED) {
                 const data = (await response.json()) as Project

--- a/src/app/[locale]/projects/detail/[id]/components/Administration.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Administration.tsx
@@ -33,6 +33,35 @@ export default function Administration({ data, clearingDetailCount }: Props): JS
     const [toggleLicenseInfoHeader, setToggleLicenseInfoHeader] = useState(false)
     const { status } = useSession()
 
+    // summaryAdministration payload shape has changed in backend (clearingTeam was user/email -> plain string).
+    // Keep UI resilient by checking multiple possible field paths.
+    const clearingTeamValue = (() => {
+        const anyData = data as unknown as {
+            clearingTeam?: string
+            clearingTeamName?: string
+            clearingTeamEmail?: string
+            _embedded?: {
+                clearingTeam?: unknown
+            }
+        }
+
+        const embedded = anyData._embedded?.clearingTeam
+        if (typeof embedded === 'string') return embedded
+        if (embedded && typeof embedded === 'object') {
+            const e = embedded as Record<string, unknown>
+            return (
+                (anyData.clearingTeam as string | undefined) ??
+                (anyData.clearingTeamName as string | undefined) ??
+                (anyData.clearingTeamEmail as string | undefined) ??
+                (e.fullName as string | undefined) ??
+                (e.name as string | undefined) ??
+                (e.email as string | undefined)
+            )
+        }
+
+        return anyData.clearingTeam ?? anyData.clearingTeamName ?? anyData.clearingTeamEmail ?? ''
+    })()
+
     useEffect(() => {
         if (status === 'unauthenticated') {
             signOut()
@@ -71,7 +100,7 @@ export default function Administration({ data, clearingDetailCount }: Props): JS
                     </tr>
                     <tr>
                         <td>{t('Clearing Team')}:</td>
-                        <td>{data._embedded?.clearingTeam?.email ?? ''}</td>
+                        <td>{clearingTeamValue}</td>
                     </tr>
                     <tr>
                         <td>{t('Deadline for pre-evaluation')}:</td>

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -200,6 +200,7 @@ function EditProject({
         ownerGroup: '',
         ownerCountry: '',
         clearingState: '',
+        clearingTeam: '',
         businessUnit: '',
         preevaluationDeadline: '',
         clearingSummary: '',
@@ -482,6 +483,7 @@ function EditProject({
                     ownerGroup: project.ownerGroup ?? '',
                     ownerCountry: project.ownerCountry ?? '',
                     clearingState: project.clearingState ?? 'OPEN',
+                    clearingTeam: project.clearingTeam ?? '',
                     businessUnit: project.businessUnit ?? '',
                     preevaluationDeadline: project.preevaluationDeadline ?? '',
                     clearingSummary: project.clearingSummary ?? '',
@@ -591,12 +593,19 @@ function EditProject({
         try {
             if (CommonUtils.isNullOrUndefined(session.data)) return signOut()
             const dataToUpdate = payload ?? projectPayload
+            // Ensure we send the latest input value even if state update hasn't re-rendered yet.
+            const clearingTeamInput = document.getElementById('addProjects.clearingTeam') as HTMLInputElement | null
+            const clearingTeamValue = clearingTeamInput?.value?.trim()
+            const payloadToUpdate = {
+                ...dataToUpdate,
+                clearingTeam: clearingTeamValue ?? dataToUpdate.clearingTeam,
+            }
             const requests = [
                 ApiUtils.PATCH(
                     isDependencyNetworkFeatureEnabled === true
                         ? `projects/network/${projectId}`
                         : `projects/${projectId}`,
-                    dataToUpdate,
+                    payloadToUpdate,
                     session.data.user.access_token,
                 ),
             ]
@@ -665,13 +674,13 @@ function EditProject({
             }
             if (allOk) {
                 MessageService.success(
-                    t('Project') + ` ${dataToUpdate.name} (${dataToUpdate.version}) ` + t('updated successfully'),
+                    t('Project') + ` ${payloadToUpdate.name} (${payloadToUpdate.version}) ` + t('updated successfully'),
                 )
                 router.push(`/projects/detail/${projectId}`)
             } else {
                 MessageService.error(
                     t('There are some errors while updating project') +
-                        ` ${dataToUpdate.name} (${dataToUpdate.version})!`,
+                        ` ${payloadToUpdate.name} (${payloadToUpdate.version})!`,
                 )
             }
         } catch (error: unknown) {

--- a/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingDecision.tsx
+++ b/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingDecision.tsx
@@ -74,10 +74,15 @@ export default function ClearingDecision({ data }: Readonly<Props>): ReactNode |
                 <tr>
                     <td>{t('Clearing Team')}:</td>
                     <td>
-                        {data?.clearingTeam !== undefined && data?._embedded?.clearingTeam?.fullName !== undefined ? (
-                            <Link href={`mailto:${data._embedded.clearingTeam.email}`}>
-                                {data._embedded.clearingTeam.fullName}
-                            </Link>
+                        {data?.clearingTeam !== undefined ? (
+                            data?._embedded?.clearingTeam?.fullName !== undefined &&
+                            data?._embedded?.clearingTeam?.email !== undefined ? (
+                                <Link href={`mailto:${data._embedded.clearingTeam.email}`}>
+                                    {data._embedded.clearingTeam.fullName}
+                                </Link>
+                            ) : (
+                                data.clearingTeam
+                            )
                         ) : (
                             ''
                         )}

--- a/src/components/ProjectAddSummary/component/Administration/Clearing.tsx
+++ b/src/components/ProjectAddSummary/component/Administration/Clearing.tsx
@@ -74,25 +74,26 @@ export default function Clearing({ projectPayload, setProjectPayload }: Props): 
                         >
                             {t('Clearing Team')}
                         </label>
-                        <select
-                            className='form-select'
+                        <input
+                            type='text'
+                            className='form-control'
                             id='addProjects.clearingTeam'
                             aria-label='Clearing Team'
                             name='clearingTeam'
-                            value={projectPayload.clearingTeam ?? 'UNKNOWN'}
+                            value={projectPayload.clearingTeam ?? ''}
                             onChange={updateInputField}
-                        >
-                            {unknownClearingTeamEnabled && <option value={'Unknown'}>{t('Unknown')}</option>}
-                            {projectClearingTeams &&
-                                projectClearingTeams.map((team) => (
-                                    <option
-                                        value={team}
-                                        key={team}
-                                    >
-                                        {team}
-                                    </option>
-                                ))}
-                        </select>
+                            placeholder={t('Clearing Team')}
+                            list='clearing-teams'
+                        />
+                        <datalist id='clearing-teams'>
+                            {unknownClearingTeamEnabled && <option value='Unknown' />}
+                            {projectClearingTeams?.map((team) => (
+                                <option
+                                    value={team}
+                                    key={team}
+                                />
+                            ))}
+                        </datalist>
                     </div>
                     <div className='col-lg-4'>
                         <label

--- a/src/object-types/AdministrationDataType.ts
+++ b/src/object-types/AdministrationDataType.ts
@@ -9,6 +9,13 @@
 
 interface AdministrationDataType {
     clearingState?: string
+    clearingTeam?: string
+    _embedded?: {
+        clearingTeam?: {
+            email?: string
+            fullName?: string
+        }
+    }
     clearingDetails?: string
     preevaluationDeadline?: string
     clearingSummary?: string
@@ -23,11 +30,6 @@ interface AdministrationDataType {
     deliveryStart?: string
     phaseOutSince?: string
     licenseInfoHeaderText?: string
-    _embedded?: {
-        clearingTeam?: {
-            email: string
-        }
-    }
 }
 
 export default AdministrationDataType

--- a/src/object-types/Project.ts
+++ b/src/object-types/Project.ts
@@ -29,6 +29,7 @@ export interface Project {
     }
     businessUnit?: string
     clearingState?: string
+    clearingTeam?: string
     clearingSummary?: string
     clearingRequestId?: string
     contributors?: string[]


### PR DESCRIPTION
## Summary

I updated the frontend for `clearingTeam` as a simple string, but it was still not working correctly in UI because the value was coming as `null` in project responses.
fixes #1537

So to fully fix it, backend also needed a small update.

## What happened

- Frontend was sending/saving `clearingTeam` correctly.
- But after save, UI still showed empty value.
- API response for project data was not returning `clearingTeam` properly (it was effectively null/missing in the response used by UI).

## Why backend change was needed

Only frontend changes were not enough.  
The backend serialization path still had old assumptions and was not exposing `clearingTeam` consistently as a plain string in response.

Because of that, UI could not show the updated value even when save call succeeded.

## Final fix

- Keep frontend updates for plain-string `clearingTeam`.
- Add small backend update so `clearingTeam` is returned correctly in project responses.

## Is this backend change needed?
Without backend update, frontend still receives null/empty `clearingTeam` in response and UI cannot display it reliably.


## chnages i made
```git diff -- rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
diff --git a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
index 611dfce7..4e6d112c 100644
--- a/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
+++ b/rest/resource-server/src/main/java/org/eclipse/sw360/rest/resourceserver/core/JacksonCustomizations.java
@@ -267,7 +267,6 @@ public class JacksonCustomizations {
                 "attachments",
                 "createdBy",
                 "visbility",
-                "clearingTeam",
                 "homepage",
                 "wiki",
                 "documentState",
@@ -2752,7 +2751,6 @@ public class JacksonCustomizations {
                 "attachments",
                 "createdBy",
                 "visbility",
-                "clearingTeam",
                 "homepage",
                 "wiki",
                 "documentState",
aaryan@aaryan:~/Desktop/sw360$
```

## ScreenShot
[Screencast from 2026-03-20 12-43-26.webm](https://github.com/user-attachments/assets/ddd0a0ba-3b79-489e-a5d6-0a1e70136230)
