### PR TITLE
fix(version): Use new VersionInfo class

### DIFF
--- a/src/components/sw360/Footer/Footer.tsx
+++ b/src/components/sw360/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 // Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
 // Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
-// Copyright (C) Siemens AG, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2023,2026. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -13,25 +13,26 @@
 
 import '@/styles/globals.css'
 import 'bootstrap/dist/css/bootstrap.css'
+import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { type JSX, useEffect, useState } from 'react'
+import { VersionInfo } from '@/object-types'
+import { ApiUtils } from '@/utils'
 import { SW360_API_URL } from '@/utils/env'
 
 function Footer(): JSX.Element {
-    const [buildVersion, setBuildVersion] = useState<string>('')
-    const [apiVersion, setApiVersion] = useState<string>('')
+    const [versionInfo, setVersionInfo] = useState<VersionInfo>()
 
     useEffect(() => {
+        const controller = new AbortController()
+        const signal = controller.signal
+
         const fetchVersion = async () => {
             try {
-                const response = await fetch(`${SW360_API_URL}/resource/version`)
-                if (response.ok) {
-                    const data = (await response.json()) as {
-                        sw360BuildVersion?: string
-                        sw360RestVersion?: string
-                    }
-                    setBuildVersion(data.sw360BuildVersion ?? '')
-                    setApiVersion(data.sw360RestVersion ?? '')
+                const response = await ApiUtils.GET('version', '', signal)
+                if (response.status == StatusCodes.OK) {
+                    const data = (await response.json()) as VersionInfo
+                    setVersionInfo(data)
                 }
             } catch {
                 // Silently fail - version display is non-critical
@@ -39,6 +40,7 @@ function Footer(): JSX.Element {
         }
 
         void fetchVersion()
+        return () => controller.abort()
     }, [])
 
     return (
@@ -87,7 +89,15 @@ function Footer(): JSX.Element {
                     </Link>
                 </div>
                 <div className='footerVersion'>
-                    Version: {buildVersion ? buildVersion : '-'} - ApiVersion: {apiVersion ? apiVersion : '-'}
+                    {versionInfo ? (
+                        <>
+                            Version: {versionInfo.sw360Version} | Branch: {versionInfo.gitBranch} (
+                            {versionInfo.buildNumber}) | Build time: {versionInfo.buildTime} | API:{' '}
+                            {versionInfo.apiVersion}
+                        </>
+                    ) : (
+                        'No build information available.'
+                    )}
                 </div>
             </footer>
         </>

--- a/src/object-types/VersionInfo.ts
+++ b/src/object-types/VersionInfo.ts
@@ -1,0 +1,18 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+interface VersionInfo {
+    apiVersion: string
+    buildTime: string
+    buildNumber: string
+    sw360Version: string
+    gitBranch: string
+}
+
+export default VersionInfo

--- a/src/object-types/index.ts
+++ b/src/object-types/index.ts
@@ -27,11 +27,31 @@ import ComponentPayload from './ComponentPayLoad'
 import Configuration from './Configuration'
 import CreateClearingRequestPayload from './CreateClearingRequestPayload'
 import CVEReference from './CVEReference'
+// Enums + Constants
+import AttachmentTypes from './constants/AttachmentTypes'
+import CommonTabIds from './constants/CommonTabsIds'
+import ComponentTabIds from './constants/ComponentTabIds'
+import ConfigurationContainers from './constants/ConfigurationContainers'
+import LicenseTabIds from './constants/LicenseTabIds'
+import ReleaseTabIds from './constants/ReleaseTabIds'
 import ImportSBOMMetadata from './cyclonedx/ImportSBOMMetadata'
 import ImportSummary from './cyclonedx/ImportSummary'
 import ECCInterface from './ECC'
 import ECCInformation from './ECCInformation'
 import Embedded from './Embedded'
+import ActionType from './enums/ActionType'
+import ClearingRequestStates from './enums/ClearingRequestStates'
+import ConfigKeys from './enums/ConfigKeys'
+import DocumentTypes from './enums/DocumentTypes'
+import MergeOrSplitActionType from './enums/MergeOrSplitActionType'
+import ObligationType from './enums/ObligationType'
+import ProjectVulnerabilityTabType from './enums/ProjectVulnerabilityTabType'
+import ReleaseClearingStateMapping from './enums/ReleaseClearingStateMapping'
+import RequestDocumentTypes from './enums/RequestDocumentTypes'
+import RequestType from './enums/RequestType'
+import { ArrayTypeUIConfigKeys, UIConfigKeys } from './enums/UIConfigKeys'
+import UserGroupType from './enums/UserGroupType'
+import VulnerabilitiesVerificationState from './enums/VulnerabilitiesVerificationState'
 import ErrorDetails from './error'
 import FossologyConfig from './FossologyConfig'
 import FossologyProcessInfo from './FossologyProcessInfo'
@@ -102,6 +122,7 @@ import UserCredentialInfo from './UserCredentialInfo'
 import Vendor from './Vendor'
 import VendorAdvisory from './VendorAdvisory'
 import VerificationStateInfo from './VerificationStateInfo'
+import VersionInfo from './VersionInfo'
 import Vulnerability from './Vulnerability'
 import { ProjectVulnerabilityTrackingStatus, VulnerabilityTrackingStatus } from './VulnerabilityTrackingStatus'
 
@@ -214,6 +235,7 @@ export type {
     Vendor,
     VendorAdvisory,
     VerificationStateInfo,
+    VersionInfo,
     Vulnerability,
     VulnerabilityRatingAndActionPayload,
     VulnerabilityTrackingStatus,
@@ -221,27 +243,6 @@ export type {
 
 // Special functions for populate data
 export { NavList, Preferences, parseRawUiConfig }
-
-// Enums + Constants
-import AttachmentTypes from './constants/AttachmentTypes'
-import CommonTabIds from './constants/CommonTabsIds'
-import ComponentTabIds from './constants/ComponentTabIds'
-import ConfigurationContainers from './constants/ConfigurationContainers'
-import LicenseTabIds from './constants/LicenseTabIds'
-import ReleaseTabIds from './constants/ReleaseTabIds'
-import ActionType from './enums/ActionType'
-import ClearingRequestStates from './enums/ClearingRequestStates'
-import ConfigKeys from './enums/ConfigKeys'
-import DocumentTypes from './enums/DocumentTypes'
-import MergeOrSplitActionType from './enums/MergeOrSplitActionType'
-import ObligationType from './enums/ObligationType'
-import ProjectVulnerabilityTabType from './enums/ProjectVulnerabilityTabType'
-import ReleaseClearingStateMapping from './enums/ReleaseClearingStateMapping'
-import RequestDocumentTypes from './enums/RequestDocumentTypes'
-import RequestType from './enums/RequestType'
-import { ArrayTypeUIConfigKeys, UIConfigKeys } from './enums/UIConfigKeys'
-import UserGroupType from './enums/UserGroupType'
-import VulnerabilitiesVerificationState from './enums/VulnerabilitiesVerificationState'
 
 export {
     ActionType,


### PR DESCRIPTION
This PR adds more version information provided by the PR https://github.com/eclipse-sw360/sw360/pull/3979 on `/version` endpoint.

This renders it like the old UI, with API version in addition:
![img](https://github.com/user-attachments/assets/f6b444f2-a7d7-493f-a8dd-51591118fc49)