### PR TITLE
fix(header): Restricting CSP header values

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,10 +15,11 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const csp = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  script-src 'self'${isDev ? " 'unsafe-eval' 'unsafe-inline'" : ''};
   style-src 'self' 'unsafe-inline';
   img-src 'self' data: https:;
   font-src 'self' data:;
+  object-src 'none';
   connect-src 'self' https:${isDev ? ' http://localhost:8080' : ''};
 `
     .replace(/\s{2,}/g, ' ')


### PR DESCRIPTION
Summary
Harden the Content-Security-Policy header in next.config.ts as recommended by CRA security assessment.

Problem
The CSP header was using insecure keywords unsafe-eval and unsafe-inline in the script-src directive unconditionally, and was missing restrictive directives like object-src.

Testing
Start the server
Check headers via curl 
curl -sI http://localhost:3000 | grep -i "content-security-policy"