### PR TITLE
Revert "fix(header): Restricting CSP header values"

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,11 +15,10 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const csp = `
   default-src 'self';
-  script-src 'self'${isDev ? " 'unsafe-eval' 'unsafe-inline'" : ''};
+  script-src 'self' 'unsafe-eval' 'unsafe-inline';
   style-src 'self' 'unsafe-inline';
   img-src 'self' data: https:;
   font-src 'self' data:;
-  object-src 'none';
   connect-src 'self' https:${isDev ? ' http://localhost:8080' : ''};
 `
     .replace(/\s{2,}/g, ' ')


### PR DESCRIPTION
Reverts eclipse-sw360/sw360-frontend#1562

The CSP fails in production mode and the page cannot load script.

![csp](https://github.com/user-attachments/assets/a90f4230-7b3c-45db-920a-c92320c385c2)
