### PR TITLE
fix(components): handle empty response in release overview

### DIFF
--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -223,12 +223,14 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                     })
                 }
 
-                const data = (await response.json()) as EmbeddedLinkedReleases
-                setReleaseData(
-                    CommonUtils.isNullOrUndefined(data['_embedded']['sw360:releaseLinks'])
-                        ? []
-                        : data['_embedded']['sw360:releaseLinks'],
-                )
+                const responseText = await response.text()
+                if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
+                    setReleaseData([])
+                    return
+                }
+
+                const data = JSON.parse(responseText) as EmbeddedLinkedReleases
+                setReleaseData(data['_embedded']?.['sw360:releaseLinks'] ?? [])
             } catch (error) {
                 ApiUtils.reportError(error)
             } finally {


### PR DESCRIPTION
## Summary
Fixes JSON parse error when the backend returns an empty response body in the Release Overview component.

## Problem
When viewing a component with no releases, the API returns an empty response body (HTTP 200 with no content). The previous implementation attempted to call `response.json()` directly, causing a `SyntaxError: Unexpected end of JSON input`.

<img width="1072" height="431" alt="image" src="https://github.com/user-attachments/assets/52b2e71d-3610-4786-ba84-f0517ff725f5" />


## Solution
- Check response text before parsing JSON
- Use optional chaining (`?.`) for safer property access on `_embedded`
- Return empty array when response body is empty

## Changes
- [ReleaseOverview.tsx](src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx#L226-L233)


## Suggested Reviewer
@amritkv  @deo002 

## Testing
1. Navigate to a component detail page with no releases
2. Verify no console errors appear
3. Release overview table shows "No releases found" (or similar empty state)