### PR TITLE
feat(components): add 'All' option to Release Overview page size selector

### DIFF
--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -273,7 +273,10 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
             <div className='mb-3'>
                 {table ? (
                     <>
-                        <ClientSidePageSizeSelector table={table} />
+                        <ClientSidePageSizeSelector
+                            table={table}
+                            showAllOption={true}
+                        />
                         <SW360Table
                             table={table}
                             showProcessing={showProcessing}

--- a/src/components/sw360/Table/Components.tsx
+++ b/src/components/sw360/Table/Components.tsx
@@ -198,9 +198,11 @@ function TableFooterUI({
 export function PageSizeSelector({
     pageableQueryParam,
     setPageableQueryParam,
+    totalElements,
 }: {
     pageableQueryParam: PageableQueryParam
     setPageableQueryParam: Dispatch<SetStateAction<PageableQueryParam>>
+    totalElements?: number
 }): ReactNode {
     const setPageSize = (sz: number) =>
         setPageableQueryParam({
@@ -211,22 +213,51 @@ export function PageSizeSelector({
         <PageSelectorUI
             pageSize={pageableQueryParam.page_entries}
             setPageSize={setPageSize}
+            totalElements={totalElements}
         />
     )
 }
 
-export function ClientSidePageSizeSelector<K>({ table }: { table: Table<K> }): ReactNode {
+export function ClientSidePageSizeSelector<K>({
+    table,
+    showAllOption = false,
+}: {
+    table: Table<K>
+    showAllOption?: boolean
+}): ReactNode {
     const setPageSize = (sz: number) => table.setPageSize(sz)
+    const totalElements = showAllOption ? table.getRowCount() : undefined
     return (
         <PageSelectorUI
             pageSize={table.getState().pagination.pageSize}
             setPageSize={setPageSize}
+            totalElements={totalElements}
         />
     )
 }
 
-function PageSelectorUI({ pageSize, setPageSize }: { pageSize: number; setPageSize: (size: number) => void }) {
+function PageSelectorUI({
+    pageSize,
+    setPageSize,
+    totalElements,
+}: {
+    pageSize: number
+    setPageSize: (size: number) => void
+    totalElements?: number
+}) {
     const t = useTranslations('default')
+    const standardOptions = [
+        10,
+        25,
+        50,
+        100,
+    ]
+    const isAllSelected =
+        totalElements !== undefined &&
+        totalElements > 0 &&
+        !standardOptions.includes(pageSize) &&
+        pageSize >= totalElements
+
     return (
         <div className='table-component mt-3 mb-3'>
             <div className='dataTables_length'>
@@ -234,13 +265,16 @@ function PageSelectorUI({ pageSize, setPageSize }: { pageSize: number; setPageSi
                 <label className='mx-2'>
                     <select
                         className='form-select'
-                        value={pageSize}
+                        value={isAllSelected && totalElements ? totalElements : pageSize}
                         onChange={(e) => setPageSize(Number(e.target.value))}
                     >
                         <option value={10}>10</option>
                         <option value={25}>25</option>
                         <option value={50}>50</option>
                         <option value={100}>100</option>
+                        {totalElements !== undefined && totalElements > 0 && (
+                            <option value={totalElements}>{t('All')}</option>
+                        )}
                     </select>
                 </label>
                 <span>{t('entries')}</span>


### PR DESCRIPTION
## Summary
Add "All" option to the page size selector dropdown in the Components Release Overview tab, allowing users to view all releases in a single page.


## Changes
- Added optional `showAllOption` prop to `ClientSidePageSizeSelector` component (default: `false`)
- Added optional `totalElements` prop to `PageSizeSelector` for server-side pagination support
- Updated `PageSelectorUI` to render "All" option when `totalElements` is provided
- Enabled `showAllOption={true}` in Release Overview tab only

### Files Modified
- `src/components/sw360/Table/Components.tsx`
- `src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx`

## Testing
1. Navigate to Components → Select a component → Release Overview tab
2. Verify dropdown shows: 10 / 25 / 50 / 100 / All ( when count is >0)
3. Select "All" to display all releases in one page
4. Verify other pages using `ClientSidePageSizeSelector` do NOT show "All" option (e.g., Projects detail)

## Screenshots
<img width="1910" height="808" alt="Screenshot 2026-04-13 142018" src="https://github.com/user-attachments/assets/6a03a115-fdbf-456c-9b6a-38d3013471f8" />

## Checklist
- [x] Biome CI passes
- [x] All locales updated (uses existing "All" translation key)
- [x] Tested locally
- [x] Self-reviewed my code

## Reviewers
@amritkv 