### PR TITLE
fix: Show clearer invalid pURL error in package forms

### DIFF
--- a/src/app/[locale]/packages/add/components/CreatePackage.tsx
+++ b/src/app/[locale]/packages/add/components/CreatePackage.tsx
@@ -20,6 +20,7 @@ import { Package, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
 import CreateOrEditPackage from '../../components/CreateOrEditPackage'
+import { getPackageSubmitErrorMessage } from '../../components/packageSubmitError'
 
 function CreatePackage(): ReactNode {
     const t = useTranslations('default')
@@ -52,17 +53,17 @@ function CreatePackage(): ReactNode {
             setCreatingPackage(true)
             const session = await getSession()
             if (CommonUtils.isNullOrUndefined(session)) return signOut()
+            const { packageManager: _packageManager, ...packageRequestPayload } = packagePayload
             const response = await ApiUtils.POST(
                 'packages',
                 {
-                    ...packagePayload,
+                    ...packageRequestPayload,
                     createdBy: session.user.email,
-                    packageManager: packagePayload.purl?.substring(4, packagePayload.purl.indexOf('/')).toUpperCase(),
                 },
                 session.user.access_token,
             )
-            const res = (await response.json()) as Record<string, string>
             if (response.status == StatusCodes.CREATED) {
+                const res = (await response.json()) as Record<string, string>
                 MessageService.success(t('Package created successfully'))
                 if (res.id) {
                     router.push(`/packages/detail/${res.id}`)
@@ -72,7 +73,12 @@ function CreatePackage(): ReactNode {
             } else if (response.status === StatusCodes.UNAUTHORIZED) {
                 await signOut()
             } else {
-                MessageService.error(`${t('Something went wrong')}: ${res.message}`)
+                const errorMessage = await getPackageSubmitErrorMessage(
+                    response,
+                    packageRequestPayload.purl,
+                    t('Something went wrong'),
+                )
+                MessageService.error(`${t('Something went wrong')}: ${errorMessage}`)
             }
         } catch (e) {
             console.error(e)

--- a/src/app/[locale]/packages/components/packageSubmitError.ts
+++ b/src/app/[locale]/packages/components/packageSubmitError.ts
@@ -1,0 +1,64 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+const DEPENDENT_DOCUMENT_ERROR = 'Dependent document Id/ids not valid.'
+const INVALID_PURL_MESSAGE = 'Invalid pURL'
+
+export async function getPackageSubmitErrorMessage(
+    response: Response,
+    submittedPurl: string | undefined,
+    fallbackMessage: string,
+): Promise<string> {
+    const message = extractErrorMessage(await response.text()) ?? fallbackMessage
+
+    if (isPurlErrorMessage(message) && isClearlyInvalidPurl(submittedPurl)) {
+        return INVALID_PURL_MESSAGE
+    }
+
+    return message
+}
+
+function extractErrorMessage(responseText: string): string | undefined {
+    const text = responseText.trim()
+
+    if (!text) {
+        return undefined
+    }
+
+    try {
+        const body = JSON.parse(text) as {
+            message?: string
+        }
+
+        if (typeof body.message === 'string' && body.message.trim()) {
+            return body.message.trim()
+        }
+    } catch {
+        // Fall through to XML/plain-text parsing.
+    }
+
+    const xmlMessage = text.match(/<message>([\s\S]*?)<\/message>/i)?.[1]?.trim()
+    if (xmlMessage) {
+        return xmlMessage
+    }
+
+    return text
+}
+
+function isPurlErrorMessage(message: string): boolean {
+    return (
+        message === DEPENDENT_DOCUMENT_ERROR ||
+        /invalid purl|invalid purl or linked release id|invalid package input/i.test(message) ||
+        /Cannot deserialize value of type .*PackageManager/i.test(message)
+    )
+}
+
+function isClearlyInvalidPurl(purl: string | undefined): boolean {
+    return !/^pkg:[A-Za-z0-9.+-]+\/.+/.test(purl?.trim() ?? '')
+}

--- a/src/app/[locale]/packages/edit/[id]/components/EditPackage.tsx
+++ b/src/app/[locale]/packages/edit/[id]/components/EditPackage.tsx
@@ -20,6 +20,7 @@ import { Package, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
 import { ApiUtils, CommonUtils } from '@/utils'
 import CreateOrEditPackage from '../../../components/CreateOrEditPackage'
+import { getPackageSubmitErrorMessage } from '../../../components/packageSubmitError'
 
 function EditPackage({ packageId }: { packageId: string }): ReactNode {
     const t = useTranslations('default')
@@ -58,12 +59,10 @@ function EditPackage({ packageId }: { packageId: string }): ReactNode {
             setUpdatingPackage(true)
             const session = await getSession()
             if (CommonUtils.isNullOrUndefined(session)) return signOut()
+            const { packageManager: _packageManager, ...packageRequestPayload } = packagePayload ?? {}
             const response = await ApiUtils.PATCH(
                 `packages/${packageId}`,
-                {
-                    ...packagePayload,
-                    packageManager: packagePayload?.purl?.substring(4, packagePayload.purl.indexOf('/')).toUpperCase(),
-                },
+                packageRequestPayload,
                 session.user.access_token,
             )
             if (response.status == StatusCodes.OK) {
@@ -72,8 +71,12 @@ function EditPackage({ packageId }: { packageId: string }): ReactNode {
             } else if (response.status === StatusCodes.UNAUTHORIZED) {
                 await signOut()
             } else {
-                const res = (await response.json()) as Record<string, string>
-                MessageService.error(`${t('Something went wrong')}: ${res.message}`)
+                const errorMessage = await getPackageSubmitErrorMessage(
+                    response,
+                    packageRequestPayload.purl,
+                    t('Something went wrong'),
+                )
+                MessageService.error(`${t('Something went wrong')}: ${errorMessage}`)
             }
         } finally {
             setUpdatingPackage(false)


### PR DESCRIPTION
Closes eclipse-sw360/sw360#4066
Improves package add/edit error handling in the frontend by avoiding invalid packageManager submission and showing a clearer Invalid pURL message for malformed pURLs.
