### PR TITLE
fix(components): handle empty response in edit component page

### DIFF
--- a/src/app/[locale]/components/edit/[id]/components/EditComponent.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/EditComponent.tsx
@@ -124,10 +124,15 @@ const EditComponent = ({ componentId }: Props): ReactNode => {
                 } else if (response.status !== StatusCodes.OK) {
                     return notFound()
                 }
-                const dataAttachments: EmbeddedAttachments = (await response.json()) as EmbeddedAttachments
-                if (!CommonUtils.isNullOrUndefined(dataAttachments)) {
-                    setAttachmentData(dataAttachments._embedded['sw360:attachments'])
+
+                const responseText = await response.text()
+                if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
+                    setAttachmentData([])
+                    return
                 }
+
+                const dataAttachments = JSON.parse(responseText) as EmbeddedAttachments
+                setAttachmentData(dataAttachments._embedded?.['sw360:attachments'] ?? [])
             } catch (error) {
                 ApiUtils.reportError(error)
             }

--- a/src/app/[locale]/components/edit/[id]/components/Releases.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/Releases.tsx
@@ -112,12 +112,14 @@ const Releases = ({ componentId }: Props): ReactNode => {
                     })
                 }
 
-                const data = (await response.json()) as EmbeddedLinkedReleases
-                setReleaseData(
-                    CommonUtils.isNullOrUndefined(data['_embedded']['sw360:releaseLinks'])
-                        ? []
-                        : data['_embedded']['sw360:releaseLinks'],
-                )
+                const responseText = await response.text()
+                if (CommonUtils.isNullEmptyOrUndefinedString(responseText)) {
+                    setReleaseData([])
+                    return
+                }
+
+                const data = JSON.parse(responseText) as EmbeddedLinkedReleases
+                setReleaseData(data['_embedded']?.['sw360:releaseLinks'] ?? [])
             } catch (error) {
                 ApiUtils.reportError(error)
             } finally {


### PR DESCRIPTION
## Summary

Fixes JSON parse error when the backend returns an empty response body in the Edit Component page for releases and attachments.

Related to: #1613

## Problem

When editing a component with no releases or attachments, the API returns an empty response body (HTTP 200 with no content). The previous implementation attempted to call `response.json()` directly, causing a `SyntaxError: Unexpected end of JSON input`.

This is the same issue that was fixed in PR #1613 for the component detail page, but the Edit Component page (`EditComponent.tsx` and `Releases.tsx`) was not addressed.

## Solution

- Check response text before parsing JSON
- Use optional chaining (`?.`) for safer property access on `_embedded`
- Return empty array when response body is empty

## Changes

- `src/app/[locale]/components/edit/[id]/components/Releases.tsx`
- `src/app/[locale]/components/edit/[id]/components/EditComponent.tsx`

## Suggested Reviewer

@amritkv @deo002

## Testing

1. Navigate to Edit Component page for a component with no releases
2. Verify no console errors appear
3. Releases table shows empty state correctly

Local Test screenshots:
<img width="1908" height="632" alt="image" src="https://github.com/user-attachments/assets/fdfe2d49-7567-4eaa-8734-2bfab87bc61b" />

<img width="1899" height="623" alt="image" src="https://github.com/user-attachments/assets/f74a831d-0314-433b-91e0-4f1dad580765" />

