### PR TITLE
fix(docker): Tighten CSP against XSS

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -201,9 +201,8 @@ The proxy configuration at
 | `/authorization` | `sw360:8080` | SW360 OAuth2 endpoints |
 | `/kc` | `keycloak:8533` | Keycloak admin and auth |
 
-The template also configures security headers (HSTS, CSP, X-Frame-Options) and
-uses a self-signed snakeoil certificate for TLS. For production, replace the
-certificate paths with your own.
+The template also a self-signed snakeoil certificate for TLS. For production,
+replace the certificate paths with your own.
 
 The server domain is set via `SERVER_DOMAIN` in
 [config/nginx/.env.web](config/nginx/.env.web).

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,11 +15,12 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const csp = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
+  script-src 'self' 'unsafe-inline';
   style-src 'self' 'unsafe-inline';
-  img-src 'self' data: https:;
+  img-src 'self' data: https://secure.gravatar.com https://www.gravatar.com;
   font-src 'self' data:;
-  connect-src 'self' https:${isDev ? ' http://localhost:8080' : ''};
+  connect-src 'self' https://www.gravatar.com${isDev ? ' http://localhost:*' : ''};
+  frame-ancestors 'self';
 `
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

> Please provide a summary of your changes here.

This PR patches CSP vulnerabilities.
1. Updates `next.config.ts` to omit `unsafe-eval` scripts.
2. Hardens external image sources to valid Gravatar endpoints only instead of wide wildcard values.
3. Maps wildcard local development `connect-src` variables intelligently.
4. Documents how to interface frontend reverse-proxies securely with the backend `SW360_CORS_ALLOWED_ORIGIN` variable inside `.env.backend`.

> * Did you add or update any new dependencies that are required for your change?
> No

### Suggest Reviewer
@amritkv @deo002 