### PR TITLE
fix(scp): Tighten CSP against object-src

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,9 @@ const csp = `
   img-src 'self' data: https://secure.gravatar.com https://www.gravatar.com;
   font-src 'self' data:;
   connect-src 'self' https://www.gravatar.com${isDev ? ' http://localhost:*' : ''};
+  object-src 'none';
   frame-ancestors 'self';
+  require-trusted-types-for 'script';
 `
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
Add more strict `object-src 'none';` for old browsers.