### PR TITLE
refactor(releases): Refactor linked releases table to TanStack

### DIFF
--- a/src/components/LinkedReleases/LinkedReleases.tsx
+++ b/src/components/LinkedReleases/LinkedReleases.tsx
@@ -14,11 +14,11 @@
 import { signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useCallback, useEffect, useState } from 'react'
+import { Spinner } from 'react-bootstrap'
 import { ActionType, Release, ReleaseDetail, ReleaseLink } from '@/object-types'
 import { CommonUtils } from '@/utils'
 import SearchReleasesModal from '../sw360/SearchReleasesModal'
 import TableLinkedReleases from './TableLinkedReleases/TableLinkedReleases'
-import TitleLinkedReleases from './TitleLinkedReleases/TitleLinkedReleases'
 
 interface Props {
     release?: ReleaseDetail
@@ -29,13 +29,8 @@ interface Props {
 
 const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload }: Props): JSX.Element => {
     const t = useTranslations('default')
-    const [reRender, setReRender] = useState(false)
     const [releaseLinks, setReleaseLinks] = useState<ReleaseLink[]>([])
-    const handleReRender = () => {
-        setReRender(!reRender)
-    }
     const [linkedReleasesDiaglog, setLinkedReleasesDiaglog] = useState(false)
-    const handleClickSelectLinkedReleases = useCallback(() => setLinkedReleasesDiaglog(true), [])
     const { status } = useSession()
 
     useEffect(() => {
@@ -46,13 +41,19 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
         status,
     ])
 
-    const setReleaseIdToRelationshipsToReleasePayLoad = (releaseIdToRelationships: Map<string, string>) => {
-        const obj = Object.fromEntries(releaseIdToRelationships)
-        setReleasePayload({
-            ...releasePayload,
-            releaseIdToRelationship: obj,
-        })
-    }
+    const setReleaseIdToRelationshipsToReleasePayLoad = useCallback(
+        (releaseIdToRelationships: Map<string, string>) => {
+            const obj = Object.fromEntries(releaseIdToRelationships)
+            setReleasePayload({
+                ...releasePayload,
+                releaseIdToRelationship: obj,
+            })
+        },
+        [
+            releasePayload,
+            setReleasePayload,
+        ],
+    )
 
     const handleSelectReleases = useCallback(
         (selectedReleases: ReleaseDetail[]) => {
@@ -81,7 +82,6 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
                 ...releasePayload,
                 releaseIdToRelationship: obj,
             })
-            handleReRender()
         },
         [
             releaseLinks,
@@ -110,34 +110,37 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
 
     return (
         <>
-            <div
-                className='col'
-                style={{
-                    fontSize: '0.875rem',
-                }}
-            >
-                <SearchReleasesModal
-                    show={linkedReleasesDiaglog}
-                    setShow={setLinkedReleasesDiaglog}
-                    onSelect={handleSelectReleases}
-                    showExactMatch={false}
-                />
-                <div className='row ps-4 pb-4'>
-                    <TitleLinkedReleases />
-                    <TableLinkedReleases
-                        releaseLinks={releaseLinks}
-                        setReleaseLinks={setReleaseLinks}
-                        setReleaseIdToRelationshipsToReleasePayLoad={setReleaseIdToRelationshipsToReleasePayLoad}
-                    />
+            <SearchReleasesModal
+                show={linkedReleasesDiaglog}
+                setShow={setLinkedReleasesDiaglog}
+                onSelect={handleSelectReleases}
+                showExactMatch={false}
+            />
+            <div className='row mb-4'>
+                <h6 className='header-underlined mb-2'>{t('LINKED RELEASES')}</h6>
+                <div className='mb-3'>
+                    {releaseLinks ? (
+                        <TableLinkedReleases
+                            releaseLinks={releaseLinks}
+                            setReleaseLinks={setReleaseLinks}
+                            setReleaseIdToRelationshipsToReleasePayLoad={setReleaseIdToRelationshipsToReleasePayLoad}
+                        />
+                    ) : (
+                        <div className='col-12 mt-1 text-center'>
+                            <Spinner className='spinner' />
+                        </div>
+                    )}
                 </div>
-                <div>
-                    <button
-                        type='button'
-                        className={`fw-bold btn btn-secondary ms-2`}
-                        onClick={handleClickSelectLinkedReleases}
-                    >
-                        {t('Click to add Releases')}
-                    </button>
+                <div className='row p-0'>
+                    <div className='col-lg-4'>
+                        <button
+                            type='button'
+                            className='btn btn-secondary'
+                            onClick={() => setLinkedReleasesDiaglog(true)}
+                        >
+                            {t('Click to add Releases')}
+                        </button>
+                    </div>
                 </div>
             </div>
         </>

--- a/src/components/LinkedReleases/TableLinkedReleases/TableLinkedReleases.tsx
+++ b/src/components/LinkedReleases/TableLinkedReleases/TableLinkedReleases.tsx
@@ -1,5 +1,6 @@
 // Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
 // Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2025. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -8,9 +9,13 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { useTranslations } from 'next-intl'
-import React, { type JSX } from 'react'
-import { BsFillTrashFill } from 'react-icons/bs'
+import { type JSX, useCallback, useMemo } from 'react'
+import { FaTrashAlt } from 'react-icons/fa'
+import { SW360Table } from '@/components/sw360'
 import { ReleaseLink } from '@/object-types'
 
 interface Props {
@@ -25,104 +30,155 @@ export default function TableLinkedReleases({
     setReleaseIdToRelationshipsToReleasePayLoad,
 }: Props): JSX.Element {
     const t = useTranslations('default')
-    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>, index: number) => {
-        const { name, value } = e.target
-        const list = [
-            ...releaseLinks,
-        ]
-        list[index][name as keyof ReleaseLink] = value as never
-        const map = new Map<string, string>()
-        list.forEach((item) => {
-            map.set(item.id, item.releaseRelationship)
-        })
-        setReleaseLinks(list)
-        setReleaseIdToRelationshipsToReleasePayLoad(map)
-    }
 
-    const handleClickDelete = (index: number) => {
-        const list: ReleaseLink[] = [
-            ...releaseLinks,
-        ]
-        list.splice(index, 1)
-        const map = new Map<string, string>()
-        list.forEach((item) => {
-            map.set(item.id, item.releaseRelationship)
-        })
-        setReleaseLinks(list)
-        setReleaseIdToRelationshipsToReleasePayLoad(map)
-    }
+    const updateReleaseRelationship = useCallback(
+        (releaseId: string, updatedReleaseRelationship: string) => {
+            const updated = releaseLinks.map((item) =>
+                item.id === releaseId
+                    ? {
+                          ...item,
+                          releaseRelationship: updatedReleaseRelationship,
+                      }
+                    : item,
+            )
+            setReleaseLinks(updated)
+
+            const map = new Map<string, string>()
+            updated.forEach((item) => {
+                map.set(item.id, item.releaseRelationship)
+            })
+            setReleaseIdToRelationshipsToReleasePayLoad(map)
+        },
+        [
+            releaseLinks,
+            setReleaseLinks,
+            setReleaseIdToRelationshipsToReleasePayLoad,
+        ],
+    )
+
+    const handleClickDelete = useCallback(
+        (releaseId: string) => {
+            const updated = releaseLinks.filter((item) => item.id !== releaseId)
+            setReleaseLinks(updated)
+
+            const map = new Map<string, string>()
+            updated.forEach((item) => {
+                map.set(item.id, item.releaseRelationship)
+            })
+            setReleaseIdToRelationshipsToReleasePayLoad(map)
+        },
+        [
+            releaseLinks,
+            setReleaseLinks,
+            setReleaseIdToRelationshipsToReleasePayLoad,
+        ],
+    )
+
+    const columns = useMemo<ColumnDef<ReleaseLink>[]>(
+        () => [
+            {
+                id: 'vendor',
+                header: t('Vendor'),
+                cell: ({ row }) => <>{row.original.vendor}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'name',
+                header: t('Name'),
+                cell: ({ row }) => <>{row.original.name}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'version',
+                header: t('Version'),
+                cell: ({ row }) => <>{row.original.version}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'releaseRelationship',
+                header: t('Release Relation'),
+                cell: ({ row }) => (
+                    <div className='form-dropdown'>
+                        <select
+                            className='form-select'
+                            value={row.original.releaseRelationship}
+                            onChange={(event) => {
+                                updateReleaseRelationship(row.original.id, event.target.value)
+                            }}
+                            required
+                        >
+                            <option value='CONTAINED'>{t('CONTAINED')}</option>
+                            <option value='REFERRED'>{t('REFERRED')}</option>
+                            <option value='UNKNOWN'>{t('UNKNOWN')}</option>
+                            <option value='DYNAMICALLY_LINKED'>{t('DYNAMICALLY_LINKED')}</option>
+                            <option value='STATICALLY_LINKED'>{t('STATICALLY_LINKED')}</option>
+                            <option value='SIDE_BY_SIDE'>{t('SIDE_BY_SIDE')}</option>
+                            <option value='STANDALONE'>{t('STANDALONE')}</option>
+                            <option value='INTERNAL_USE'>{t('INTERNAL_USE')}</option>
+                            <option value='OPTIONAL'>{t('OPTIONAL')}</option>
+                            <option value='TO_BE_REPLACED'>{t('TO_BE_REPLACED')}</option>
+                            <option value='CODE_SNIPPET'>{t('CODE_SNIPPET')}</option>
+                        </select>
+                    </div>
+                ),
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'actions',
+                header: t('Actions'),
+                cell: ({ row }) => (
+                    <button
+                        type='button'
+                        className='btn btn-secondary p-0 border-0 d-inline-flex align-items-center justify-content-center'
+                        onClick={() => handleClickDelete(row.original.id)}
+                        title={t('Delete')}
+                        aria-label={t('Delete linked release')}
+                    >
+                        <FaTrashAlt />
+                    </button>
+                ),
+                meta: {
+                    width: '8%',
+                },
+            },
+        ],
+        [
+            t,
+            updateReleaseRelationship,
+            handleClickDelete,
+        ],
+    )
+
+    const memoizedData = useMemo(
+        () => releaseLinks,
+        [
+            releaseLinks,
+        ],
+    )
+
+    const table = useReactTable({
+        data: memoizedData,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+    })
+
+    // Always render the table. Let SW360Table show an empty state when there are
+    // no releases so users see the table structure instead of nothing.
 
     return (
         <>
-            <div className='row'>
-                {releaseLinks.map((item: ReleaseLink, index: number) => {
-                    return (
-                        <div
-                            key={index}
-                            className='my-1'
-                        >
-                            <div className='d-flex justify-content-between pt-2 px-1 pb-1'>
-                                <input
-                                    className='form-control me-2'
-                                    name='vendor'
-                                    value={item.vendor}
-                                    type='text'
-                                    placeholder='Enter Vendor'
-                                    readOnly
-                                />
-                                <input
-                                    className='form-control mx-2'
-                                    type='text'
-                                    value={item.name}
-                                    name='name'
-                                    readOnly
-                                />
-                                <input
-                                    className='form-control mx-2'
-                                    type='text'
-                                    value={item.version}
-                                    name='version'
-                                    readOnly
-                                />
-                                <select
-                                    className='form-select mx-2'
-                                    aria-label='releaseRelationship'
-                                    id='releaseRelationship'
-                                    name='releaseRelationship'
-                                    value={item.releaseRelationship}
-                                    onChange={(e) => handleInputChange(e, index)}
-                                >
-                                    <option value='CONTAINED'>{t('CONTAINED')}</option>
-                                    <option value='REFERRED'> {t('REFERRED')}</option>
-                                    <option value='UNKNOWN'>{t('UNKNOWN')}</option>
-                                    <option value='DYNAMICALLY_LINKED'>{t('DYNAMICALLY_LINKED')}</option>
-                                    <option value='STATICALLY_LINKED'> {t('STATICALLY_LINKED')}</option>
-                                    <option value='SIDE_BY_SIDE'>{t('SIDE_BY_SIDE')}</option>
-                                    <option value='STANDALONE'>{t('STANDALONE')}</option>
-                                    <option value='INTERNAL_USE'> {t('INTERNAL_USE')}</option>
-                                    <option value='OPTIONAL'>{t('OPTIONAL')}</option>
-                                    <option value='TO_BE_REPLACED'>{t('TO_BE_REPLACED')}</option>
-                                    <option value='CODE_SNIPPET'> {t('CODE_SNIPPET')}</option>
-                                </select>
-                                <button
-                                    type='button'
-                                    onClick={() => handleClickDelete(index)}
-                                    style={{
-                                        border: 'none',
-                                    }}
-                                    className={`fw-bold btn btn-secondary`}
-                                >
-                                    <BsFillTrashFill
-                                        className='bi bi-trash3-fill'
-                                        size={20}
-                                    />
-                                </button>
-                            </div>
-                            <hr className='my-2' />
-                        </div>
-                    )
-                })}
-            </div>
+            <SW360Table
+                table={table}
+                showProcessing={false}
+            />
         </>
     )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1292,6 +1292,10 @@ svg.action:hover {
     color: white !important;
 }
 
+.linked-releases-table-compact-col {
+    width: 5%;
+}
+
 .import-department-success {
     background-color: #edf9f0 !important;
     border: 1px solid #5aca75 !important;


### PR DESCRIPTION
## Description

Refactor the Edit Linked Releases table component to use TanStack tables, 
completing the code unification effort from issue #1505.

## Changes

### Files Modified
- `src/components/LinkedReleases/TableLinkedReleases/TableLinkedReleases.tsx`
- `src/components/LinkedReleases/LinkedReleases.tsx`

### Key Changes

**TableLinkedReleases.tsx:**
- Migrated from custom div-based HTML layout to TanStack table
- Implemented `ColumnDef` columns for Vendor, Name, Version, Release Relationship, and Actions
- Added inline editing capability for release relationship dropdown
- Replaced `BsFillTrashFill` icon with `FaTrashAlt` for consistency
- Improved state management with proper callback memoization
- Integrated `SW360Table` component for standardized rendering

**LinkedReleases.tsx:**
- Removed unused `TitleLinkedReleases` component
- Restructured component layout to match the edit projects linked releases pattern
- Added section header "LINKED RELEASES" with consistent styling
- Improved callback functions with proper dependency arrays
- Added loading spinner state with React Bootstrap
- Cleaned up unnecessary state management (removed `reRender`)
