### PR TITLE
fix(headers): Add dev mode headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,14 +15,14 @@ const isDev = process.env.NODE_ENV === 'development'
 
 const csp = `
   default-src 'self';
-  script-src 'self' 'unsafe-inline';
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
   style-src 'self' 'unsafe-inline';
   img-src 'self' data: https://secure.gravatar.com https://www.gravatar.com;
   font-src 'self' data:;
   connect-src 'self' https://www.gravatar.com${isDev ? ' http://localhost:*' : ''};
   object-src 'none';
   frame-ancestors 'self';
-  require-trusted-types-for 'script';
+  ${isDev ? '' : "require-trusted-types-for 'script'"};
 `
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
Add `unsafe-eval` and remove `require-trusted-types-for 'script'` for dev mode which are used by react. They are not used in development, thus using the `isDev` flag.

## How to test
1. Run the server in dev mode: `pnpm dev`
2. Run the server in prod mode: `pnpm build && pnpm start`

Check the browser console and node terminal logs for errors.