### PR TITLE
refactor(releases): Convert linked releases table to TanStack

### DIFF
--- a/src/components/LinkedReleases/LinkedReleases.tsx
+++ b/src/components/LinkedReleases/LinkedReleases.tsx
@@ -11,20 +11,21 @@
 
 'use client'
 
+import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { signOut, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
-import { type JSX, useCallback, useEffect, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { type Dispatch, type JSX, type SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
+import { FaTrashAlt } from 'react-icons/fa'
+import { SW360Table } from '@/components/sw360'
 import { ActionType, Release, ReleaseDetail, ReleaseLink } from '@/object-types'
 import { CommonUtils } from '@/utils'
 import SearchReleasesModal from '../sw360/SearchReleasesModal'
-import TableLinkedReleases from './TableLinkedReleases/TableLinkedReleases'
 
 interface Props {
     release?: ReleaseDetail
     actionType?: string
     releasePayload: Release
-    setReleasePayload: React.Dispatch<React.SetStateAction<Release>>
+    setReleasePayload: Dispatch<SetStateAction<Release>>
 }
 
 const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload }: Props): JSX.Element => {
@@ -55,6 +56,51 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
         ],
     )
 
+    const updateReleaseRelationship = useCallback(
+        (releaseId: string, updatedReleaseRelationship: string) => {
+            setReleaseLinks((currentReleaseLinks) => {
+                const updatedReleaseLinks = currentReleaseLinks.map((item) =>
+                    item.id === releaseId
+                        ? {
+                              ...item,
+                              releaseRelationship: updatedReleaseRelationship,
+                          }
+                        : item,
+                )
+
+                const mapReleaseRelationship = new Map<string, string>()
+                updatedReleaseLinks.forEach((item) => {
+                    mapReleaseRelationship.set(item.id, item.releaseRelationship)
+                })
+                setReleaseIdToRelationshipsToReleasePayLoad(mapReleaseRelationship)
+
+                return updatedReleaseLinks
+            })
+        },
+        [
+            setReleaseIdToRelationshipsToReleasePayLoad,
+        ],
+    )
+
+    const handleClickDelete = useCallback(
+        (releaseId: string) => {
+            setReleaseLinks((currentReleaseLinks) => {
+                const updatedReleaseLinks = currentReleaseLinks.filter((item) => item.id !== releaseId)
+
+                const mapReleaseRelationship = new Map<string, string>()
+                updatedReleaseLinks.forEach((item) => {
+                    mapReleaseRelationship.set(item.id, item.releaseRelationship)
+                })
+                setReleaseIdToRelationshipsToReleasePayLoad(mapReleaseRelationship)
+
+                return updatedReleaseLinks
+            })
+        },
+        [
+            setReleaseIdToRelationshipsToReleasePayLoad,
+        ],
+    )
+
     const handleSelectReleases = useCallback(
         (selectedReleases: ReleaseDetail[]) => {
             const newReleaseLinks: ReleaseLink[] = selectedReleases.map((release: ReleaseDetail) => ({
@@ -67,26 +113,23 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
                 releaseRelationship: 'CONTAINED',
             }))
 
-            const updatedReleaseLinks = [
-                ...releaseLinks,
-                ...newReleaseLinks,
-            ]
-            setReleaseLinks(updatedReleaseLinks)
+            setReleaseLinks((currentReleaseLinks) => {
+                const updatedReleaseLinks = [
+                    ...currentReleaseLinks,
+                    ...newReleaseLinks,
+                ]
 
-            const mapReleaseRelationship = new Map<string, string>()
-            updatedReleaseLinks.forEach((item) => {
-                mapReleaseRelationship.set(item.id, item.releaseRelationship)
-            })
-            const obj = Object.fromEntries(mapReleaseRelationship)
-            setReleasePayload({
-                ...releasePayload,
-                releaseIdToRelationship: obj,
+                const mapReleaseRelationship = new Map<string, string>()
+                updatedReleaseLinks.forEach((item) => {
+                    mapReleaseRelationship.set(item.id, item.releaseRelationship)
+                })
+                setReleaseIdToRelationshipsToReleasePayLoad(mapReleaseRelationship)
+
+                return updatedReleaseLinks
             })
         },
         [
-            releaseLinks,
-            releasePayload,
-            setReleasePayload,
+            setReleaseIdToRelationshipsToReleasePayLoad,
         ],
     )
 
@@ -96,17 +139,109 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
                 !CommonUtils.isNullOrUndefined(release['_embedded']) &&
                 !CommonUtils.isNullOrUndefined(release['_embedded']['sw360:releaseLinks'])
             ) {
-                const linkedReleases: ReleaseLink[] = []
-                release['_embedded']['sw360:releaseLinks'].map((item: ReleaseLink) => [
-                    linkedReleases.push(item),
-                ])
-                setReleaseLinks(linkedReleases)
+                setReleaseLinks(release['_embedded']['sw360:releaseLinks'])
             }
         }
     }, [
         actionType,
         release,
     ])
+
+    const columns = useMemo<ColumnDef<ReleaseLink>[]>(
+        () => [
+            {
+                id: 'vendor',
+                header: t('Vendor'),
+                cell: ({ row }) => <>{row.original.vendor}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'name',
+                header: t('Name'),
+                cell: ({ row }) => <>{row.original.name}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'version',
+                header: t('Version'),
+                cell: ({ row }) => <>{row.original.version}</>,
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'releaseRelationship',
+                header: t('Release Relation'),
+                cell: ({ row }) => (
+                    <div className='form-dropdown'>
+                        <select
+                            className='form-select'
+                            value={row.original.releaseRelationship}
+                            onChange={(event) => {
+                                updateReleaseRelationship(row.original.id, event.target.value)
+                            }}
+                            required
+                        >
+                            <option value='CONTAINED'>{t('CONTAINED')}</option>
+                            <option value='REFERRED'>{t('REFERRED')}</option>
+                            <option value='UNKNOWN'>{t('UNKNOWN')}</option>
+                            <option value='DYNAMICALLY_LINKED'>{t('DYNAMICALLY_LINKED')}</option>
+                            <option value='STATICALLY_LINKED'>{t('STATICALLY_LINKED')}</option>
+                            <option value='SIDE_BY_SIDE'>{t('SIDE_BY_SIDE')}</option>
+                            <option value='STANDALONE'>{t('STANDALONE')}</option>
+                            <option value='INTERNAL_USE'>{t('INTERNAL_USE')}</option>
+                            <option value='OPTIONAL'>{t('OPTIONAL')}</option>
+                            <option value='TO_BE_REPLACED'>{t('TO_BE_REPLACED')}</option>
+                            <option value='CODE_SNIPPET'>{t('CODE_SNIPPET')}</option>
+                        </select>
+                    </div>
+                ),
+                meta: {
+                    width: '23%',
+                },
+            },
+            {
+                id: 'actions',
+                header: t('Actions'),
+                cell: ({ row }) => (
+                    <button
+                        type='button'
+                        className='btn btn-secondary p-0 border-0 d-inline-flex align-items-center justify-content-center'
+                        onClick={() => handleClickDelete(row.original.id)}
+                        title={t('Delete')}
+                        aria-label={t('Delete linked release')}
+                    >
+                        <FaTrashAlt />
+                    </button>
+                ),
+                meta: {
+                    width: '8%',
+                },
+            },
+        ],
+        [
+            t,
+            handleClickDelete,
+            updateReleaseRelationship,
+        ],
+    )
+
+    const memoizedData = useMemo(
+        () => releaseLinks,
+        [
+            releaseLinks,
+        ],
+    )
+
+    const table = useReactTable({
+        data: memoizedData,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+    })
 
     return (
         <>
@@ -119,15 +254,17 @@ const LinkedReleases = ({ release, actionType, releasePayload, setReleasePayload
             <div className='row mb-4'>
                 <h6 className='header-underlined mb-2'>{t('LINKED RELEASES')}</h6>
                 <div className='mb-3'>
-                    {releaseLinks ? (
-                        <TableLinkedReleases
-                            releaseLinks={releaseLinks}
-                            setReleaseLinks={setReleaseLinks}
-                            setReleaseIdToRelationshipsToReleasePayLoad={setReleaseIdToRelationshipsToReleasePayLoad}
+                    {table ? (
+                        <SW360Table
+                            table={table}
+                            showProcessing={false}
                         />
                     ) : (
                         <div className='col-12 mt-1 text-center'>
-                            <Spinner className='spinner' />
+                            <div
+                                className='spinner-border spinner'
+                                role='status'
+                            />
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
Closes #1505 

### Summary
This refactors the Linked Releases edit view to use the shared TanStack table pattern instead of the old HTML table implementation. The table now renders through [SW360Table], with columns for vendor, name, version, release relation, and delete action, while preserving the existing release relationship payload updates.