### PR TITLE
fix(admin): Fix conditional hook call in ScheduleList causing hook order violation

### DIFF
--- a/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
+++ b/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
@@ -25,6 +25,7 @@ export default function VendorsList(): JSX.Element {
     const t = useTranslations('default')
     const router = useRouter()
     const { status } = useSession()
+    const svmConfigValue = useConfigValue(UIConfigKeys.UI_ENABLE_SECURITY_VULNERABILITY_MONITORING)
 
     useEffect(() => {
         if (status === 'unauthenticated') {
@@ -90,10 +91,7 @@ export default function VendorsList(): JSX.Element {
         }
     }
 
-    const isSvmEnabled =
-        useConfigValue(UIConfigKeys.UI_ENABLE_SECURITY_VULNERABILITY_MONITORING) === null
-            ? true
-            : (useConfigValue(UIConfigKeys.UI_ENABLE_SECURITY_VULNERABILITY_MONITORING) as boolean)
+    const isSvmEnabled = svmConfigValue === null ? true : (svmConfigValue as boolean)
 
     return (
         <>


### PR DESCRIPTION
## Summary
Fixes a React hook order violation in the `VendorsList` component within the Admin Schedule page.

## Problem
React detected a change in the order of hooks called by `VendorsList` on the Admin > Schedule page. The `useUiConfigContext` hook was being called conditionally, causing the hook count to differ between renders (9 hooks on next render vs 8 on previous).

## Root Cause
`useConfigValue` (which internally calls `useContext`) was being invoked conditionally inside `ScheduleList.tsx`, violating React's Rules of Hooks.

## Fix
Moved the hook call to the top level of the component to ensure consistent hook order across all renders.

## Testing
- Navigated to Admin > Schedule page
- Verified no hook order warnings in console
- Verified schedule list renders correctly
- 
Closes #1663
<img width="881" height="470" alt="Screenshot 2026-05-02 at 6 02 52 PM" src="https://github.com/user-attachments/assets/76c8dde2-737b-45ea-84b1-a532221ef42a" />
