### PR TITLE
fix(csp): Remove require-trusted-types-for

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,7 +22,6 @@ const csp = `
   connect-src 'self' https://www.gravatar.com${isDev ? ' http://localhost:*' : ''};
   object-src 'none';
   frame-ancestors 'self';
-  ${isDev ? '' : "require-trusted-types-for 'script'"};
 `
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
Apparently even after using production mode, there are still `innerHTML` elements in the code.

Created a separate issue https://github.com/eclipse-sw360/sw360-frontend/issues/1677 to address it in code.

In meanwhile, removing it from here so page loads.

![img](https://github.com/user-attachments/assets/847d0d3b-c203-4887-bfc8-313b58ad70ea)
