### PR TITLE
fix(package): Package deletion infinite loading issue

### DIFF
--- a/src/app/[locale]/packages/components/DeletePackageModal.tsx
+++ b/src/app/[locale]/packages/components/DeletePackageModal.tsx
@@ -57,11 +57,7 @@ export default function DeletePackageModal({
     ])
 
     const handleGoBack = () => {
-        if (window.history.length > 1) {
-            router.back()
-        } else {
-            router.push('/packages')
-        }
+        router.push('/packages')
     }
 
     const deletePackage = async () => {


### PR DESCRIPTION

After deleting a package from the edit page, the browser would show an infinite loading spinner instead of displaying a success message and redirecting properly.

Before Changes:
<img width="1909" height="427" alt="image" src="https://github.com/user-attachments/assets/a3701527-6a72-448c-96d7-a7f40e374568" />

After Changes:
<img width="1924" height="204" alt="image" src="https://github.com/user-attachments/assets/1e45c6fc-6848-4132-bcbb-a4ecab4141e2" />
