### PR TITLE
Revert "fix(csp): Remove require-trusted-types-for"

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,7 @@ const csp = `
   connect-src 'self' https://www.gravatar.com${isDev ? ' http://localhost:*' : ''};
   object-src 'none';
   frame-ancestors 'self';
+  ${isDev ? '' : "require-trusted-types-for 'script'"};
 `
     .replace(/\s{2,}/g, ' ')
     .trim()


### PR DESCRIPTION
Reverts eclipse-sw360/sw360-frontend#1678

As mentioned in PR #1678, once the `innerHTML` issues are fixed (resolved in PR #1697) we've to revert the PR #1678.   