### PR TITLE
fix(ci): Restrict contents write permission to job

### DIFF
--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -15,14 +15,14 @@ on:
       - 'package.json'
       - 'pnpm-lock.yaml'
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   migrate:
     if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3


### PR DESCRIPTION
Attempt to fix https://github.com/eclipse-sw360/sw360-frontend/security/code-scanning/57

This restricts the `content: write` to only the job which needs it, not the entire workflow.