### PR TITLE
feat(search): Search by lucene ranking based on score

### DIFF
--- a/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
+++ b/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
@@ -449,7 +449,7 @@ export default function BulkReleaseEdit(): JSX.Element {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: Object.keys(search).length > 0 ? 'score,asc' : '',
         })
     }, [
         search,

--- a/src/app/[locale]/admin/obligations/components/Obligations.tsx
+++ b/src/app/[locale]/admin/obligations/components/Obligations.tsx
@@ -301,7 +301,7 @@ function Obligations(): ReactNode {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: Object.keys(search).length > 0 ? 'score,asc' : '',
         })
     }, [
         search,

--- a/src/app/[locale]/admin/users/components/UserAdministration.tsx
+++ b/src/app/[locale]/admin/users/components/UserAdministration.tsx
@@ -331,7 +331,7 @@ export default function UserAdminstration(): JSX.Element {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: params.toString() ? 'score,asc' : '',
         })
     }, [
         params.toString(),

--- a/src/app/[locale]/admin/vendors/components/VendorsList.tsx
+++ b/src/app/[locale]/admin/vendors/components/VendorsList.tsx
@@ -325,7 +325,7 @@ export default function VendorsList(): JSX.Element {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: Object.keys(search).length > 0 ? 'score,asc' : '',
         })
     }, [
         search,

--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -186,7 +186,7 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
         page_entries: 10,
-        sort: 'name,asc',
+        sort: params.toString() ? 'score,asc' : 'name,asc',
     })
     const [paginationMeta, setPaginationMeta] = useState<PaginationMeta | undefined>({
         size: 0,
@@ -264,7 +264,7 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: params.toString() ? 'score,asc' : '',
         })
     }, [
         params.toString(),

--- a/src/app/[locale]/licenses/components/LicensePage.tsx
+++ b/src/app/[locale]/licenses/components/LicensePage.tsx
@@ -45,7 +45,7 @@ function LicensePage(): ReactNode {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: Object.keys(search).length > 0 ? 'score,asc' : '',
         })
     }, [
         search,

--- a/src/app/[locale]/packages/components/Packages.tsx
+++ b/src/app/[locale]/packages/components/Packages.tsx
@@ -361,7 +361,7 @@ function Packages(): ReactNode {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: params.toString() ? 'score,asc' : '',
         })
     }, [
         params.toString(),

--- a/src/app/[locale]/projects/components/LinkProjects.tsx
+++ b/src/app/[locale]/projects/components/LinkProjects.tsx
@@ -192,7 +192,7 @@ export default function LinkProjects({
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
         page_entries: 10,
-        sort: 'name,asc',
+        sort: 'score,asc',
     })
     const [paginationMeta, setPaginationMeta] = useState<PaginationMeta | undefined>({
         size: 0,
@@ -575,6 +575,7 @@ export default function LinkProjects({
                                         setPageableQueryParam((prev) => ({
                                             ...prev,
                                             page: 0,
+                                            sort: 'score,asc',
                                         }))
                                         handleSearch()
                                     }}

--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -666,7 +666,7 @@ function Project(): JSX.Element {
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
         page_entries: 10,
-        sort: 'name,asc',
+        sort: params.toString() ? 'score,asc' : 'name,asc',
     })
     const [paginationMeta, setPaginationMeta] = useState<PaginationMeta | undefined>({
         size: 0,
@@ -807,7 +807,7 @@ function Project(): JSX.Element {
         setPageableQueryParam({
             page: 0,
             page_entries: 10,
-            sort: '',
+            sort: params.toString() ? 'score,asc' : '',
         })
     }, [
         params.toString(),

--- a/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
+++ b/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
@@ -203,7 +203,7 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
         page_entries: 10,
-        sort: 'name,asc',
+        sort: 'score,asc',
     })
     const [paginationMeta, setPaginationMeta] = useState<PaginationMeta | undefined>({
         size: 0,
@@ -636,6 +636,7 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
                                             setPageableQueryParam((prev) => ({
                                                 ...prev,
                                                 page: 0,
+                                                sort: 'score,asc',
                                             }))
                                             handleSearch()
                                         }}

--- a/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
+++ b/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
@@ -196,7 +196,7 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
         page_entries: 10,
-        sort: 'name,asc',
+        sort: 'score,asc',
     })
     const [paginationMeta, setPaginationMeta] = useState<PaginationMeta | undefined>({
         size: 0,
@@ -542,6 +542,7 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
                                         setPageableQueryParam((prev) => ({
                                             ...prev,
                                             page: 0,
+                                            sort: 'score,asc',
                                         }))
                                         handleSearch()
                                     }}


### PR DESCRIPTION
Problem Description

When users perform a search (advanced search or modal search) in the SW360 frontend, the results returned from the backend are ranked by **Lucene relevance score**. However, the frontend was not passing the appropriate `sort` parameter to the REST API during search requests. This caused search results to appear in an arbitrary or default column order (e.g., alphabetical by name) instead of being sorted by relevance.

Solution
Conditionally set `sort: 'score,asc'` whenever a search is active, and reset to the default sort (empty string or column-based) when no search is active.

Testing

1. **Search relevance**: Perform a search on any list page → results should appear with the most relevant match first.
2. **No search**: Clear the search → results should return to default ordering (alphabetical or server default).
3. **Column sort after search**: Click a column header after searching → results should sort by that column (overriding score sort).

Note: This PR requires the backend PR(https://github.com/eclipse-sw360/sw360/pull/4200) to be deployed as well for testing.
