### PR TITLE
fix(projects): Handle Unicode in report download filename and correct file extension

### DIFF
--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
@@ -137,10 +137,16 @@ export default function DownloadLicenseInfoModal({
                 variant: 'DISCLOSURE',
                 selectedRelRelationship,
             })
+            const extensionMap: Record<string, string> = {
+                DocxGenerator: 'docx',
+                XhtmlGenerator: 'html',
+                TextGenerator: 'txt',
+            }
+            const ext = extensionMap[generatorClassName] ?? 'zip'
             const downloadStatus = await DownloadService.download(
                 downloadUrl,
                 session.data,
-                `LicenseInfo-${currentDate}.zip`,
+                `LicenseInfo-${currentDate}.${ext}`,
             )
             if (downloadStatus === StatusCodes.OK) {
                 setShowConfirmation(true)

--- a/src/services/download.service.ts
+++ b/src/services/download.service.ts
@@ -13,6 +13,25 @@ import { Session } from 'next-auth'
 import { signOut } from 'next-auth/react'
 import { ApiUtils, CommonUtils } from '@/utils'
 
+const parseFilenameFromContentDisposition = (response: Response): string | null => {
+    const header = response.headers.get('Content-Disposition')
+    if (!header) return null
+
+    // Prefer RFC 5987 filename* (UTF-8 encoded)
+    const filenameStar = header.match(/filename\*=UTF-8''(.+?)(?:;|$)/i)
+    if (filenameStar) {
+        return decodeURIComponent(filenameStar[1].trim())
+    }
+
+    // Fallback to plain filename="..."
+    const filenameQuoted = header.match(/filename="(.+?)"/) || header.match(/filename=([^;\s]+)/)
+    if (filenameQuoted) {
+        return filenameQuoted[1].trim()
+    }
+
+    return null
+}
+
 const download = async (
     url: string,
     session: Session | null,
@@ -29,11 +48,12 @@ const download = async (
         if (!response.ok) {
             return response.status
         }
+        const resolvedFileName = parseFilenameFromContentDisposition(response) ?? fileName
         const blob = await response.blob()
         const objectURL = URL.createObjectURL(blob)
         const link = document.createElement('a')
         link.href = objectURL
-        link.setAttribute('download', fileName)
+        link.setAttribute('download', resolvedFileName)
         link.click()
         setTimeout(() => window.URL.revokeObjectURL(objectURL), 0)
         return response.status


### PR DESCRIPTION
## Problem

When generating a license-info report for a project whose name contains non-ASCII characters (e.g. `™`, umlauts), two issues occurred:

1. **Wrong file extension**: The downloaded file always had `.zip` extension regardless of the selected output format (DOCX, XHTML, TEXT).
2. **Unicode filename loss**: The backend `Content-Disposition` header was stripped by Tomcat when project names contained non-ISO-8859-1 characters, causing the browser to fall back to the generic frontend filename.

## Changes

### `src/services/download.service.ts`
- Added `parseFilenameFromContentDisposition()` utility that extracts the filename from the response header
- Supports RFC 5987 `filename*=UTF-8''...` (preferred) and plain `filename="..."` (fallback)
- Download now uses the server-provided filename when available, falling back to the caller-supplied name

### `src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx`
- File extension is now derived from the selected `generatorClassName`:
  - `DocxGenerator` → `.docx`
  - `XhtmlGenerator` → `.html`
  - `TextGenerator` → `.txt`
  - fallback → `.zip`

## Backend PR
https://github.com/eclipse-sw360/sw360/pull/4202
## Testing

- Created a project with Unicode name (`Gridscale X™ Protection Data Manager`)
- Generated license-info report with DOCX format
- Verified file downloads with correct `.docx` extension
- Verified RFC 5987 header parsing works when backend sends encoded filename


https://github.com/user-attachments/assets/3c75e82c-8e7f-407a-865c-c666fd66ee4e


