### PR TITLE
feat(project): Save attachment usages return 400

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "Die API-Token-Länge muss mindestens 20 betragen",
     "APPROVED": "genehmigt",
     "ATTACHMENTS": "ANHÄNGE",
+    "AttachmentUsages saved successfully (with warnings)": "Anhangsnutzungen erfolgreich gespeichert (mit Warnungen)",
     "AWAITING_RESPONSE": "Warten auf Antwort",
     "Accept Decline All MRs": "Sind Sie sicher, dass Sie alle ausgewählten Moderationsanfragen annehmen/ablehnen?",
     "Accept Decline All Selected Moderation Requests": "Alle ausgewählten Moderationsanfragen annehmen/ablehnen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "API Token Length must be at least 20",
     "APPROVED": "Approved",
     "ATTACHMENTS": "ATTACHMENTS",
+    "AttachmentUsages saved successfully (with warnings)": "AttachmentUsages saved successfully (with warnings)",
     "AWAITING_RESPONSE": "Awaiting Response",
     "Accept Decline All MRs": "Are you sure to Accept/Decline all selected Moderation Requests?",
     "Accept Decline All Selected Moderation Requests": "Accept/Decline All Selected Moderation Requests",

--- a/messages/es.json
+++ b/messages/es.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "La longitud del token API debe ser al menos 20",
     "APPROVED": "Aprobado",
     "ATTACHMENTS": "ARCHIVOS ADJUNTOS",
+    "AttachmentUsages saved successfully (with warnings)": "Usos de adjuntos guardados correctamente (con advertencias)",
     "AWAITING_RESPONSE": "Esperando respuesta",
     "Accept Decline All MRs": "¿Está seguro de aceptar o rechazar todas las solicitudes de moderación seleccionadas?",
     "Accept Decline All Selected Moderation Requests": "Aceptar/Rechazar todas las solicitudes de moderación seleccionadas",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "La longueur du jeton API doit être d'au moins 20",
     "APPROVED": "Approuvé",
     "ATTACHMENTS": "ACCESSOIRES",
+    "AttachmentUsages saved successfully (with warnings)": "Utilisations des pièces jointes enregistrées avec succès (avec avertissements)",
     "AWAITING_RESPONSE": "En attente de réponse",
     "Accept Decline All MRs": "Êtes-vous sûr d'accepter/refuser toutes les demandes de modération sélectionnées ?",
     "Accept Decline All Selected Moderation Requests": "Accepter/refuser toutes les demandes de modération sélectionnées",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "APIトークンの長さは20以上である必要があります",
     "APPROVED": "承認済",
     "ATTACHMENTS": "添付ファイル",
+    "AttachmentUsages saved successfully (with warnings)": "添付ファイルの使用状況が正常に保存されました（警告あり）",
     "AWAITING_RESPONSE": "応答待ち",
     "Accept Decline All MRs": "選択したすべてのモデレーションリクエストを承認/拒否してもよろしいですか?",
     "Accept Decline All Selected Moderation Requests": "選択したすべてのモデレーション リクエストの承認/拒否",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "API 토큰 길이는 최소 20이어야 합니다",
     "APPROVED": "이름 *",
     "ATTACHMENTS": "첨부 파일",
+    "AttachmentUsages saved successfully (with warnings)": "첨부 파일 사용이 성공적으로 저장되었습니다 (경고 포함)",
     "AWAITING_RESPONSE": "응답을 기다리는 중",
     "Accept Decline All MRs": "선택한 모든 중재 요청을 수락/거절하시겠습니까?",
     "Accept Decline All Selected Moderation Requests": "선택한 모든 중재 요청 수락/거부",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "O comprimento do token API deve ser pelo menos 20",
     "APPROVED": "Aprovado",
     "ATTACHMENTS": "Anexos",
+    "AttachmentUsages saved successfully (with warnings)": "Usos de anexos salvos com sucesso (com avisos)",
     "AWAITING_RESPONSE": "Aguardando resposta",
     "Accept Decline All MRs": "Você tem certeza de aceitar/recusar todas as solicitações de moderação selecionadas?",
     "Accept Decline All Selected Moderation Requests": "Aceitar/recusar todas as solicitações de moderação selecionadas",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "Độ dài mã thông báo API phải ít nhất là 20",
     "APPROVED": "Tán thành",
     "ATTACHMENTS": "ĐÍNH KÈM",
+    "AttachmentUsages saved successfully (with warnings)": "Đã lưu thành công việc sử dụng tệp đính kèm (có cảnh báo)",
     "AWAITING_RESPONSE": "Đang chờ phản hồi",
     "Accept Decline All MRs": "Bạn có chắc chắn Chấp nhận/Từ chối tất cả các Yêu cầu Kiểm duyệt đã chọn không?",
     "Accept Decline All Selected Moderation Requests": "Chấp nhận/Từ chối tất cả các yêu cầu kiểm duyệt đã chọn",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "API 令牌长度必须至少为 20",
     "APPROVED": "得到正式认可的",
     "ATTACHMENTS": "附件",
+    "AttachmentUsages saved successfully (with warnings)": "附件使用情况已成功保存（有警告）",
     "AWAITING_RESPONSE": "等待回复",
     "Accept Decline All MRs": "您确定接受/拒绝所有选定的审核请求吗？",
     "Accept Decline All Selected Moderation Requests": "接受/拒绝所有选定的审核请求",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -14,6 +14,7 @@
     "API Token Length must be at least 20": "API 令牌長度必須至少為 20",
     "APPROVED": "核定",
     "ATTACHMENTS": "附件",
+    "AttachmentUsages saved successfully (with warnings)": "附件使用情況已成功儲存（有警告）",
     "AWAITING_RESPONSE": "等待回覆",
     "Accept Decline All MRs": "您確定接受/拒絕所有選定的審核請求嗎？",
     "Accept Decline All Selected Moderation Requests": "接受/拒絕所有選定的審核請求",

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -211,6 +211,7 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
 
     const [showProcessingLinkedProjects, setShowProcessingLinkedProjects] = useState(false)
     const [showProcessingAttachmentUsages, setShowProcessingAttachmentUsages] = useState(false)
+    const [isTableBuilding, setIsTableBuilding] = useState(false)
 
     const [linkedProjects, setLinkedProjects] = useState<Project[]>(() => [])
     const memoizedLinkedProjects = useMemo(
@@ -269,9 +270,26 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 MessageService.error(t('Something went wrong'))
                 return notFound()
             }
-            MessageService.success(t('AttachmentUsages saved successfully'))
+
+            // Check for warnings in response (e.g. stale sub-project or release references)
+            try {
+                const responseBody = await response.json()
+                if (responseBody.warnings && responseBody.warnings.length > 0) {
+                    responseBody.warnings.forEach((warning: string) => {
+                        MessageService.warn(warning, {
+                            autoClose: false,
+                        })
+                    })
+                    MessageService.success(t('AttachmentUsages saved successfully (with warnings)'))
+                } else {
+                    MessageService.success(t('AttachmentUsages saved successfully'))
+                }
+            } catch {
+                // Response was plain text (no warnings)
+                MessageService.success(t('AttachmentUsages saved successfully'))
+            }
         } catch (e) {
-            console.error(e)
+            ApiUtils.reportError(e)
         } finally {
             setSaveUsagesLoading(false)
         }
@@ -950,7 +968,13 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
     useEffect(() => {
         if (memoizedAttachmentUsages === undefined) return
 
-        buildTable(setData, memoizedAttachmentUsages, memoizedLinkedProjects)
+        setIsTableBuilding(true)
+        // Use requestAnimationFrame to allow the browser to paint the loading indicator
+        // before starting the expensive table build
+        requestAnimationFrame(() => {
+            buildTable(setData, memoizedAttachmentUsages, memoizedLinkedProjects)
+            setIsTableBuilding(false)
+        })
     }, [
         memoizedAttachmentUsages,
         memoizedLinkedProjects,
@@ -977,7 +1001,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 {table ? (
                     <SW360Table
                         table={table}
-                        showProcessing={showProcessingLinkedProjects || showProcessingAttachmentUsages}
+                        showProcessing={
+                            showProcessingLinkedProjects || showProcessingAttachmentUsages || isTableBuilding
+                        }
                     />
                 ) : (
                     <div className='col-12 mt-1 text-center'>

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
@@ -130,6 +130,20 @@ export default function DownloadLicenseInfoModal({
                 const err = (await response.json()) as ErrorDetails
                 throw new Error(err.message)
             }
+
+            // Display warnings (e.g. stale sub-project/release references) without blocking download
+            try {
+                const responseBody = await response.json()
+                if (responseBody.warnings && responseBody.warnings.length > 0) {
+                    responseBody.warnings.forEach((warning: string) => {
+                        MessageService.warn(warning, {
+                            autoClose: false,
+                        })
+                    })
+                }
+            } catch {
+                // Response was plain text (no warnings) - continue normally
+            }
             const downloadUrl = CommonUtils.createUrlWithParams(`reports`, {
                 withlinkedreleases: 'false',
                 projectId,

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -799,14 +799,20 @@ function GenerateLicenseInfo({
                     )
                 }
                 const responses = await Promise.all(requests)
-                responses.map(async (r) => {
+                for (const r of responses) {
                     if (r.status !== StatusCodes.OK) {
-                        const err = (await r.json()) as ErrorDetails
-                        throw new ApiError(err.message, {
+                        let message = `Request failed with status ${r.status}`
+                        try {
+                            const err = (await r.json()) as ErrorDetails
+                            message = err.message
+                        } catch {
+                            // Response body is not valid JSON
+                        }
+                        throw new ApiError(message, {
                             status: r.status,
                         })
                     }
-                })
+                }
 
                 const proj = (await responses[0].json()) as Project
                 setProject(proj)

--- a/src/services/message.service.ts
+++ b/src/services/message.service.ts
@@ -50,7 +50,7 @@ function showMessage(type: string, text: string, lead: string, options?: Message
         type: type,
         lead: lead,
         text: text,
-        autoClose: options && (options.autoClose ?? false) ? options.autoClose : true,
+        autoClose: options?.autoClose !== undefined ? options.autoClose : true,
         keepAfterRouteChange: options?.keepAfterRouteChange ?? true,
     }
 


### PR DESCRIPTION
Problem
On the Attachment Usage page and the Generate License Info / Clearing Report download page (/projects/generateLicenseInfo/{id}?withSubProjects=true), saving attachment usages would fail with a 400 Bad Request error when linked sub-projects or releases had been deleted or become unreachable (stale references).

This blocked users from:

- Saving any attachment usage changes on the project detail page
- Downloading clearing reports / license info documents

Solution
Backend (separate PR, https://github.com/eclipse-sw360/sw360/pull/4236): Changed saveAttachmentUsages to always return 201 Created, skipping stale entries and returning a [warnings] array in the response body when entries are skipped.

Frontend (this PR):
- After successful save, parses response JSON for array. Displays each warning via with so warnings persist until user dismisses them. Save always shows success regardless of warnings.
- Same pattern: parses warnings from response, displays them with [autoClose: false], and always proceeds with the report download.
- Fixed the unawaited async→ replaced with a for...of loop. Wrapped [r.json()] in try/catch to handle non-JSON error responses gracefully.
- Added [isTableBuilding] state with [requestAnimationFrame] to keep the processing spinner visible during the expensive table render phase.
- Fixed a bug where passing [autoClose: false] was ignored due to faulty ternary logic.

Note: need backend PR( https://github.com/eclipse-sw360/sw360/pull/4236) to test this.