### PR TITLE
fix(user): Add externalid upon create and edit of user

### DIFF
--- a/src/app/[locale]/admin/users/add/page.tsx
+++ b/src/app/[locale]/admin/users/add/page.tsx
@@ -29,6 +29,7 @@ export default function CreateUser(): JSX.Element {
         department: '',
         fullName: '',
         password: '',
+        externalid: '',
         secondaryDepartmentsAndRoles: {},
     })
     const router = useRouter()

--- a/src/app/[locale]/admin/users/edit/[id]/page.tsx
+++ b/src/app/[locale]/admin/users/edit/[id]/page.tsx
@@ -65,6 +65,7 @@ const AdminEditUserPage = (): JSX.Element => {
                     fullName: user.fullName,
                     userGroup: user.userGroup,
                     password: '',
+                    externalid: user.externalid,
                     secondaryDepartmentsAndRoles: user.secondaryDepartmentsAndRoles,
                 })
                 setIsUserDeactived(user.deactivated === true)

--- a/src/components/UserEditForm/UserEditForm.tsx
+++ b/src/components/UserEditForm/UserEditForm.tsx
@@ -95,9 +95,9 @@ const UserEditForm = ({ userPayload, handleChange, userOperationType, setUserPay
                         {t('Global Identifier')} <span className='required'>*</span>
                     </label>
                     <input
-                        type='globalIdentifier'
-                        name='globalIdentifier'
-                        value={userPayload.externalid}
+                        type='text'
+                        name='externalid'
+                        value={userPayload.externalid ?? ''}
                         onChange={handleChange}
                         className='form-control'
                         id='user.globalIdentifier'


### PR DESCRIPTION
# fix(user): Add externalid upon create and edit of user

## Summary of Changes

The `externalid` (Global Identifier) field was not being populated when editing a user and was not being sent correctly when creating a user due to a wrong `name` attribute in the form input.

**Changes:**
- **`UserEditForm.tsx`**: Fixed the Global Identifier input — changed `name='globalIdentifier'` → `name='externalid'` and `type='globalIdentifier'` → `type='text'`, so `handleChange` writes to the correct `UserPayload.externalid` field
- **`edit/[id]/page.tsx`**: Added `externalid: user.externalid` when mapping the API response into `userPayload`, so the field is pre-populated on the edit form
- **`add/page.tsx`**: Added `externalid: ''` to the initial state so the field is tracked from the start and included in the POST request

---

## Issue

> Global Identifier (externalid) is not fetched/displayed on the edit user page and is not saved when creating or updating a user.

closes: https://github.com/eclipse-sw360/sw360-frontend/issues/1755

---

## Suggest Reviewer

> @GMishx, @amritkv 

---

## How To Test?

1. Navigate to **Admin → Users → Add User**
   - Fill in all fields including **Global Identifier**
   - Submit → verify the new user is created with the correct `externalid` via the user detail page

2. Navigate to **Admin → Users → Edit** an existing user
   - Verify the **Global Identifier** field is pre-populated from the API
   - Change the value and save → verify the updated `externalid` is reflected on the user detail page

---