### PR TITLE
feat(releases): add config flag to enable/disable nested release linking

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Ihre ausgewählten Moderationsanfragen sind:",
     "additional data": "zusätzliche Daten",
     "admin_private_access_description": "Ermöglichen Sie Administratorbenutzern, auf private Ressourcen zugreifen",
+    "nested_release_enabled_description": "Aktivieren oder deaktivieren Sie die Funktion zur Verknüpfung von Releases (verschachtelte Releases)",
+    "Nested Release Linking Feature": "Funktion zur Verknüpfung verschachtelter Releases",
     "as of": "als",
     "attachment_delete_number_of_days_description": "Löschen Sie Anhänge nach einer bestimmten Anzahl von Tagen",
     "attachment_storage_location_description": "Konfigurieren Sie den Speicherort des Anhangsspeichers",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Your selected Moderation Requests are : ",
     "additional data": "additional data",
     "admin_private_access_description": "Allow ADMIN users to access private resources",
+    "nested_release_enabled_description": "Enable or disable release-to-release linking (nested releases) feature",
+    "Nested Release Linking Feature": "Nested Release Linking Feature",
     "as of": "as of",
     "attachment_delete_number_of_days_description": "Delete attachments after a specified number of days",
     "attachment_storage_location_description": "Configure attachment storage location",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Sus solicitudes de moderación seleccionadas son:",
     "additional data": "Datos adicionales",
     "admin_private_access_description": "Permitir a los usuarios de administración acceder a recursos privados",
+    "nested_release_enabled_description": "Habilitar o deshabilitar la función de vinculación de versiones (versiones anidadas)",
+    "Nested Release Linking Feature": "Función de vinculación de versiones anidadas",
     "as of": "a",
     "attachment_delete_number_of_days_description": "Eliminar archivos adjuntos después de un número específico de días",
     "attachment_storage_location_description": "Configurar la ubicación de almacenamiento de archivos adjuntos",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Vos demandes de modération sélectionnées sont :",
     "additional data": "données supplémentaires",
     "admin_private_access_description": "Permettre aux utilisateurs de l'administrateur d'accéder aux ressources privées",
+    "nested_release_enabled_description": "Activer ou désactiver la fonctionnalité de liaison de versions (versions imbriquées)",
+    "Nested Release Linking Feature": "Fonctionnalité de liaison de versions imbriquées",
     "as of": "à partir de",
     "attachment_delete_number_of_days_description": "Supprimer les pièces jointes après un nombre spécifié de jours",
     "attachment_storage_location_description": "Configurer l'emplacement du stockage de la pièce jointe",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "選択したモデレーション リクエストは次のとおりです:",
     "additional data": "追加データ",
     "admin_private_access_description": "管理者ユーザーがプライベートリソースにアクセスできるようにします",
+    "nested_release_enabled_description": "リリース間のリンク（ネストされたリリース）機能を有効または無効にします",
+    "Nested Release Linking Feature": "ネストされたリリースリンク機能",
     "as of": "as of",
     "attachment_delete_number_of_days_description": "指定された日数の後に添付ファイルを削除します",
     "attachment_storage_location_description": "添付ファイルストレージの場所を構成します",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "선택한 중재 요청은 다음과 같습니다.",
     "additional data": "더 많은 데이터",
     "admin_private_access_description": "관리자가 개인 리소스에 액세스 할 수 있도록합니다",
+    "nested_release_enabled_description": "릴리스 간 연결(중첩 릴리스) 기능 활성화 또는 비활성화",
+    "Nested Release Linking Feature": "중첩 릴리스 연결 기능",
     "as of": "이름 *",
     "attachment_delete_number_of_days_description": "지정된 일 후 첨부 파일을 삭제합니다",
     "attachment_storage_location_description": "첨부 스토리지 위치를 구성하십시오",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Suas solicitações de moderação selecionadas são:",
     "additional data": "Dados adicionais ",
     "admin_private_access_description": "Permitir que os usuários administradores acessem recursos privados",
+    "nested_release_enabled_description": "Ativar ou desativar a funcionalidade de vinculação de versões (versões aninhadas)",
+    "Nested Release Linking Feature": "Funcionalidade de vinculação de versões aninhadas",
     "as of": "A partir de",
     "attachment_delete_number_of_days_description": "Excluir anexos após um número especificado de dias",
     "attachment_storage_location_description": "Configurar local de armazenamento de anexo",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "Yêu cầu Kiểm duyệt đã chọn của bạn là:",
     "additional data": "dữ liệu bổ sung",
     "admin_private_access_description": "Cho phép người dùng quản trị truy cập tài nguyên riêng tư",
+    "nested_release_enabled_description": "Bật hoặc tắt tính năng liên kết phiên bản (phiên bản lồng nhau)",
+    "Nested Release Linking Feature": "Tính năng liên kết phiên bản lồng nhau",
     "as of": "kể từ",
     "attachment_delete_number_of_days_description": "Xóa tệp đính kèm sau một số ngày được chỉ định",
     "attachment_storage_location_description": "Định cấu hình vị trí lưu trữ đính kèm",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "您选择的审核请求是：",
     "additional data": "附加数据",
     "admin_private_access_description": "允许管理员用户访问私人资源",
+    "nested_release_enabled_description": "启用或禁用版本到版本链接（嵌套版本）功能",
+    "Nested Release Linking Feature": "嵌套版本链接功能",
     "as of": "作为",
     "attachment_delete_number_of_days_description": "指定天数后删除附件",
     "attachment_storage_location_description": "配置附件存储位置",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1613,6 +1613,8 @@
     "Your selected Moderation requests are": "您選擇的審核請求是：",
     "additional data": "其他資料",
     "admin_private_access_description": "允許管理員用戶訪問私人資源",
+    "nested_release_enabled_description": "啟用或禁用版本到版本鏈接（嵌套版本）功能",
+    "Nested Release Linking Feature": "嵌套版本鏈接功能",
     "as of": "截至",
     "attachment_delete_number_of_days_description": "指定天數後刪除附件",
     "attachment_storage_location_description": "配置附件存儲位置",

--- a/src/app/[locale]/admin/configurations/components/FeatureConfigurations.tsx
+++ b/src/app/[locale]/admin/configurations/components/FeatureConfigurations.tsx
@@ -252,6 +252,18 @@ const FeatureConfigurations = (): JSX.Element => {
                                     </td>
                                     <td className='align-middle'>{t('admin_private_access_description')}</td>
                                 </tr>
+                                <tr id='nested-release-enabled'>
+                                    <td className='align-middle fw-bold'>{t('Nested Release Linking Feature')}</td>
+                                    <td>
+                                        <OnOffSwitch
+                                            size={25}
+                                            setCurrentConfig={setCurrentConfig}
+                                            checked={currentConfig[ConfigKeys.IS_NESTED_RELEASE_ENABLED] === 'true'}
+                                            propKey={ConfigKeys.IS_NESTED_RELEASE_ENABLED}
+                                        />
+                                    </td>
+                                    <td className='align-middle'>{t('nested_release_enabled_description')}</td>
+                                </tr>
                                 <tr id='sbom-import-export-access-usergroup'>
                                     <td className='align-middle fw-bold'>
                                         {t('SBOM Import Export Access User Group')}

--- a/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
+++ b/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
@@ -20,11 +20,13 @@ import { ReactNode, useEffect, useState } from 'react'
 import { Col, ListGroup, Row, Tab } from 'react-bootstrap'
 import AddCommercialDetails from '@/components/CommercialDetails/AddCommercialDetails'
 import LinkedReleases from '@/components/LinkedReleases/LinkedReleases'
+import { useConfigKeyValue } from '@/contexts'
 import {
     ActionType,
     COTSDetails,
     CommonTabIds,
     Component,
+    ConfigKeys,
     Release,
     ReleaseDetail,
     ReleaseTabIds,
@@ -59,6 +61,8 @@ const cotsDetails: COTSDetails = {
 function AddRelease({ componentId }: Props): ReactNode {
     const t = useTranslations('default')
     const router = useRouter()
+    const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
+    const showLinkedReleases = isNestedReleaseEnabled !== 'false'
 
     const [releasePayload, setReleasePayload] = useState<Release>({
         name: '',
@@ -297,12 +301,14 @@ function AddRelease({ componentId }: Props): ReactNode {
                                 >
                                     <div className='my-2'>{t('Summary')}</div>
                                 </ListGroup.Item>
-                                <ListGroup.Item
-                                    action
-                                    eventKey={ReleaseTabIds.LINKED_RELEASES}
-                                >
-                                    <div className='my-2'>{t('Linked Releases')}</div>
-                                </ListGroup.Item>
+                                {showLinkedReleases && (
+                                    <ListGroup.Item
+                                        action
+                                        eventKey={ReleaseTabIds.LINKED_RELEASES}
+                                    >
+                                        <div className='my-2'>{t('Linked Releases')}</div>
+                                    </ListGroup.Item>
+                                )}
                                 {withCotsDetails && (
                                     <ListGroup.Item
                                         action
@@ -332,14 +338,16 @@ function AddRelease({ componentId }: Props): ReactNode {
                                             releaseDetail={sourceRelease ?? undefined}
                                         />
                                     </Tab.Pane>
-                                    <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
-                                        <LinkedReleases
-                                            actionType={duplicateFromReleaseId ? ActionType.EDIT : ActionType.ADD}
-                                            release={sourceRelease ?? undefined}
-                                            releasePayload={releasePayload}
-                                            setReleasePayload={setReleasePayload}
-                                        />
-                                    </Tab.Pane>
+                                    {showLinkedReleases && (
+                                        <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
+                                            <LinkedReleases
+                                                actionType={duplicateFromReleaseId ? ActionType.EDIT : ActionType.ADD}
+                                                release={sourceRelease ?? undefined}
+                                                releasePayload={releasePayload}
+                                                setReleasePayload={setReleasePayload}
+                                            />
+                                        </Tab.Pane>
+                                    )}
                                     {withCotsDetails && (
                                         <Tab.Pane eventKey={ReleaseTabIds.COMMERCIAL_DETAILS}>
                                             <AddCommercialDetails

--- a/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
@@ -25,11 +25,13 @@ import EditAttachments from '@/components/Attachments/EditAttachments'
 import AddCommercialDetails from '@/components/CommercialDetails/AddCommercialDetails'
 import CreateMRCommentDialog from '@/components/CreateMRCommentDialog/CreateMRCommentDialog'
 import LinkedReleases from '@/components/LinkedReleases/LinkedReleases'
+import { useConfigKeyValue } from '@/contexts'
 import {
     ActionType,
     ClearingInformation,
     COTSDetails,
     CommonTabIds,
+    ConfigKeys,
     Creator,
     DocumentCreationInformation,
     DocumentTypes,
@@ -59,6 +61,8 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
     const router = useRouter()
     const t = useTranslations('default')
     const params = useSearchParams()
+    const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
+    const showLinkedReleases = isNestedReleaseEnabled !== 'false'
     const [release, setRelease] = useState<ReleaseDetail>()
     const [componentId, setComponentId] = useState('')
     const [deletingRelease, setDeletingRelease] = useState('')
@@ -595,12 +599,14 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                                             <div className='my-2'>{t('SPDX Document')}</div>
                                         </ListGroup.Item>
                                     )}
-                                    <ListGroup.Item
-                                        action
-                                        eventKey={ReleaseTabIds.LINKED_RELEASES}
-                                    >
-                                        <div className='my-2'>{t('Linked Releases')}</div>
-                                    </ListGroup.Item>
+                                    {showLinkedReleases && (
+                                        <ListGroup.Item
+                                            action
+                                            eventKey={ReleaseTabIds.LINKED_RELEASES}
+                                        >
+                                            <div className='my-2'>{t('Linked Releases')}</div>
+                                        </ListGroup.Item>
+                                    )}
                                     <ListGroup.Item
                                         action
                                         eventKey={ReleaseTabIds.LINKED_PACKAGES}
@@ -681,14 +687,16 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
                                                 />
                                             </Tab.Pane>
                                         )}
-                                        <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
-                                            <LinkedReleases
-                                                actionType={ActionType.EDIT}
-                                                release={release}
-                                                releasePayload={releasePayload}
-                                                setReleasePayload={setReleasePayload}
-                                            />
-                                        </Tab.Pane>
+                                        {showLinkedReleases && (
+                                            <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
+                                                <LinkedReleases
+                                                    actionType={ActionType.EDIT}
+                                                    release={release}
+                                                    releasePayload={releasePayload}
+                                                    setReleasePayload={setReleasePayload}
+                                                />
+                                            </Tab.Pane>
+                                        )}
                                         <Tab.Pane eventKey={ReleaseTabIds.LINKED_PACKAGES}>
                                             <EditLinkedPackages
                                                 releasePayload={releasePayload}

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -27,10 +27,12 @@ import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
 import ComponentVulnerabilities from '@/components/ComponentVulnerabilities/ComponentVulnerabilities'
 import LinkReleaseToProjectModal from '@/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal'
 import { PageButtonHeader } from '@/components/sw360'
+import { useConfigKeyValue } from '@/contexts'
 import {
     Attachment,
     Changelogs,
     CommonTabIds,
+    ConfigKeys,
     DocumentTypes,
     Embedded,
     ErrorDetails,
@@ -68,6 +70,8 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     const [activeKey, setActiveKey] = useState(CommonTabIds.SUMMARY)
     const searchParams = useSearchParams()
     const router = useRouter()
+    const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
+    const showLinkedReleases = isNestedReleaseEnabled !== 'false'
     const [release, setRelease] = useState<ReleaseDetail>()
     const [releasesSameComponent, setReleasesSameComponent] = useState<Array<ReleaseLink>>([])
     const [embeddedAttachments, setEmbeddedAttachments] = useState<Array<Attachment>>([])
@@ -440,12 +444,14 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                             <div className='my-2'>{t('SPDX Document')}</div>
                                         </ListGroup.Item>
                                     )}
-                                    <ListGroup.Item
-                                        action
-                                        eventKey={ReleaseTabIds.LINKED_RELEASES}
-                                    >
-                                        <div className='my-2'>{t('Linked Releases')}</div>
-                                    </ListGroup.Item>
+                                    {showLinkedReleases && (
+                                        <ListGroup.Item
+                                            action
+                                            eventKey={ReleaseTabIds.LINKED_RELEASES}
+                                        >
+                                            <div className='my-2'>{t('Linked Releases')}</div>
+                                        </ListGroup.Item>
+                                    )}
                                     <ListGroup.Item
                                         action
                                         eventKey={ReleaseTabIds.LINKED_PACKAGES}
@@ -611,9 +617,11 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                                                 <SPDXDocumentTab releaseId={releaseId} />
                                             </Tab.Pane>
                                         )}
-                                        <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
-                                            <LinkedReleases releaseId={releaseId} />
-                                        </Tab.Pane>
+                                        {showLinkedReleases && (
+                                            <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
+                                                <LinkedReleases releaseId={releaseId} />
+                                            </Tab.Pane>
+                                        )}
                                         <Tab.Pane eventKey={ReleaseTabIds.LINKED_PACKAGES}>
                                             <LinkedPackagesTab releaseId={releaseId} />
                                         </Tab.Pane>

--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
@@ -12,7 +12,8 @@
 import { StatusCodes } from 'http-status-codes'
 import { signOut, useSession } from 'next-auth/react'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
-import { Attachment, ErrorDetails, Release, ReleaseDetail } from '@/object-types'
+import { useConfigKeyValue } from '@/contexts'
+import { Attachment, ConfigKeys, ErrorDetails, Release, ReleaseDetail } from '@/object-types'
 import CommonUtils from '@/utils/common.utils'
 import { ApiError, ApiUtils } from '@/utils/index'
 import AdditionalDataSection from './AdditionalDataSection'
@@ -44,6 +45,8 @@ export default function MergeReleaseDataCheck({
 }): ReactNode {
     const session = useSession()
     const [sourceReleaseDetail, setSourceReleaseDetail] = useState<ReleaseDetail | null>()
+    const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
+    const showLinkedReleases = isNestedReleaseEnabled !== 'false'
 
     useEffect(() => {
         if (session.status === 'unauthenticated') {
@@ -132,12 +135,14 @@ export default function MergeReleaseDataCheck({
                         finalReleasePayload={finalReleasePayload}
                         setFinalReleasePayload={setFinalReleasePayload}
                     />
-                    <LinkedReleasesSection
-                        targetRelease={targetRelease}
-                        sourceReleaseDetail={sourceReleaseDetail}
-                        finalReleasePayload={finalReleasePayload}
-                        setFinalReleasePayload={setFinalReleasePayload}
-                    />
+                    {showLinkedReleases && (
+                        <LinkedReleasesSection
+                            targetRelease={targetRelease}
+                            sourceReleaseDetail={sourceReleaseDetail}
+                            finalReleasePayload={finalReleasePayload}
+                            setFinalReleasePayload={setFinalReleasePayload}
+                        />
+                    )}
                     <ClearingDetailsSection
                         targetRelease={targetRelease}
                         sourceReleaseDetail={sourceReleaseDetail}

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
@@ -21,10 +21,12 @@ import Summary from '@/app/[locale]/components/releases/detail/[id]/components/S
 import Attachments from '@/components/Attachments/Attachments'
 import ChangeLogDetail from '@/components/ChangeLog/ChangeLogDetail/ChangeLogDetail'
 import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
+import { useConfigKeyValue } from '@/contexts'
 import {
     Attachment,
     Changelogs,
     CommonTabIds,
+    ConfigKeys,
     DocumentTypes,
     Embedded,
     ErrorDetails,
@@ -49,6 +51,8 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
     const session = useSession()
     const [activeKey, setActiveKey] = useState(CommonTabIds.SUMMARY)
     const t = useTranslations('default')
+    const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
+    const showLinkedReleases = isNestedReleaseEnabled !== 'false'
 
     useEffect(() => {
         if (session.status === 'unauthenticated') {
@@ -195,12 +199,14 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
                             >
                                 <div className='my-2'>{t('Summary')}</div>
                             </ListGroup.Item>
-                            <ListGroup.Item
-                                action
-                                eventKey={ReleaseTabIds.LINKED_RELEASES}
-                            >
-                                <div className='my-2'>{t('Linked Releases')}</div>
-                            </ListGroup.Item>
+                            {showLinkedReleases && (
+                                <ListGroup.Item
+                                    action
+                                    eventKey={ReleaseTabIds.LINKED_RELEASES}
+                                >
+                                    <div className='my-2'>{t('Linked Releases')}</div>
+                                </ListGroup.Item>
+                            )}
                             <ListGroup.Item
                                 action
                                 eventKey={ReleaseTabIds.CLEARING_DETAILS}
@@ -237,9 +243,11 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
                                     releaseId={releaseId}
                                 />
                             </Tab.Pane>
-                            <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
-                                <LinkedReleases releaseId={releaseId} />
-                            </Tab.Pane>
+                            {showLinkedReleases && (
+                                <Tab.Pane eventKey={ReleaseTabIds.LINKED_RELEASES}>
+                                    <LinkedReleases releaseId={releaseId} />
+                                </Tab.Pane>
+                            )}
                             <Tab.Pane eventKey={ReleaseTabIds.CLEARING_DETAILS}>
                                 <ClearingDetails
                                     release={release}

--- a/src/object-types/enums/ConfigKeys.ts
+++ b/src/object-types/enums/ConfigKeys.ts
@@ -31,6 +31,7 @@ enum ConfigKeys {
     IS_PACKAGE_PORTLET_ENABLED = 'package.portlet.enabled',
     RELEASE_SOURCECODE_URL_SKIP_DOMAINS = 'release.sourcecodeurl.skip.domains',
     REST_API_TOKEN_LENGTH = 'rest.apitoken.length',
+    IS_NESTED_RELEASE_ENABLED = 'nested.release.enabled',
 }
 
 export default ConfigKeys


### PR DESCRIPTION
## Summary

Add a configuration flag to enable/disable the nested release (release-to-release linking) feature in the frontend. This feature allows organizations to control whether users can link releases to other releases based on their compliance policies.

## Changes

### New Configuration Key
- Added `IS_NESTED_RELEASE_ENABLED` (`nested.release.enabled`) to `ConfigKeys` enum

### Conditional UI Rendering
When the configuration is disabled (`nested.release.enabled = false`), the "Linked Releases" tab and content are completely hidden in:

| File | Description |
|------|-------------|
| `EditRelease.tsx` | Release edit page |
| `AddRelease.tsx` | Release add page |
| `DetailOverview.tsx` | Release detail view page |
| `CurrentReleaseDetail.tsx` | Moderation request release view |
| `MergeReleaseDataCheck.tsx` | Release merge page |

## Behavior

| Config Value | Behavior |
|--------------|----------|
| `true` (default) | Linked Releases tab is visible and functional |
| `false` | Linked Releases tab is completely hidden |
| Not set / `null` | Defaults to `true` (enabled) |

## Backend Dependency

Requires: https://github.com/eclipse-sw360/sw360/pull/4239

## Testing

1. Set `nested.release.enabled = false` in SW360 configuration database
2. Navigate to any release page (add/edit/detail)
3. Verify "Linked Releases" tab is not visible
4. Set `nested.release.enabled = true` or remove the config
5. Verify "Linked Releases" tab is visible and functional


<img width="1902" height="1146" alt="Screenshot 2026-06-01 175451" src="https://github.com/user-attachments/assets/06ed6e94-fcae-43c1-829d-b556f6efb1e5" />
