### PR TITLE
fix(licenseClearing): Handle no releases

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -214,8 +214,8 @@ const extractLinkedReleases = (
     path: string[],
 ) => {
     path.push(`${projectName} (${projectVersion})`)
-    for (const l of licenseClearing['linkedReleases']) {
-        const release = licenseClearing['_embedded']['sw360:release'].filter(
+    for (const l of licenseClearing?.['linkedReleases'] ?? []) {
+        const release = licenseClearing?._embedded?.['sw360:release']?.filter(
             (r: Release) => r.id === l.release.split('/').at(-1),
         )?.[0]
         finalData.push({
@@ -244,7 +244,7 @@ const buildTable = (
     const finalData: (TypedProject | TypedRelease)[] = []
     const path: string[] = []
     extractLinkedProjectsAndTheirLinkedReleases(
-        licenseClearing['_embedded']['sw360:release'],
+        licenseClearing['_embedded']?.['sw360:release'] ?? [],
         linkedProjects,
         finalData,
         path,

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -169,15 +169,12 @@ const buildTable = (
     licenseClearing: LicenseClearing,
     linkedProjects: Project[],
 ) => {
-    const linkedProjectRows = extractLinkedProjectsAndTheirLinkedReleases(
-        licenseClearing['_embedded']['sw360:release'],
-        linkedProjects,
-    )
+    const embeddedReleases = licenseClearing._embedded?.['sw360:release'] ?? []
+    const linkedProjectRows = extractLinkedProjectsAndTheirLinkedReleases(embeddedReleases, linkedProjects)
     const releaseRows: NestedRows<TypedProject | TypedRelease>[] = []
-    for (const l of licenseClearing['linkedReleases']) {
-        const release = licenseClearing['_embedded']['sw360:release'].filter(
-            (r: Release) => r.id === l.release.split('/').at(-1),
-        )?.[0]
+    for (const l of licenseClearing.linkedReleases ?? []) {
+        const release = embeddedReleases.filter((r: Release) => r.id === l.release.split('/').at(-1))?.[0]
+        if (release === undefined) continue
         const nodeRelease: NestedRows<TypedProject | TypedRelease> = {
             node: {
                 type: 'release',

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -416,7 +416,7 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
                             if (index !== -1) {
                                 return (
                                     <div className='text-center'>
-                                        {Capitalize(memoizedLicenseClearing?.linkedReleases[index].relation ?? '')}
+                                        {Capitalize(memoizedLicenseClearing?.linkedReleases?.[index].relation ?? '')}
                                     </div>
                                 )
                             }

--- a/src/object-types/LicenseClearing.ts
+++ b/src/object-types/LicenseClearing.ts
@@ -28,10 +28,10 @@ export default interface LicenseClearing {
     enableSvm: boolean
     considerReleasesFromExternalList: boolean
     enableVulnerabilitiesDisplay: boolean
-    linkedReleases: LinkedRelease[]
+    linkedReleases?: LinkedRelease[]
     linkedProjects?: LinkedProject[]
     _links: Links
-    _embedded: {
-        'sw360:release': Release[]
+    _embedded?: {
+        'sw360:release'?: Release[]
     }
 }


### PR DESCRIPTION
Handle `/licenseClearing` response where there are no embedded releases. Also update the object type to indicate the value can be undefined.