### PR TITLE
fix(deps): Replace ignoredBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   # include packages in subfolders (change as required)
   - 'src/**'
 
-ignoredBuiltDependencies:
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
   - cypress
   - sharp


### PR DESCRIPTION
## Summary

`pnpm i` was failing in CI with:

    [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6,
    @swc/core@1.15.33, cypress@15.15.0, sharp@0.34.5
    Run "pnpm approve-builds" to pick which dependencies should be allowed
    to run scripts.

pnpm v10 removed the silent-ignore behavior of `ignoredBuiltDependencies`
and now errors instead. The replacement is `onlyBuiltDependencies` — an
explicit allowlist of packages that may run install-time build scripts.

## Changes

- `pnpm-workspace.yaml`: replace `ignoredBuiltDependencies` with
  `onlyBuiltDependencies`, adding all four packages that require native
  compilation (`@parcel/watcher`, `@swc/core`, `cypress`, `sharp`).

## How to Test

Run `pnpm i` locally or trigger CI — the `ERR_PNPM_IGNORED_BUILDS`
error should no longer appear.