### PR TITLE
chore(deps): Upgrade pnpm from v10 to v11

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
 # Add pnpm
-RUN npm install -g pnpm@latest-10
+RUN npm install -g pnpm@latest-11
 
 USER ${USERNAME}
 WORKDIR $HOMEDIR

--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -35,7 +35,7 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          version: 10
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG NEXTAUTH_URL=http://localhost:3000
 ARG AUTH_SECRET=mysecret
 
 RUN npm config set registry $NPM_CONFIG_REGISTRY \
- && npm install -g pnpm@latest-10
+ && npm install -g pnpm@latest-11
 
 WORKDIR /frontend
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,18 @@ packages:
   # include packages in subfolders (change as required)
   - 'src/**'
 
+# pnpm v11 requires explicit approval for every package that has install scripts.
+# 1. @swc/core for transpilation
+# 2. sharp for image optimisation
+# 3. @parcel/watcher (next-intl dev file-watching)
+# 4. cypress (test runner binary)
+allowBuilds:
+  '@swc/core': true
+  sharp: true
+  '@parcel/watcher': true
+  cypress: true
+
+# Kept for compatibility with pnpm v9/v10 workspaces.
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@swc/core'


### PR DESCRIPTION
## What

Upgrade the project from pnpm v10 to pnpm v11 across all install surfaces.

## Why

pnpm v11 changed how build scripts of dependencies are controlled.
Running `pnpm install` with v11 and the old v10 configuration fails with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.5.6, @swc/core@1.x, cypress@15.x, sharp@0.34.x
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

In v9/v10, `onlyBuiltDependencies` silently skipped unlisted packages.
In v11, **every** package with an install script must be explicitly approved
(`true`) or denied (`false`) via the new `allowBuilds` map.

## Changes

### `pnpm-workspace.yaml`
- Added `allowBuilds` map (pnpm v11 requirement)
- **Approved** (`true`):
  - `@swc/core` — Next.js transpilation
  - `sharp` — Next.js image optimisation
  - `@parcel/watcher` — dev-only file watching (pulled by `next-intl`)
  - `cypress` — E2E test runner binary
- Retained `onlyBuiltDependencies` for compatibility with pnpm v9/v10

### `Dockerfile` / `.devcontainer/Dockerfile`
- `pnpm@latest-10` → `pnpm@latest-11`

### `.github/workflows/build_deploy.yml`
- Updated to `version: 11`

## How to Verify

```bash
# Requires pnpm >= 11
pnpm --version

# Must complete with no ERR_PNPM_IGNORED_BUILDS error
CI=true pnpm ci

# Must produce a successful Next.js build
pnpm build
```