### PR TITLE
fix(sort): Add sorting to license clearing page

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -235,6 +235,20 @@ const tableIdToUrlParamMapper: Record<string, string> = {
     state: 'clearingState',
 }
 
+const comparator = (a: TypedProject | TypedRelease, b: TypedProject | TypedRelease): number => {
+    if (a.type === 'release' && b.type === 'project') {
+        return -1
+    } else if (a.type === 'project' && b.type === 'release') {
+        return 1
+    } else {
+        const aName = `${a.entity.name} ${!CommonUtils.isNullEmptyOrUndefinedString(a.entity.version) && `(${a.entity.version})`}`
+        const bName = `${b.entity.name} ${!CommonUtils.isNullEmptyOrUndefinedString(b.entity.version) && `(${b.entity.version})`}`
+        if (aName === bName) return 0
+        else if (aName < bName) return -1
+        else return 1
+    }
+}
+
 const buildTable = (
     licenseClearing: LicenseClearing,
     linkedProjects: Project[],
@@ -253,6 +267,7 @@ const buildTable = (
     )
     path.splice(0, path.length)
     extractLinkedReleases(projectName, projectVersion, licenseClearing, finalData, path)
+    finalData.sort(comparator)
     return finalData
 }
 

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -164,6 +164,27 @@ const stateFilterOptions: FilterOption[] = [
     },
 ]
 
+const comparator = (a: NestedRows<TypedProject | TypedRelease>, b: NestedRows<TypedProject | TypedRelease>): number => {
+    if (a.node.type === 'release' && b.node.type === 'project') {
+        return -1
+    } else if (a.node.type === 'project' && b.node.type === 'release') {
+        return 1
+    } else {
+        const aName = `${a.node.entity.name} ${!CommonUtils.isNullEmptyOrUndefinedString(a.node.entity.version) && `(${a.node.entity.version})`}`
+        const bName = `${b.node.entity.name} ${!CommonUtils.isNullEmptyOrUndefinedString(b.node.entity.version) && `(${b.node.entity.version})`}`
+        if (aName === bName) return 0
+        else if (aName < bName) return -1
+        else return 1
+    }
+}
+
+const sortAllLevels = (rows: NestedRows<TypedProject | TypedRelease>[]) => {
+    for (const r of rows) {
+        if (r.children && r.children.length !== 0) sortAllLevels(r.children)
+    }
+    rows.sort(comparator)
+}
+
 const buildTable = (
     setRowData: Dispatch<SetStateAction<NestedRows<TypedProject | TypedRelease>[]>>,
     licenseClearing: LicenseClearing,
@@ -185,10 +206,14 @@ const buildTable = (
         releaseRows.push(nodeRelease)
     }
 
-    setRowData([
+    const rows = [
         ...linkedProjectRows,
         ...releaseRows,
-    ])
+    ]
+
+    sortAllLevels(rows)
+
+    setRowData(rows)
 }
 
 const extractLinkedProjectsAndTheirLinkedReleases = (


### PR DESCRIPTION
- First list all Releases sorted by name in ascending order.
- Then list all Projects sorted by name in ascending order.
- When a Project is expanded, the same order (1, 2) should be followed.