### PR TITLE
fix(Project): Differentiate and fixed create project clearing report from generate license info

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "Vollständiger Name ist nicht null oder leer!",
     "Fullname shortname should not be null or empty": "Vollständiger Name und Kurzname sollten nicht null oder leer sein",
     "Further properties": "Weitere Eigenschaften",
+    "CREATE PROJECT CLEARING REPORT": "PROJEKTFREIGABEBERICHT ERSTELLEN",
     "GENERATE LICENSE INFORMATION": "Lizenzinformationen erstellen",
     "GENERATE SOURCE CODE BUNDLE": "QUELLCODEBUNDLE GENERIEREN",
     "GNU arch": "GNU arch",

--- a/messages/en.json
+++ b/messages/en.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "Fullname not null or empty",
     "Fullname shortname should not be null or empty": "Fullname, shortname should not be null or Empty",
     "Further properties": "Further properties",
+    "CREATE PROJECT CLEARING REPORT": "CREATE PROJECT CLEARING REPORT",
     "GENERATE LICENSE INFORMATION": "GENERATE LICENSE INFORMATION",
     "GENERATE SOURCE CODE BUNDLE": "GENERATE SOURCE CODE BUNDLE",
     "GNU arch": "GNU arch",

--- a/messages/es.json
+++ b/messages/es.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "¡El nombre completo no es nulo ni está vacío!",
     "Fullname shortname should not be null or empty": "Nombre completo, nombre corto no debe ser nulo o vacío",
     "Further properties": "Otras propiedades",
+    "CREATE PROJECT CLEARING REPORT": "CREAR INFORME DE COMPENSACIÓN DEL PROYECTO",
     "GENERATE LICENSE INFORMATION": "Generar información de licencia",
     "GENERATE SOURCE CODE BUNDLE": "GENERAR PAQUETE DE CÓDIGO FUENTE",
     "GNU arch": "Archivo de GNU",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "Nom complet ni nul ni vide !",
     "Fullname shortname should not be null or empty": "Nom complet, nom court ne doit pas être nul ou vide",
     "Further properties": "Autres propriétés",
+    "CREATE PROJECT CLEARING REPORT": "CRÉER UN RAPPORT DE COMPENSATION DE PROJET",
     "GENERATE LICENSE INFORMATION": "Générer des informations de licence",
     "GENERATE SOURCE CODE BUNDLE": "GÉNÉRER UN GROUPE DE CODE SOURCE",
     "GNU arch": "Arche GNU",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "フルネームが null または空ではありません!",
     "Fullname shortname should not be null or empty": "フルネーム、ショートネームはnullまたは空であってはなりません",
     "Further properties": "さらなるプロパティ",
+    "CREATE PROJECT CLEARING REPORT": "プロジェクト清算レポートの作成",
     "GENERATE LICENSE INFORMATION": "ライセンス情報を生成します",
     "GENERATE SOURCE CODE BUNDLE": "ソースコードバンドルの生成",
     "GNU arch": "GNU アーチ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "전체 이름은 null이거나 비어 있지 않습니다!",
     "Fullname shortname should not be null or empty": "전체 이름, 단축 이름은 null이거나 비어 있을 수 없습니다.",
     "Further properties": "추가 속성",
+    "CREATE PROJECT CLEARING REPORT": "프로젝트 청산 보고서 생성",
     "GENERATE LICENSE INFORMATION": "라이센스 정보를 생성합니다",
     "GENERATE SOURCE CODE BUNDLE": "소스 코드 번들 생성",
     "GNU arch": "GNU 아카이브",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "Nome completo não nulo ou vazio!",
     "Fullname shortname should not be null or empty": "Nome completo, nome abreviado não deve ser nulo ou vazio",
     "Further properties": "Propriedades adicionais",
+    "CREATE PROJECT CLEARING REPORT": "CRIAR RELATÓRIO DE COMPENSAÇÃO DO PROJETO",
     "GENERATE LICENSE INFORMATION": "Gerar informações de licença",
     "GENERATE SOURCE CODE BUNDLE": "GERAR PACOTE DE CÓDIGO FONTE",
     "GNU arch": "Arco GNU",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "Tên đầy đủ không rỗng hoặc trống!",
     "Fullname shortname should not be null or empty": "Tên đầy đủ, tên viết tắt không được rỗng hoặc trống",
     "Further properties": "Tài sản hơn nữa",
+    "CREATE PROJECT CLEARING REPORT": "TẠO BÁO CÁO THANH TOÁN DỰ ÁN",
     "GENERATE LICENSE INFORMATION": "Tạo thông tin giấy phép",
     "GENERATE SOURCE CODE BUNDLE": "TẠO BỘ MÃ NGUỒN",
     "GNU arch": "Vòm GNU",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "全名不为空！",
     "Fullname shortname should not be null or empty": "全名、简称不得为空或为空",
     "Further properties": "进一步的属性",
+    "CREATE PROJECT CLEARING REPORT": "创建项目清算报告",
     "GENERATE LICENSE INFORMATION": "生成许可证信息",
     "GENERATE SOURCE CODE BUNDLE": "生成源代码包",
     "GNU arch": "GNU 拱门",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -687,6 +687,7 @@
     "Fullname not null or empty": "全名不為空！",
     "Fullname shortname should not be null or empty": "全名、簡稱不得為空或為空",
     "Further properties": "進一步的屬性",
+    "CREATE PROJECT CLEARING REPORT": "建立專案清算報告",
     "GENERATE LICENSE INFORMATION": "生成許可證信息",
     "GENERATE SOURCE CODE BUNDLE": "產生原始碼包",
     "GNU arch": "GNU 拱門",

--- a/src/app/[locale]/projects/components/Obligations/Obligations.tsx
+++ b/src/app/[locale]/projects/components/Obligations/Obligations.tsx
@@ -43,7 +43,7 @@ function Obligations({ projectId, actionType, payload, setPayload }: Props): JSX
     const generateLicenseInfo = (withSubProjects: boolean) => {
         const isCalledFromProjectLicenseTab = false
         sessionStorage.setItem('isCalledFromProjectLicenseTab', JSON.stringify(isCalledFromProjectLicenseTab))
-        router.push(`/projects/generateLicenseInfo/${projectId}?withSubProjects=${withSubProjects}`)
+        router.push(`/projects/generateLicenseInfo/${projectId}?withSubProjects=${withSubProjects}&variant=REPORT`)
     }
 
     return (

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
@@ -144,13 +144,14 @@ export default function DownloadLicenseInfoModal({
             } catch {
                 // Response was plain text (no warnings) - continue normally
             }
+            const variant = params.get('variant') ?? 'DISCLOSURE'
             const downloadUrl = CommonUtils.createUrlWithParams(`reports`, {
                 withlinkedreleases: 'false',
                 projectId,
                 module: 'licenseInfo',
                 withSubProject: withSubProject ? 'true' : 'false',
                 generatorClassName,
-                variant: 'DISCLOSURE',
+                variant,
                 selectedRelRelationship,
             })
             const mailEnabled = mailRequestForReport === 'true'

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -967,7 +967,11 @@ function GenerateLicenseInfo({
             <div className='container page-content'>
                 <div className='row'>
                     <div className='row d-flex justify-content-between'>
-                        <div className='col-auto buttonheader-title'>{t('GENERATE LICENSE INFORMATION')}</div>
+                        <div className='col-auto buttonheader-title'>
+                            {isCalledFromProjectLicenseTab
+                                ? t('GENERATE LICENSE INFORMATION')
+                                : t('CREATE PROJECT CLEARING REPORT')}
+                        </div>
                         <div className='col-auto text-truncate buttonheader-title'>
                             {project && `${project.name} ${project.version !== undefined && `(${project.version})`}`}
                         </div>


### PR DESCRIPTION
## Summary

This PR differentiates the **Create Project Clearing Report** flow from the **Generate License Information** flow, which previously shared the same page and download behavior without distinction.

**Changes made:**
- Added `variant=REPORT` query param to the URL when navigating from the **"Create Project Clearing Report"** button in the Obligations tab (`Obligations.tsx`)
- Updated `DownloadLicenseInfoModal.tsx` to read `variant` from the URL params instead of hardcoding `DISCLOSURE`, falling back to `DISCLOSURE` when not present — so the correct variant is sent to the backend reports API
- Updated `GenerateLicenseInfo.tsx` to show **"CREATE PROJECT CLEARING REPORT"** as the page title when accessed from the Obligations tab, and **"GENERATE LICENSE INFORMATION"** when accessed from the License Clearing tab
- Added the `"CREATE PROJECT CLEARING REPORT"` translation key to all 10 locale files (`en`, `de`, `es`, `fr`, `ja`, `ko`, `pt-BR`, `vi`, `zh-CN`, `zh-TW`)

**New/updated dependencies:** None

Closes: https://github.com/eclipse-sw360/sw360-frontend/issues/1771

---

### Suggest Reviewer

> @GMishx @amritkv .

---

### How To Test?

1. Open any project and navigate to the **Obligations** tab
2. Click **"Create Project Clearing Report"** → select "Projects only" or "Projects with sub projects"
3. Verify the page title shows **"CREATE PROJECT CLEARING REPORT"** (not "GENERATE LICENSE INFORMATION")
4. Click **Download** and verify the report is downloaded with `variant=REPORT` sent to the backend
5. Navigate to the **License Clearing** tab of the same project
6. Click **"Create Project Clearing Report"** from there
7. Verify the page title shows **"GENERATE LICENSE INFORMATION"** and the download uses `variant=DISCLOSURE`

No additional automated tests were added.

---

### Checklist

Must:
- [ ] All related issues are referenced in commit messages and in PR

