### PR TITLE
fix(redirect): Redirect user to path after auth

### DIFF
--- a/src/components/sw360/AuthScreen/AuthScreen.tsx
+++ b/src/components/sw360/AuthScreen/AuthScreen.tsx
@@ -1,5 +1,6 @@
 // Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
 // Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -11,18 +12,20 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { signIn, useSession } from 'next-auth/react'
 import { useLocale, useTranslations } from 'next-intl'
 import { LanguageSwitcher, PageSpinner } from 'next-sw360'
-import { ReactNode, useState } from 'react'
+import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { Alert, Button, Form, InputGroup, Modal } from 'react-bootstrap'
 import { BsEye, BsEyeSlash } from 'react-icons/bs'
 import { CREDENTIALS, KEYCLOAK_PROVIDER, SW360OAUTH_PROVIDER } from '@/constants'
+import { resolveAuthCallbackUrl } from '@/utils/authRedirect.utils'
 import { AUTH_PROVIDER } from '@/utils/env'
 
 function AuthScreen(): ReactNode {
     const router = useRouter()
+    const searchParams = useSearchParams()
     const locale = useLocale()
     const t = useTranslations('default')
     const [dialogShow, setDialogShow] = useState<boolean>(false)
@@ -31,36 +34,65 @@ function AuthScreen(): ReactNode {
     const [password, setPassword] = useState<string>('')
     const { status } = useSession()
     const [showPassword, setShowPassword] = useState<boolean>(false)
+    const rawCallbackUrl = searchParams.get('callbackUrl')
+    const origin = typeof window === 'undefined' ? undefined : window.location.origin
+    const callbackUrl = useMemo(
+        () => resolveAuthCallbackUrl(rawCallbackUrl, locale, origin),
+        [
+            locale,
+            origin,
+            rawCallbackUrl,
+        ],
+    )
+    const isRedirectingToCallback = status === 'authenticated' && rawCallbackUrl !== null
 
     const handleClose = () => setDialogShow(false)
+
+    useEffect(() => {
+        if (isRedirectingToCallback) {
+            router.replace(callbackUrl)
+        }
+    }, [
+        callbackUrl,
+        isRedirectingToCallback,
+        router,
+    ])
+
     const handleShow = () => {
         const authProvider = AUTH_PROVIDER
         if (authProvider === 'keycloak') {
-            void signIn(KEYCLOAK_PROVIDER)
+            void signIn(KEYCLOAK_PROVIDER, {
+                callbackUrl,
+            })
         } else if (authProvider === 'sw360oauth') {
-            void signIn(SW360OAUTH_PROVIDER)
+            void signIn(SW360OAUTH_PROVIDER, {
+                callbackUrl,
+            })
         } else {
             setDialogShow(true)
         }
     }
 
     const handleLogin = async () => {
-        await signIn(CREDENTIALS, {
+        const result = await signIn(CREDENTIALS, {
             username: emailAddress,
             password: password,
             redirect: false,
-        }).then((result) => {
-            if (result === undefined) {
-                setMessageShow(true)
-                return
-            }
-
-            if (result.status === StatusCodes.OK) {
-                router.push(`/${locale}/home`)
-            } else {
-                setMessageShow(true)
-            }
+            callbackUrl,
         })
+
+        if (result === undefined) {
+            setMessageShow(true)
+            return
+        }
+
+        if (result.status === StatusCodes.OK) {
+            const resolvedResultUrl = resolveAuthCallbackUrl(result.url, locale, origin)
+            router.replace(resolvedResultUrl)
+            return
+        }
+
+        setMessageShow(true)
     }
 
     return (
@@ -70,7 +102,7 @@ function AuthScreen(): ReactNode {
                 id='portlet_sw360_portlet_welcome'
             >
                 <div>
-                    {status == 'loading' ? (
+                    {status === 'loading' || isRedirectingToCallback ? (
                         <PageSpinner />
                     ) : (
                         <div className='authscreen'>
@@ -104,7 +136,7 @@ function AuthScreen(): ReactNode {
                                             <Button
                                                 variant='primary'
                                                 size='lg'
-                                                href='/home'
+                                                href={callbackUrl}
                                             >
                                                 {t('Start')}
                                             </Button>

--- a/src/utils/authRedirect.utils.ts
+++ b/src/utils/authRedirect.utils.ts
@@ -1,0 +1,76 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+import { locales } from '../object-types/Constants'
+
+export const getLocalizedHomePath = (locale: string): string => `/${locale}/home`
+
+const isWelcomePath = (pathname: string, locale: string): boolean => {
+    const normalizedPath = pathname.endsWith('/') && pathname.length > 1 ? pathname.slice(0, -1) : pathname
+
+    return normalizedPath === '' || normalizedPath === '/' || normalizedPath === `/${locale}`
+}
+
+const toInternalPath = (url: URL): string => `${url.pathname}${url.search}${url.hash}`
+
+const hasLocalePrefix = (pathname: string): boolean => {
+    return locales.some(
+        (supportedLocale) => pathname === `/${supportedLocale}` || pathname.startsWith(`/${supportedLocale}/`),
+    )
+}
+
+const normalizeInternalPath = (pathname: string, locale: string): string => {
+    if (!pathname.startsWith('/')) {
+        return getLocalizedHomePath(locale)
+    }
+
+    if (isWelcomePath(pathname, locale)) {
+        return getLocalizedHomePath(locale)
+    }
+
+    if (hasLocalePrefix(pathname)) {
+        return pathname
+    }
+
+    return `/${locale}${pathname}`
+}
+
+export const resolveAuthCallbackUrl = (
+    rawCallbackUrl: string | null | undefined,
+    locale: string,
+    origin?: string,
+): string => {
+    const fallbackPath = getLocalizedHomePath(locale)
+
+    if (!rawCallbackUrl) {
+        return fallbackPath
+    }
+
+    if (rawCallbackUrl.startsWith('/') && !rawCallbackUrl.startsWith('//')) {
+        return normalizeInternalPath(rawCallbackUrl, locale)
+    }
+
+    if (!origin) {
+        return fallbackPath
+    }
+
+    try {
+        const currentOrigin = new URL(origin)
+        const callbackUrl = new URL(rawCallbackUrl)
+
+        if (callbackUrl.origin !== currentOrigin.origin) {
+            return fallbackPath
+        }
+
+        const internalPath = toInternalPath(callbackUrl)
+        return normalizeInternalPath(internalPath, locale)
+    } catch {
+        return fallbackPath
+    }
+}


### PR DESCRIPTION
If user opens a direct link for the first time, they are redirected to home page with `callbackUrl=` parameter. Once they come back authenticated, this value is ignored.

This change makes sure the user is redirected back to localized path once authenticated.