### PR TITLE
fix(color): Applied soften colors globally

### DIFF
--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -1055,7 +1055,7 @@ function Project(): JSX.Element {
                 },
                 {
                     key: 'PHASE_OUT',
-                    text: t('PhaseOut'),
+                    text: t('Phaseout'),
                 },
                 {
                     key: 'UNKNOWN',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -567,6 +567,22 @@ body {
     background-color: #ffd350 !important;
 }
 
+.badge.bg-success {
+    background-color: #69c17d !important;
+}
+
+.badge.bg-danger {
+    background-color: #e6717c !important;
+}
+
+.badge.bg-secondary {
+    background-color: #dee2e6 !important;
+}
+
+.badge.bg-warning {
+    background-color: #ffd350 !important;
+}
+
 .spinner {
     color: #f7941e;
 }


### PR DESCRIPTION
## Soften license clearing state badge colors

### What
Override Bootstrap's default `.bg-success`, `.bg-danger`, `.bg-warning`, and `.bg-secondary` background colors with softer, solid SW360 values for the project/release state badges (the `PS`/`CS` capsules) in `globals.css`

### Why
The previous custom overrides weren't applying — the badges rendered in Bootstrap's harsh default colors instead of the intended softer palette.

### Root cause
The custom `.bg-success` rule and Bootstrap's `.bg-success` both used `!important` with identical specificity `(0,1,0)`. With importance and specificity tied, the cascade falls back to source order, and Bootstrap's stylesheet loads last in the final `<head>`, so Bootstrap won.

### How
Scoped each override to `.badge.bg-*`, raising specificity to `(0,2,0)` so it beats Bootstrap's `(0,1,0)` on specificity directly — making the fix independent of stylesheet import order. 


Closes : #1775 