### PR TITLE
fix(frontend): Enforce valid use client directives

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -56,6 +56,11 @@ jobs:
         run: |
           pnpm i
 
+      - name: Check client directives
+        shell: bash
+        run: |
+          pnpm check:client-directives
+
       - name: Run linting
         shell: bash
         run: |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+pnpm check:client-directives
 pnpx lint-staged

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "tsconfig.json",
       "package.json",
       "next.config.ts",
-      "**/*.md"
+      "**/*.md",
+      "scripts/**"
     ]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "NODE_OPTIONS='--inspect' next dev --turbopack",
     "build": "next build",
     "start": "next start",
+    "check:client-directives": "node scripts/check-client-directives.mjs",
     "lint": "biome lint",
     "format": "biome format",
     "lint::fix": "biome lint --fix",

--- a/scripts/check-client-directives.mjs
+++ b/scripts/check-client-directives.mjs
@@ -1,0 +1,183 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+//
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const clientComponentDirectories = [
+    path.join('src', 'app') + path.sep,
+    path.join('src', 'components') + path.sep,
+]
+const fileExtensions = new Set([
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+])
+const invalidDirectives = new Set([
+    'use-client',
+    'used-client',
+])
+const clientMarkers = [
+    /from\s+['"]next-auth\/react['"]/,
+    /from\s+['"][^'"]*authenticatedApi\.util['"]/,
+    /from\s+['"][^'"]*api\.util['"]/,
+    /\bApiUtils\./,
+    /\bwindow\b/,
+    /\bdocument\b/,
+    /\blocation\b/,
+    /\buse(State|Effect|LayoutEffect|Reducer|Ref|Memo|Callback|ImperativeHandle)\b/,
+]
+
+function getMeaningfulFirstStatement(content) {
+    const lines = content.split(/\r?\n/)
+    let inBlockComment = false
+
+    for (const line of lines) {
+        const trimmed = line.trim()
+
+        if (inBlockComment) {
+            if (trimmed.includes('*/')) {
+                inBlockComment = false
+            }
+            continue
+        }
+
+        if (trimmed === '') {
+            continue
+        }
+
+        if (trimmed.startsWith('/*')) {
+            if (!trimmed.includes('*/')) {
+                inBlockComment = true
+            }
+            continue
+        }
+
+        if (trimmed.startsWith('//')) {
+            continue
+        }
+
+        return trimmed.endsWith(';') ? trimmed.slice(0, -1) : trimmed
+    }
+
+    return ''
+}
+
+function isClientComponentFile(relativePath) {
+    return (
+        relativePath.endsWith('.tsx') &&
+        clientComponentDirectories.some((directory) => relativePath.startsWith(directory))
+    )
+}
+
+function hasValidUseClientDirective(content) {
+    const firstStatement = getMeaningfulFirstStatement(content)
+    return firstStatement === "'use client'" || firstStatement === '"use client"'
+}
+
+function findInvalidDirective(content) {
+    const lines = content.split(/\r?\n/)
+    for (const line of lines) {
+        const match = line.trim().match(/^(?<quote>['"])(?<directive>use-client|used-client)\k<quote>;?$/)
+        if (match?.groups?.directive) {
+            return match.groups.directive
+        }
+    }
+    return undefined
+}
+
+function usesClientOnlyPatterns(content) {
+    return clientMarkers.some((pattern) => pattern.test(content))
+}
+
+function normalizePaths(values) {
+    return values
+        .map((value) => value.trim())
+        .filter((value) => value !== '')
+        .map((value) => path.normalize(value))
+        .filter((value) => fileExtensions.has(path.extname(value)))
+        .filter((value) => value.startsWith('src' + path.sep) || value.startsWith('src/'))
+}
+
+function getStagedFiles() {
+    const output = execFileSync(
+        'git',
+        [
+            'diff',
+            '--cached',
+            '--name-only',
+            '--diff-filter=ACMR',
+        ],
+        {
+            cwd: repoRoot,
+            encoding: 'utf8',
+        },
+    )
+    return normalizePaths(output.split(/\r?\n/))
+}
+
+function getTargetFiles(argv) {
+    if (argv.length > 0) {
+        return normalizePaths(argv)
+    }
+
+    return getStagedFiles()
+}
+
+function main() {
+    const targetFiles = getTargetFiles(process.argv.slice(2))
+
+    if (targetFiles.length === 0) {
+        process.exit(0)
+    }
+
+    const issues = []
+
+    for (const relativePath of targetFiles) {
+        const absolutePath = path.join(repoRoot, relativePath)
+
+        if (!fs.existsSync(absolutePath)) {
+            continue
+        }
+
+        const content = fs.readFileSync(absolutePath, 'utf8')
+        const invalidDirective = findInvalidDirective(content)
+
+        if (invalidDirective && invalidDirectives.has(invalidDirective)) {
+            issues.push(`${relativePath}: replace '${invalidDirective}' with 'use client'`)
+            continue
+        }
+
+        if (
+            isClientComponentFile(relativePath) &&
+            usesClientOnlyPatterns(content) &&
+            !hasValidUseClientDirective(content)
+        ) {
+            issues.push(`${relativePath}: add 'use client' as the first statement for client-only component code`)
+        }
+    }
+
+    if (issues.length === 0) {
+        process.exit(0)
+    }
+
+    process.stderr.write('Client directive check failed:\n')
+    for (const issue of issues) {
+        process.stderr.write(`- ${issue}\n`)
+    }
+    process.stderr.write(
+        '\nThis repo is frontend-client-first for now, so staged app/components files with client-only code must declare `use client`.\n',
+    )
+    process.exit(1)
+}
+
+main()

--- a/src/app/[locale]/admin/users/components/EditSecondaryDepartmentsAndRolesModal.tsx
+++ b/src/app/[locale]/admin/users/components/EditSecondaryDepartmentsAndRolesModal.tsx
@@ -9,6 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { StatusCodes } from 'http-status-codes'
 
 import { useTranslations } from 'next-intl'

--- a/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
+++ b/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-'use-client'
+'use client'
 
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'

--- a/src/app/[locale]/home/components/RecentComponentsWidget.tsx
+++ b/src/app/[locale]/home/components/RecentComponentsWidget.tsx
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-'use-client'
+'use client'
 
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'

--- a/src/app/[locale]/home/components/RecentReleasesWidget.tsx
+++ b/src/app/[locale]/home/components/RecentReleasesWidget.tsx
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-'used-client'
+'use client'
 
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'

--- a/src/components/UserEditForm/SecondaryDepartmentsAndRoles.tsx
+++ b/src/components/UserEditForm/SecondaryDepartmentsAndRoles.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { StatusCodes } from 'http-status-codes'
 
 import { useTranslations } from 'next-intl'


### PR DESCRIPTION
## Summary

This PR fixes frontend components affected by invalid or missing `'use client'` directives and adds guardrails so the same issue is caught before merge.

### Changes
- fix invalid directive typos such as `'use-client'` / `'used-client'`
- add missing `'use client'` to client-only components
- add a Husky pre-commit check for client directives
- run the same client-directive check in CI build workflow

### Client directive check

This PR adds a small check script to prevent invalid or missing client component directives.

The script does the following:

- scans staged frontend source files under `src/`
- fails if it finds invalid directive typos like:
  - `'use-client'`
  - `'used-client'`
- checks `.tsx` files in `src/app/` and `src/components/`
- if a file uses obvious client-only patterns, it requires `'use client'` as the first statement

Examples of client-only patterns the script looks for:

- `next-auth/react`
- `ApiUtils`
- browser globals such as `window`, `document`, or `location`
- React client hooks such as `useState`, `useEffect`, `useMemo`, and `useCallback`

This helps enforce the current frontend direction of client-side rendering only and prevents broken directive spellings from reaching CI or deployment.

## Why

Recent stage deployments exposed frontend requests being executed from the wrong runtime boundary. Since the current direction is client-side rendering only, client-only components should explicitly declare `'use client'`, and invalid spellings should fail fast in local checks and CI.

## Scope

This change is limited to the `sw360-frontend` repository.

## How to test

```bash
pnpm check:client-directives
pnpm build
```
