### PR TITLE
fix(frontend): Add use client files using ApiUtils

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/scripts/check-client-directives.mjs
+++ b/scripts/check-client-directives.mjs
@@ -79,6 +79,23 @@ function isClientComponentFile(relativePath) {
     )
 }
 
+function isAppDirectoryFileMakingApiCalls(relativePath, content) {
+    // Check if this is a .tsx file under src/app (any file in the page tree)
+    const isAppFile = relativePath.endsWith('.tsx') && relativePath.startsWith(path.join('src', 'app') + path.sep)
+
+    if (!isAppFile) return false
+
+    // Any file under src/app that makes API calls must be a client component
+    // because they're part of the page tree and could execute server-side
+    const apiCallPatterns = [
+        /from\s+['"][^'"]*authenticatedApi\.util['"]/,
+        /from\s+['"][^'"]*api\.util['"]/,
+        /\bApiUtils\./,
+    ]
+
+    return apiCallPatterns.some((pattern) => pattern.test(content))
+}
+
 function hasValidUseClientDirective(content) {
     const firstStatement = getMeaningfulFirstStatement(content)
     return firstStatement === "'use client'" || firstStatement === '"use client"'
@@ -163,6 +180,13 @@ function main() {
             !hasValidUseClientDirective(content)
         ) {
             issues.push(`${relativePath}: add 'use client' as the first statement for client-only component code`)
+        }
+
+        if (
+            isAppDirectoryFileMakingApiCalls(relativePath, content) &&
+            !hasValidUseClientDirective(content)
+        ) {
+            issues.push(`${relativePath}: files under src/app making API calls must declare 'use client'`)
         }
     }
 

--- a/scripts/check-client-directives.mjs
+++ b/scripts/check-client-directives.mjs
@@ -112,6 +112,10 @@ function findInvalidDirective(content) {
     return undefined
 }
 
+function hasServerSessionUsage(content) {
+    return /\bgetServerSession\b/.test(content)
+}
+
 function usesClientOnlyPatterns(content) {
     return clientMarkers.some((pattern) => pattern.test(content))
 }
@@ -174,6 +178,10 @@ function main() {
             continue
         }
 
+        if (hasValidUseClientDirective(content) && hasServerSessionUsage(content)) {
+            issues.push(`${relativePath}: do not use getServerSession in 'use client' files`)
+        }
+
         if (
             isClientComponentFile(relativePath) &&
             usesClientOnlyPatterns(content) &&
@@ -182,10 +190,7 @@ function main() {
             issues.push(`${relativePath}: add 'use client' as the first statement for client-only component code`)
         }
 
-        if (
-            isAppDirectoryFileMakingApiCalls(relativePath, content) &&
-            !hasValidUseClientDirective(content)
-        ) {
+        if (isAppDirectoryFileMakingApiCalls(relativePath, content) && !hasValidUseClientDirective(content)) {
             issues.push(`${relativePath}: files under src/app making API calls must declare 'use client'`)
         }
     }

--- a/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
+++ b/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, QuickFilter, SW360Table, TableFooter, VendorDialog } from 'next-sw360'
 import React, { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -20,7 +19,6 @@ import { BsXCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Release, Vendor } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface AlertData {
     variant: string
@@ -253,8 +251,6 @@ export default function BulkReleaseEdit(): JSX.Element {
     const [reloadKey, setReloadKey] = useState(1)
     const [search, setSearch] = useState('')
 
-    const session = useSession()
-
     const columns = useMemo<ColumnDef<Release>[]>(
         () => [
             {
@@ -362,7 +358,6 @@ export default function BulkReleaseEdit(): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -373,7 +368,6 @@ export default function BulkReleaseEdit(): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `releases`,
                     Object.fromEntries(
@@ -422,7 +416,6 @@ export default function BulkReleaseEdit(): JSX.Element {
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
         search,
         reloadKey,
     ])

--- a/src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx
+++ b/src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx
@@ -12,14 +12,12 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import { type JSX, useMemo, useState } from 'react'
 import { ErrorDetails, SearchDuplicatesResponse } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 export default function DatabaseSanitation(): JSX.Element {
     const t = useTranslations('default')
@@ -30,12 +28,10 @@ export default function DatabaseSanitation(): JSX.Element {
             duplicates,
         ],
     )
-    const session = useSession()
 
     const searchDuplicate = async () => {
         try {
             setDuplicates(null)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             const response = await ApiUtils.GET('databaseSanitation/searchDuplicate')
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails

--- a/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
+++ b/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
@@ -14,21 +14,18 @@
 import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import { ErrorDetails } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import SecondaryDepartments from './SecondaryDepartments'
 
 const SecondaryDepartmentsTable = (): JSX.Element => {
     const t = useTranslations('default')
-    const session = useSession()
 
     const columns = useMemo<
         ColumnDef<
@@ -98,7 +95,6 @@ const SecondaryDepartmentsTable = (): JSX.Element => {
     const [showProcessing, setShowProcessing] = useState(true)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -109,8 +105,6 @@ const SecondaryDepartmentsTable = (): JSX.Element => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
                 const response = await ApiUtils.GET('departments/members', signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -130,9 +124,7 @@ const SecondaryDepartmentsTable = (): JSX.Element => {
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     const table = useReactTable({
         data: Object.entries(memoizedData),

--- a/src/app/[locale]/admin/licenseTypes/add/components/AddLicenseTypes.tsx
+++ b/src/app/[locale]/admin/licenseTypes/add/components/AddLicenseTypes.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useRef } from 'react'
 import MessageService from '@/services/message.service'
@@ -20,7 +19,6 @@ import ApiUtils from '@/utils/api/authenticatedApi.util'
 
 export default function AddLicenseTypes(): JSX.Element {
     const router = useRouter()
-    const { status } = useSession()
     const t = useTranslations('default')
     const searchValueRef = useRef<HTMLInputElement>(null)
 
@@ -69,7 +67,6 @@ export default function AddLicenseTypes(): JSX.Element {
                             type='submit'
                             id='add_license_type.submit'
                             className='btn btn-primary col-auto me-2'
-                            disabled={status !== 'authenticated'}
                         >
                             {t('Create License Type')}
                         </button>

--- a/src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx
+++ b/src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, QuickFilter, SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -22,7 +21,6 @@ import { Embedded, ErrorDetails, LicenseType } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import DeleteLicenseTypesModal from './DeleteLicenseTypesModal'
 
 type EmbeddedLicenseTypes = Embedded<LicenseType, 'sw360:licenseTypes'>
@@ -35,7 +33,6 @@ export default function LicenseTypesDetail(): ReactNode {
     const [licenseTypeName, setLicenseTypeName] = useState<string>('')
     const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
     const [licenseTypeCount, setLicenseTypeCount] = useState<null | number>(null)
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<LicenseType>[]>(
         () => [
@@ -88,7 +85,6 @@ export default function LicenseTypesDetail(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(true)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -99,7 +95,6 @@ export default function LicenseTypesDetail(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     'licenseTypes',
                     Object.fromEntries(
@@ -135,7 +130,6 @@ export default function LicenseTypesDetail(): ReactNode {
 
         return () => controller.abort()
     }, [
-        session,
         quickFilter,
     ])
 

--- a/src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx
+++ b/src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, JSX, ReactNode, SetStateAction, useRef, useState } from 'react'
 import { Alert, Modal } from 'react-bootstrap'
@@ -20,7 +19,6 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import DeleteAllLicenseInformationModal from './DeleteAllLicenseInformationModal'
 
 type ModalType = 'OSADL' | 'SPDX' | undefined
@@ -51,15 +49,11 @@ function ConfirmationModal({ type, setType }: { type: ModalType; setType: Dispat
         DONE,
     }
     const [state, setState] = useState<ImportState>(ImportState.IMPORT)
-    const session = useSession()
     const [alert, setAlert] = useState<AlertData | null>(null)
 
     const handleImport = async () => {
         try {
             setState(ImportState.LOADING)
-            if (!session.data) {
-                return dispatchSessionExpiredEvent()
-            }
             const response = await ApiUtils.POST(url, {})
             const res = (await response.json()) as ImportResult
             if (response.status !== StatusCodes.OK) {
@@ -157,7 +151,6 @@ export default function LicenseAdministration(): ReactNode {
     const [overwriteIfIdMatchesEvenWithoutExternalIdMatch, setOverwriteIfIdMatchesEvenWithoutExternalIdMatch] =
         useState(false)
     const [confirmationModalType, setConfirmationModalType] = useState<ModalType>(undefined)
-    const session = useSession()
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.currentTarget.files
@@ -176,9 +169,6 @@ export default function LicenseAdministration(): ReactNode {
             const formData = new FormData()
             formData.append('licenseFile', file.current, file.current.name)
 
-            if (!session.data) {
-                return dispatchSessionExpiredEvent()
-            }
             const response = await ApiUtils.POST(
                 `licenses/upload?overwriteIfExternalIdMatches=${
                     overwriteIfExternalIdMatches
@@ -200,7 +190,6 @@ export default function LicenseAdministration(): ReactNode {
 
     const downloadLicenseArchive = () => {
         try {
-            if (!session.data) return dispatchSessionExpiredEvent()
             void DownloadService.download('licenses/downloadLicenses', `LicensesBackup.lics`)
         } catch (error) {
             ApiUtils.reportError(error)

--- a/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Nav, Tab } from 'react-bootstrap'
@@ -20,7 +19,6 @@ import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
 import { Changelogs, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedChangeLogs = Embedded<Changelogs, 'sw360:changeLogs'>
 
@@ -29,7 +27,6 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [changeLogId, setChangeLogId] = useState('')
     const router = useRouter()
-    const session = useSession()
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -52,7 +49,6 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -63,7 +59,6 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${obligationId}`,
                     Object.fromEntries(
@@ -106,7 +101,6 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
     }, [
         pageableQueryParam,
         obligationId,
-        session,
     ])
 
     return (

--- a/src/app/[locale]/admin/obligations/components/Obligations.tsx
+++ b/src/app/[locale]/admin/obligations/components/Obligations.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageButtonHeader, PageSizeSelector, QuickFilter, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -23,7 +22,6 @@ import { BsCheck2Square, BsClipboard, BsFillTrashFill, BsPencil } from 'react-ic
 import { Embedded, ErrorDetails, Obligation, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import { ObligationLevelInfo, ObligationLevels } from '../../../../../object-types/Obligation'
 import DeleteObligationDialog from './DeleteObligationDialog'
 
@@ -33,7 +31,6 @@ function Obligations(): ReactNode {
     const t = useTranslations('default')
     const [search, setSearch] = useState({})
     const [obligationCount, setObligationCount] = useState(0)
-    const session = useSession()
     const [showDeleteDialog, setShowDeleteDialog] = useState(false)
     const [deletedObligationId, setDeletedObligationId] = useState('')
     const router = useRouter()
@@ -199,7 +196,6 @@ function Obligations(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -210,7 +206,6 @@ function Obligations(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `obligations`,
                     Object.fromEntries(
@@ -250,7 +245,6 @@ function Obligations(): ReactNode {
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
         search,
     ])
 

--- a/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
+++ b/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
@@ -11,19 +11,16 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { JSX, useCallback, useEffect, useState } from 'react'
 import { ErrorDetails, ServiceDetailsResponse } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import { ScheduleItem } from './ScheduleItem'
 
 export default function VendorsList(): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
     const [serviceDetails, setServiceDetails] = useState<ServiceDetailsResponse>({})
     const [refreshTrigger, setRefreshTrigger] = useState(0)
 
@@ -35,8 +32,6 @@ export default function VendorsList(): JSX.Element {
         const controller = new AbortController()
 
         const fetchServiceDetails = async () => {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             try {
                 const response = await ApiUtils.GET('schedule/serviceDetails')
                 if (response.status === StatusCodes.OK) {
@@ -52,14 +47,11 @@ export default function VendorsList(): JSX.Element {
 
         return () => controller.abort()
     }, [
-        session,
         refreshTrigger,
     ])
 
     const handleCancelAllTasks = async () => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const response = await ApiUtils.POST('schedule/unscheduleAllServices', {})
             if (response.status === StatusCodes.OK) {
                 setServiceDetails((prev) =>
@@ -74,8 +66,6 @@ export default function VendorsList(): JSX.Element {
                     ),
                 )
                 MessageService.success(t('Every task unscheduled successfully'))
-            } else if (response.status === StatusCodes.UNAUTHORIZED) {
-                return dispatchSessionExpiredEvent()
             } else {
                 const err = (await response.json()) as ErrorDetails
                 throw new ApiError(err.message, {
@@ -93,8 +83,6 @@ export default function VendorsList(): JSX.Element {
         successMessage: string,
     ): Promise<void> => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             let response
 
             if (action === 'unschedule') {
@@ -111,8 +99,6 @@ export default function VendorsList(): JSX.Element {
             if (response.status === StatusCodes.OK) {
                 MessageService.success(successMessage)
                 refreshServiceDetails()
-            } else if (response.status === StatusCodes.UNAUTHORIZED) {
-                return dispatchSessionExpiredEvent()
             } else {
                 const err = (await response.json()) as ErrorDetails
                 throw new ApiError(err.message, {
@@ -126,8 +112,6 @@ export default function VendorsList(): JSX.Element {
 
     const handleTriggerService = async (serviceName: string): Promise<void> => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const response = await ApiUtils.POST(
                 `schedule/triggerService?serviceName=${encodeURIComponent(serviceName)}`,
                 {},
@@ -136,8 +120,6 @@ export default function VendorsList(): JSX.Element {
             if (response.status === StatusCodes.OK) {
                 MessageService.success(t('Task performed successfully'))
                 refreshServiceDetails()
-            } else if (response.status === StatusCodes.UNAUTHORIZED) {
-                return dispatchSessionExpiredEvent()
             } else {
                 const err = (await response.json()) as ErrorDetails
                 throw new ApiError(err.message, {

--- a/src/app/[locale]/admin/users/components/UserAdministration.tsx
+++ b/src/app/[locale]/admin/users/components/UserAdministration.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTa
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { AdvancedSearch, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
@@ -25,7 +24,6 @@ import MessageService from '@/services/message.service'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import BulkUserUpload from './BulkUserUpload'
 import EditSecondaryDepartmentAndRolesModal from './EditSecondaryDepartmentsAndRolesModal'
 
@@ -41,7 +39,6 @@ export default function UserAdminstration(): JSX.Element {
         useState<boolean>(false)
     const [refreshTrigger, setRefreshTrigger] = useState<number>(0)
     const params = useSearchParams()
-    const session = useSession()
 
     const handleAddUsers = () => {
         router.push('/admin/users/add')
@@ -257,7 +254,6 @@ export default function UserAdminstration(): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const _signal = controller.signal
 
@@ -268,7 +264,6 @@ export default function UserAdminstration(): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `users`,
@@ -310,7 +305,6 @@ export default function UserAdminstration(): JSX.Element {
     }, [
         pageableQueryParam,
         params.toString(),
-        session,
         refreshTrigger,
     ])
 

--- a/src/app/[locale]/admin/vendors/components/AddVendor.tsx
+++ b/src/app/[locale]/admin/vendors/components/AddVendor.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useState } from 'react'
 import { Vendor } from '@/object-types'
@@ -22,7 +21,6 @@ import VendorDetailForm from './VendorDetailForm'
 
 export default function AddVendor(): JSX.Element {
     const t = useTranslations('default')
-    const { status } = useSession()
     const router = useRouter()
     const [vendorData, setVendorData] = useState<Vendor | null>({
         fullName: '',

--- a/src/app/[locale]/admin/vendors/components/VendorsList.tsx
+++ b/src/app/[locale]/admin/vendors/components/VendorsList.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, QuickFilter, SW360Table, TableFooter } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -23,7 +22,6 @@ import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Vendor } fr
 import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedVendors = Embedded<Vendor, 'sw360:vendors'>
 
@@ -102,7 +100,6 @@ export default function VendorsList(): JSX.Element {
 
     const [numVendors, setNumVendors] = useState<null | number>(null)
     const [delVendor, setDelVendor] = useState<Vendor | null>(null)
-    const session = useSession()
     const [search, setSearch] = useState({})
 
     const handleAddVendor = () => {
@@ -220,7 +217,6 @@ export default function VendorsList(): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -231,7 +227,6 @@ export default function VendorsList(): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `vendors`,
                     Object.fromEntries(
@@ -271,7 +266,6 @@ export default function VendorsList(): JSX.Element {
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx
+++ b/src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -19,7 +18,6 @@ import { Form, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Vendor } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedVendors = Embedded<Vendor, 'sw360:vendors'>
 
@@ -31,7 +29,6 @@ export default function VendorTable({
     setVendor: Dispatch<SetStateAction<null | Vendor>>
 }>): ReactNode {
     const t = useTranslations('default')
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<Vendor>[]>(
         () => [
@@ -107,7 +104,6 @@ export default function VendorTable({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -118,7 +114,6 @@ export default function VendorTable({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `vendors`,
                     Object.fromEntries(
@@ -154,7 +149,6 @@ export default function VendorTable({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/components/add/components/AddComponent.tsx
+++ b/src/app/[locale]/components/add/components/AddComponent.tsx
@@ -13,7 +13,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { AddAdditionalRoles, AddKeyValue, SearchUsersModal } from 'next-sw360'
 import { ReactNode, useState } from 'react'
@@ -32,14 +31,11 @@ import {
     Vendor,
 } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 function AddComponent(): ReactNode {
     const t = useTranslations('default')
     const router = useRouter()
-    const { data: session } = useSession()
     const [externalIds, setExternalIds] = useState<InputKeyValue[]>([])
     const [addtionalData, setAddtionalData] = useState<InputKeyValue[]>([])
     const [vendor, setVendor] = useState<Vendor>({
@@ -105,7 +101,6 @@ function AddComponent(): ReactNode {
     }
 
     const submit = async () => {
-        if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
         const response = await ApiUtils.POST('components', componentPayload)
 
         if (response.status === StatusCodes.CREATED) {

--- a/src/app/[locale]/components/components/ComponentIndex.tsx
+++ b/src/app/[locale]/components/components/ComponentIndex.tsx
@@ -10,17 +10,16 @@
 // License-Filename: LICENSE
 
 'use client'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Alert, Dropdown } from 'react-bootstrap'
 
 import { AdvancedSearch, PageButtonHeader } from '@/components/sw360'
-import { useConfigValue } from '@/contexts'
+import { useConfigKeyValue, useConfigValue } from '@/contexts'
 import { ConfigKeys, UIConfigKeys, UserGroupType } from '@/object-types'
 import DownloadService from '@/services/download.service'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import ComponentsTable from './ComponentsTable'
 import ImportSBOMModal from './ImportSBOMModal'
 
@@ -29,19 +28,30 @@ const ComponentIndex = (): ReactNode => {
     const [numberOfComponent, setNumberOfComponent] = useState(0)
     const [importModalOpen, setImportModalOpen] = useState(false)
     const [vendorsSuggestions, setVendorsSuggestions] = useState<string[]>([])
-    const { data: session } = useSession()
     const languagesSuggestions = useConfigValue(UIConfigKeys.UI_PROGRAMMING_LANGUAGES) as string[] | null
     const platformsSuggestions = useConfigValue(UIConfigKeys.UI_SOFTWARE_PLATFORMS) as string[] | null
     const osSuggestions = useConfigValue(UIConfigKeys.UI_OPERATING_SYSTEMS) as string[] | null
     const [showExportMessage, setShowExportMessage] = useState(false)
     const [showExportError, setShowExportError] = useState(false)
-    const [exportViaMail, setExportViaMail] = useState<boolean>(false)
+    const exportViaMail = useConfigKeyValue(ConfigKeys.MAIL_REQUEST_FOR_REPORT) === 'true'
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     useEffect(() => {
         const controller = new AbortController()
 
         const fetchVendors = async () => {
-            if (!session) return dispatchSessionExpiredEvent()
             const response = await ApiUtils.GET('vendors')
             if (!controller.signal.aborted && response.ok) {
                 const data = await response.json()
@@ -52,40 +62,12 @@ const ComponentIndex = (): ReactNode => {
             }
         }
 
-        if (session) {
-            fetchVendors()
-        }
+        fetchVendors()
 
         return () => {
             controller.abort()
         }
-    }, [
-        session,
-    ])
-
-    useEffect(() => {
-        const fetchExportConfig = async () => {
-            try {
-                if (!session) return
-
-                const response = await ApiUtils.GET('configurations')
-
-                if (response.ok) {
-                    const configs = await response.json()
-
-                    const mailEnabled = configs[ConfigKeys.MAIL_REQUEST_FOR_REPORT] === 'true'
-
-                    setExportViaMail(mailEnabled)
-                }
-            } catch {
-                setExportViaMail(false)
-            }
-        }
-
-        fetchExportConfig()
-    }, [
-        session,
-    ])
+    }, [])
 
     const handleClickImportSBOM = (e: React.MouseEvent<HTMLElement>) => {
         e.preventDefault()
@@ -97,14 +79,14 @@ const ComponentIndex = (): ReactNode => {
             link: '/components/add',
             type: 'primary',
             name: t('Add Component'),
-            disable: session?.user?.userGroup === UserGroupType.SECURITY_USER,
+            disable: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         'Import SBOM': {
             link: '#',
             type: 'secondary',
             onClick: handleClickImportSBOM,
             name: t('Import SBOM'),
-            hidden: session?.user?.userGroup === UserGroupType.SECURITY_USER,
+            hidden: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
     }
 
@@ -226,7 +208,6 @@ const ComponentIndex = (): ReactNode => {
     ]
 
     const handleExportComponent = async (withLinkedReleases: string) => {
-        if (!session) return dispatchSessionExpiredEvent()
         const currentDate = new Date().toISOString().split('T')[0]
         const mailRequestParam = exportViaMail ? 'true' : 'false'
         const url = `reports?withlinkedreleases=${withLinkedReleases}&mimetype=xlsx&mailrequest=${mailRequestParam}&module=components`

--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -15,7 +15,6 @@ import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTa
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import React, { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -25,7 +24,7 @@ import { Component, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, 
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import DeleteComponentDialog from './DeleteComponentDialog'
 
 interface Props {
@@ -39,8 +38,20 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
     const params = useSearchParams()
     const [deletingComponent, setDeletingComponent] = useState<string>('')
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-    const session = useSession()
     const router = useRouter()
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const handleClickDelete = (componentId: string) => {
         setDeletingComponent(componentId)
@@ -198,7 +209,6 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -209,7 +219,6 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `components`,
@@ -251,7 +260,6 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
     }, [
         pageableQueryParam,
         params.toString(),
-        session,
     ])
 
     useEffect(() => {
@@ -272,7 +280,7 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
         // table state config
         state: {
             columnVisibility: {
-                actions: !(session?.data?.user?.userGroup === UserGroupType.SECURITY_USER),
+                actions: !(userIdentity?.userGroup === UserGroupType.SECURITY_USER),
             },
             pagination: {
                 pageIndex: pageableQueryParam.page,

--- a/src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter, TableSearch } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -19,7 +18,6 @@ import { Form, Spinner } from 'react-bootstrap'
 import { Component, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedComponents = Embedded<Component, 'sw360:components'>
 
@@ -31,7 +29,6 @@ export default function ComponentTable({
     setComponent: Dispatch<SetStateAction<null | Component>>
 }>): ReactNode {
     const t = useTranslations('default')
-    const session = useSession()
     const [search, setSearch] = useState<{
         name: string
         luceneSearch?: boolean
@@ -121,7 +118,6 @@ export default function ComponentTable({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -132,7 +128,6 @@ export default function ComponentTable({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `components`,
                     Object.fromEntries(
@@ -172,7 +167,6 @@ export default function ComponentTable({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
         search,
     ])
 

--- a/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
@@ -14,7 +14,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Col, ListGroup, Row, Spinner, Tab } from 'react-bootstrap'
@@ -41,7 +40,7 @@ import {
 import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import ReleaseOverview from './ReleaseOverview'
 import Summary from './Summary'
 
@@ -61,11 +60,22 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
     const [vulnerData, setVulnerData] = useState<Array<LinkedVulnerability>>([])
     const [attachmentNumber, setAttachmentNumber] = useState<number>(0)
     const [subscribers, setSubscribers] = useState<Array<string>>([])
-    const [userEmail, setUserEmail] = useState<string | undefined>(undefined)
     const [changeLogId, setChangeLogId] = useState('')
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [refreshSubscriptions, setRefreshSubscriptions] = useState(false)
-    const session = useSession()
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     useEffect(() => {
         const fragment = searchParams.get('tab') ?? CommonTabIds.SUMMARY
@@ -80,28 +90,18 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
     }
 
     const downloadBundle = async () => {
-        if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
         await DownloadService.download(
             `${DocumentTypes.COMPONENT}/${componentId}/attachments/download`,
             'AttachmentBundle.zip',
         )
     }
 
-    const extractUserEmailFromSession = () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return
-        setUserEmail(session.data.user.email)
-    }
-
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
-        void extractUserEmailFromSession()
-
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`components/${componentId}`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -122,17 +122,14 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         return () => controller.abort()
     }, [
         componentId,
-        session,
     ])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`components/${componentId}/vulnerabilities`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -151,7 +148,6 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
         return () => controller.abort()
     }, [
         componentId,
-        session,
     ])
 
     const getSubcribersEmail = (component: Component) => {
@@ -161,12 +157,11 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
     }
 
     const isUserSubscribed = () => {
-        if (userEmail === undefined) return false
-        return subscribers.includes(userEmail)
+        if (userIdentity?.email === undefined) return false
+        return subscribers.includes(userIdentity?.email)
     }
 
     const handleSubcriptions = async () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return
         try {
             await ApiUtils.POST(`components/${componentId}/subscriptions`, {})
             setRefreshSubscriptions(!refreshSubscriptions)
@@ -180,19 +175,19 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
             link: `/components/edit/${componentId}`,
             type: 'primary',
             name: t('Edit component'),
-            disable: session?.data?.user?.userGroup === UserGroupType.SECURITY_USER,
+            disable: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         Merge: {
             link: `/components/detail/${componentId}/merge`,
             type: 'secondary',
             name: t('Merge'),
-            hidden: session?.data?.user?.userGroup === UserGroupType.SECURITY_USER,
+            hidden: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         Split: {
             link: `/components/detail/${componentId}/split`,
             type: 'secondary',
             name: t('Split'),
-            hidden: session?.data?.user?.userGroup === UserGroupType.SECURITY_USER,
+            hidden: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         Subscribe: {
             link: '',
@@ -223,7 +218,6 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -234,7 +228,6 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${componentId}`,
                     Object.fromEntries(
@@ -277,7 +270,6 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
     }, [
         pageableQueryParam,
         componentId,
-        session,
     ])
 
     const param = useParams()

--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -16,7 +16,6 @@ import { StatusCodes } from 'http-status-codes'
 import { StaticImport } from 'next/dist/shared/lib/get-img-props'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -28,7 +27,7 @@ import FossologyClearing from '@/components/sw360/FossologyClearing/FossologyCle
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseLink, UserGroupType } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import DeleteReleaseModal from './DeleteReleaseModal'
 
 type EmbeddedLinkedReleases = Embedded<ReleaseLink, 'sw360:releaseLinks'>
@@ -49,7 +48,19 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
     const [fossologyClearingModelOpen, setFossologyClearingModelOpen] = useState(false)
     const [linkingReleaseId, setLinkingReleaseId] = useState<string | undefined>(undefined)
     const [linkToProjectModalOpen, setLinkToProjectModalOpen] = useState(false)
-    const session = useSession()
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const handleClickDelete = (releaseId: string) => {
         setDeletingRelease(releaseId)
@@ -211,7 +222,6 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -222,7 +232,6 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `components/${componentId}/releases`,
                     Object.fromEntries(
@@ -265,7 +274,6 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
 
         return () => controller.abort()
     }, [
-        session,
         componentId,
         pageableQueryParam,
     ])
@@ -279,7 +287,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
         state: {
             columnVisibility: {
                 actions:
-                    !(session?.data?.user?.userGroup === UserGroupType.SECURITY_USER) ||
+                    !(userIdentity?.userGroup === UserGroupType.SECURITY_USER) ||
                     calledFromModerationRequestDetail === undefined ||
                     calledFromModerationRequestDetail === false,
             },

--- a/src/app/[locale]/components/edit/[id]/components/Releases.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/Releases.tsx
@@ -15,7 +15,6 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
@@ -23,7 +22,6 @@ import { SW360Table } from '@/components/sw360'
 import { Embedded, ErrorDetails, LinkedRelease, ReleaseLink } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     componentId: string
@@ -34,7 +32,6 @@ type EmbeddedLinkedReleases = Embedded<LinkedRelease, 'sw360:releaseLinks'>
 const Releases = ({ componentId }: Props): ReactNode => {
     const t = useTranslations('default')
     const router = useRouter()
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<ReleaseLink>[]>(
         () => [
@@ -82,7 +79,6 @@ const Releases = ({ componentId }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -93,7 +89,6 @@ const Releases = ({ componentId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`components/${componentId}/releases`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -120,7 +115,6 @@ const Releases = ({ componentId }: Props): ReactNode => {
 
         return () => controller.abort()
     }, [
-        session,
         componentId,
     ])
 

--- a/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
+++ b/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
@@ -13,7 +13,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound, useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageButtonHeader } from 'next-sw360'
 import { ReactNode, useEffect, useState } from 'react'
@@ -108,7 +107,6 @@ function AddRelease({ componentId }: Props): ReactNode {
         [k: string]: string
     }>({})
 
-    const session = useSession()
     const [activeKey, setActiveKey] = useState(CommonTabIds.SUMMARY)
     const params = useSearchParams()
     const duplicateFromReleaseId = params.get('duplicate')
@@ -133,7 +131,6 @@ function AddRelease({ componentId }: Props): ReactNode {
         if (!duplicateFromReleaseId) return
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`releases/${duplicateFromReleaseId}`)
                 if (response.status === StatusCodes.UNAUTHORIZED) return dispatchSessionExpiredEvent()
                 else if (response.status !== StatusCodes.OK) return notFound()
@@ -221,7 +218,6 @@ function AddRelease({ componentId }: Props): ReactNode {
         if (!componentId) return
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`components/${componentId}`)
                 if (response.status === StatusCodes.UNAUTHORIZED) {
                     return dispatchSessionExpiredEvent()
@@ -245,7 +241,6 @@ function AddRelease({ componentId }: Props): ReactNode {
     ])
 
     const submit = async () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         const response = await ApiUtils.POST('releases', releasePayload)
         if (response.status === StatusCodes.CREATED) {
             const release = (await response.json()) as ReleaseDetail

--- a/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
@@ -513,7 +513,7 @@ const EditRelease = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode => {
             name: t('Delete Release'),
         },
         Cancel: {
-            link: '/components/releases/detail/' + releaseId,
+            link: `/components/releases/detail/${releaseId}?tab=${activeKey ?? CommonTabIds.SUMMARY}`,
             type: 'secondary',
             name: t('Cancel'),
         },

--- a/src/app/[locale]/components/editRelease/[id]/page.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/page.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { getServerSession } from 'next-auth/next'
 import { ReactNode } from 'react'
 import authOptions from '@/app/api/auth/[...nextauth]/authOptions'

--- a/src/app/[locale]/components/editRelease/[id]/page.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/page.tsx
@@ -10,11 +10,9 @@
 
 'use client'
 
-import { getServerSession } from 'next-auth/next'
-import { ReactNode } from 'react'
-import authOptions from '@/app/api/auth/[...nextauth]/authOptions'
-import { ConfigKeys, Configuration } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { type ReactNode, use } from 'react'
+import { useConfigKeyValue } from '@/contexts'
+import { ConfigKeys } from '@/object-types'
 import EditRelease from './components/EditRelease'
 
 interface Context {
@@ -23,20 +21,13 @@ interface Context {
     }>
 }
 
-const ReleaseEditPage = async (props: Context): Promise<ReactNode> => {
-    const params = await props.params
-    const releaseId = params.id
-    const session = await getServerSession(authOptions)
-    if (CommonUtils.isNullOrUndefined(session)) {
-        return null
-    }
-    const response = await ApiUtils.GET('configurations', session.user.access_token)
-    const config = (await response.json()) as Configuration
-    const isSPDXFeatureEnabled = config[ConfigKeys.SPDX_DOCUMENT_ENABLED] == 'true'
+const ReleaseEditPage = ({ params }: Context): ReactNode => {
+    const resolvedParams = use(params)
+    const isSPDXFeatureEnabled = useConfigKeyValue(ConfigKeys.SPDX_DOCUMENT_ENABLED) === 'true'
 
     return (
         <EditRelease
-            releaseId={releaseId}
+            releaseId={resolvedParams.id}
             isSPDXFeatureEnabled={isSPDXFeatureEnabled}
         />
     )

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -14,7 +14,6 @@
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { notFound, useParams, useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Col, Dropdown, ListGroup, Row, Tab } from 'react-bootstrap'
@@ -50,6 +49,7 @@ import {
 import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import ClearingDetails from './ClearingDetails'
 import CommercialDetails from './CommercialDetails'
@@ -80,15 +80,26 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     const [vulnerData, setVulnerData] = useState<Array<LinkedVulnerability>>([])
     const [linkProjectModalShow, setLinkProjectModalShow] = useState<boolean>(false)
     const [subscribers, setSubscribers] = useState<Array<string>>([])
-    const [userEmail, setUserEmail] = useState<string | undefined>(undefined)
     const [changeLogId, setChangeLogId] = useState('')
     const [changelogTab, setChangelogTab] = useState('list-change')
-    const session = useSession()
     const [vulInfo, setVulInfo] = useState([
         0,
         0,
     ])
     const [fileList, setFileList] = useState<SrcFileList | undefined>()
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     useEffect(() => {
         if (!CommonUtils.isNullEmptyOrUndefinedArray(vulnerData)) {
@@ -127,26 +138,20 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
         router.push(`?tab=${key}`)
     }
 
-    const fetchData = useCallback(
-        async (url: string) => {
-            if (CommonUtils.isNullOrUndefined(session.data)) return
-            const response = await ApiUtils.GET(url)
-            if (response.status === StatusCodes.OK) {
-                const data = (await response.json()) as ReleaseDetail &
-                    EmbeddedReleaseLinks &
-                    EmbeddedVulnerabilities &
-                    EmbeddedChangelogs
-                return data
-            } else if (response.status === StatusCodes.UNAUTHORIZED) {
-                return dispatchSessionExpiredEvent()
-            } else {
-                return undefined
-            }
-        },
-        [
-            session,
-        ],
-    )
+    const fetchData = useCallback(async (url: string) => {
+        const response = await ApiUtils.GET(url)
+        if (response.status === StatusCodes.OK) {
+            const data = (await response.json()) as ReleaseDetail &
+                EmbeddedReleaseLinks &
+                EmbeddedVulnerabilities &
+                EmbeddedChangelogs
+            return data
+        } else if (response.status === StatusCodes.UNAUTHORIZED) {
+            return dispatchSessionExpiredEvent()
+        } else {
+            return undefined
+        }
+    }, [])
 
     const getSubcribersEmail = (release: ReleaseDetail) => {
         return release._embedded['sw360:subscribers']
@@ -154,16 +159,7 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
             : []
     }
 
-    const extractUserEmail = () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-        setUserEmail(session.data.user.email)
-    }
-
     useEffect(() => {
-        if (session.status === 'loading') return
-
-        void extractUserEmail()
-
         fetchData(`releases/${releaseId}`)
             .then((release) => {
                 if (CommonUtils.isNullOrUndefined(release)) {
@@ -210,17 +206,14 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     }, [
         fetchData,
         releaseId,
-        session,
     ])
 
     useEffect(() => {
-        if (session.status === 'loading' || CommonUtils.isNullOrUndefined(release)) return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`releases/${releaseId}/licenseFileList`, signal)
                 if (response.status !== StatusCodes.OK) {
                     if (response.status === StatusCodes.CONFLICT) return
@@ -239,7 +232,6 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
 
         return () => controller.abort()
     }, [
-        session,
         releaseId,
         release,
     ])
@@ -265,7 +257,6 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -276,7 +267,6 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${releaseId}`,
                     Object.fromEntries(
@@ -319,11 +309,9 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     }, [
         pageableQueryParam,
         releaseId,
-        session,
     ])
 
     const downloadBundle = async () => {
-        if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
         await DownloadService.download(
             `${DocumentTypes.RELEASE}/${releaseId}/attachments/download`,
             'AttachmentBundle.zip',
@@ -331,8 +319,6 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     }
 
     const handleSubcriptions = async () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return
-
         await ApiUtils.POST(`releases/${releaseId}/subscriptions`, {})
         fetchData(`releases/${releaseId}`)
             .then((release) => {
@@ -344,8 +330,8 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
     }
 
     const isUserSubscribed = () => {
-        if (userEmail === undefined) return false
-        return subscribers.includes(userEmail)
+        const email = userIdentity?.email
+        return email !== undefined && subscribers.includes(email)
     }
 
     const headerButtons = {
@@ -353,7 +339,7 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
             link: `/components/editRelease/${releaseId}`,
             type: 'primary',
             name: t('Edit release'),
-            disable: session?.data?.user?.userGroup === UserGroupType.SECURITY_USER,
+            disable: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         'Link To Project': {
             link: '',
@@ -362,15 +348,15 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 setLinkProjectModalShow(true)
             },
             name: t('Link To Project'),
-            disable: session?.data?.user?.userGroup === UserGroupType.SECURITY_USER,
+            disable: userIdentity?.userGroup === UserGroupType.SECURITY_USER,
         },
         Merge: {
             link: `/components/releases/detail/${releaseId}/merge`,
             type: 'secondary',
             name: t('Merge'),
             hidden:
-                session?.data?.user?.userGroup === UserGroupType.SECURITY_USER ||
-                session?.data?.user?.userGroup === UserGroupType.USER,
+                userIdentity?.userGroup === UserGroupType.SECURITY_USER ||
+                userIdentity?.userGroup === UserGroupType.USER,
         },
         Subscribe: {
             link: '',

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
@@ -19,7 +19,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Alert, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
@@ -31,7 +30,6 @@ import MessageService from '@/services/message.service'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     releaseId: string
@@ -46,7 +44,6 @@ const packageManagerFilterOptions: FilterOption[] = packageManagers.map((pm: str
 
 export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [showFilter, setShowFilter] = useState<undefined | string>()
@@ -202,7 +199,7 @@ export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
 
     const [packagesData, setPackagesData] = useState<LinkedPackage[]>(() => [])
     const deleteLinkedPackage = async () => {
-        if (!selectedPkg || !session.data) return
+        if (!selectedPkg) return
 
         try {
             setDeleting(true)
@@ -251,7 +248,6 @@ export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -262,7 +258,6 @@ export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`releases/${releaseId}`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -286,9 +281,7 @@ export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     const table = useReactTable({
         data: memoizedData,

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, ExpandedState, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
@@ -33,7 +32,6 @@ const Capitalize = (text: string) =>
 
 const LinkedReleases = ({ releaseId }: Props): ReactNode => {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [data, setData] = useState<NestedRows<ReleaseLink>[]>(() => [])
     const [showProcessing, setShowProcessing] = useState(false)
@@ -57,7 +55,6 @@ const LinkedReleases = ({ releaseId }: Props): ReactNode => {
     }
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -99,7 +96,6 @@ const LinkedReleases = ({ releaseId }: Props): ReactNode => {
         return () => controller.abort()
     }, [
         releaseId,
-        session,
     ])
 
     const columns = useMemo<ColumnDef<NestedRows<ReleaseLink>>[]>(

--- a/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
@@ -13,7 +13,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -22,7 +21,6 @@ import { BsExclamationTriangle } from 'react-icons/bs'
 import { Attachment, AttachmentTypes, Embedded, ErrorDetails } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import SPDXLicenseView from './SPDXLicenseView'
 
 interface Props {
@@ -54,7 +52,6 @@ interface SpdxLicensesPayload {
 
 const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [tableData, setTableData] = useState<CellData[]>(() => [])
     const memoizedData = useMemo(
@@ -162,7 +159,6 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
 
     const handleAddSpdxLicenses = async (att: CellData) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             setShowProcessing(true)
             const payload: SpdxLicensesPayload = {
                 mainLicenseIds: att.licenseInfo?.licenseIds ?? [],
@@ -201,7 +197,6 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
 
     const handleShowLicenseInfo = async (attachmentId: string) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             setShowProcessing(true)
             const response = await ApiUtils.GET(`releases/${releaseId}/spdxLicensesInfo?attachmentId=${attachmentId}`)
             if (response.status !== StatusCodes.OK) {
@@ -237,7 +232,6 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
     }
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -248,7 +242,6 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`releases/${releaseId}/attachments`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -298,7 +291,6 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
 
         return () => controller.abort()
     }, [
-        session,
         releaseId,
     ])
 

--- a/src/app/[locale]/components/releases/detail/[id]/components/SPDXLicenseView.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/SPDXLicenseView.tsx
@@ -12,7 +12,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import Button from 'react-bootstrap/Button'
@@ -21,7 +20,6 @@ import { BsInfoCircle } from 'react-icons/bs'
 import { ErrorDetails, FileList, SrcFileList } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface LicenseInfo {
     license: string
@@ -43,25 +41,14 @@ const SPDXLicenseView = ({ isISR, attachmentName, attachmentId, releaseId, licen
     const t = useTranslations('default')
     const [selectedLicenseId, setSelectedLicenseId] = useState<string>()
     const [modalShow, setModalShow] = useState(false)
-    const session = useSession()
     const [fileList, setFileList] = useState<FileList[] | undefined>()
 
     useEffect(() => {
-        if (session.status === 'unauthenticated') {
-            dispatchSessionExpiredEvent()
-        }
-    }, [
-        session.status,
-    ])
-
-    useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(
                     `releases/${releaseId}/licenseFileList?attachmentId=${attachmentId}`,
                     signal,
@@ -82,7 +69,6 @@ const SPDXLicenseView = ({ isISR, attachmentName, attachmentId, releaseId, licen
 
         return () => controller.abort()
     }, [
-        session,
         releaseId,
         attachmentId,
     ])

--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
@@ -10,14 +10,12 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 import { useConfigKeyValue } from '@/contexts'
 import { Attachment, ConfigKeys, ErrorDetails, Release, ReleaseDetail } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import AdditionalDataSection from './AdditionalDataSection'
 import Attachments from './Attachments'
 import ClearingDetailsSection from './ClearingDetailsSection'
@@ -45,19 +43,16 @@ export default function MergeReleaseDataCheck({
     finalReleasePayload: Release | null
     setFinalReleasePayload: Dispatch<SetStateAction<null | Release>>
 }): ReactNode {
-    const session = useSession()
     const [sourceReleaseDetail, setSourceReleaseDetail] = useState<ReleaseDetail | null>()
     const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
     const showLinkedReleases = isNestedReleaseEnabled !== 'false'
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(`releases/${sourceRelease?.id}`, {
                     allDetails: 'true',
                 })
@@ -79,7 +74,6 @@ export default function MergeReleaseDataCheck({
 
         return () => controller.abort()
     }, [
-        session,
         sourceRelease?.id,
     ])
 

--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseTable.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseTable.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table, TableSearch } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -19,7 +18,6 @@ import { Form, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, ReleaseDetail } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedReleases = Embedded<ReleaseDetail, 'sw360:releaseLinks'>
 
@@ -35,7 +33,6 @@ export default function MergeReleaseTable({
     releaseId: string | null
 }>): ReactNode {
     const t = useTranslations('default')
-    const session = useSession()
     const [search, setSearch] = useState<{
         name: string
         luceneSearch?: boolean
@@ -116,7 +113,6 @@ export default function MergeReleaseTable({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -127,7 +123,6 @@ export default function MergeReleaseTable({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `components/${componentId}/releases`,
                     Object.fromEntries(
@@ -167,7 +162,6 @@ export default function MergeReleaseTable({
 
         return () => controller.abort()
     }, [
-        session,
         search,
     ])
 

--- a/src/app/[locale]/components/releases/detail/[id]/page.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/page.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { getServerSession } from 'next-auth'
 import { ReactNode } from 'react'
 import authOptions from '@/app/api/auth/[...nextauth]/authOptions'

--- a/src/app/[locale]/components/releases/detail/[id]/page.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/page.tsx
@@ -10,11 +10,9 @@
 
 'use client'
 
-import { getServerSession } from 'next-auth'
-import { ReactNode } from 'react'
-import authOptions from '@/app/api/auth/[...nextauth]/authOptions'
-import { ConfigKeys, Configuration } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils/index'
+import { type ReactNode, use } from 'react'
+import { useConfigKeyValue } from '@/contexts'
+import { ConfigKeys } from '@/object-types'
 import DetailOverview from './components/DetailOverview'
 
 interface Context {
@@ -23,20 +21,13 @@ interface Context {
     }>
 }
 
-const Detail = async (props: Context): Promise<ReactNode> => {
-    const params = await props.params
-    const releaseId = params.id
-    const session = await getServerSession(authOptions)
-    if (CommonUtils.isNullOrUndefined(session)) {
-        return null
-    }
-    const response = await ApiUtils.GET('configurations', session.user.access_token)
-    const configs = (await response.json()) as Configuration
-    const isSPDXFeatureEnabled = configs[ConfigKeys.SPDX_DOCUMENT_ENABLED] == 'true'
+const Detail = ({ params }: Context): ReactNode => {
+    const resolvedParams = use(params)
+    const isSPDXFeatureEnabled = useConfigKeyValue(ConfigKeys.SPDX_DOCUMENT_ENABLED) === 'true'
 
     return (
         <DetailOverview
-            releaseId={releaseId}
+            releaseId={resolvedParams.id}
             isSPDXFeatureEnabled={isSPDXFeatureEnabled}
         />
     )

--- a/src/app/[locale]/ecc/components/ECC.tsx
+++ b/src/app/[locale]/ecc/components/ECC.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, QuickFilter, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -27,7 +26,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedECC = Embedded<ECCInterface, 'sw360:releases'>
 
@@ -36,7 +34,6 @@ const Capitalize = (text: string) =>
 
 function ECC(): ReactNode {
     const t = useTranslations('default')
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<ECCInterface>[]>(
         () => [
@@ -127,7 +124,6 @@ function ECC(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -138,7 +134,6 @@ function ECC(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `ecc`,
                     Object.fromEntries(
@@ -174,7 +169,6 @@ function ECC(): ReactNode {
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/licenses/components/LicensePage.tsx
+++ b/src/app/[locale]/licenses/components/LicensePage.tsx
@@ -14,7 +14,6 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageButtonHeader, PageSizeSelector, QuickFilter, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -33,14 +32,12 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 function LicensePage(): ReactNode {
     const params = useSearchParams()
     const t = useTranslations('default')
     const [search, setSearch] = useState({})
     const [numberLicense, setNumberLicense] = useState(0)
-    const { data: session } = useSession()
     const deleteLicense = params.get('delete')
 
     useEffect(() => {
@@ -171,8 +168,6 @@ function LicensePage(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
-
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `licenses`,
                     Object.fromEntries(

--- a/src/app/[locale]/licenses/detail/components/LicenseDetailOverview.tsx
+++ b/src/app/[locale]/licenses/detail/components/LicenseDetailOverview.tsx
@@ -13,7 +13,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Col, ListGroup, Row, Tab } from 'react-bootstrap'
@@ -34,7 +33,6 @@ import {
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import Detail from './Detail'
 import Obligations from './Obligations'
 import Text from './Text'
@@ -53,7 +51,6 @@ const LicenseDetailOverview = ({ licenseId }: Props): ReactNode => {
     const params = useSearchParams()
     const [changeLogId, setChangeLogId] = useState('')
     const [changelogTab, setChangelogTab] = useState('list-change')
-    const session = useSession()
     const [activeKey, setActiveKey] = useState(LicenseTabIds.DETAILS)
 
     const handleSelect = (key: string | null) => {
@@ -163,7 +160,6 @@ const LicenseDetailOverview = ({ licenseId }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -174,7 +170,6 @@ const LicenseDetailOverview = ({ licenseId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${licenseId}`,
                     Object.fromEntries(
@@ -217,7 +212,6 @@ const LicenseDetailOverview = ({ licenseId }: Props): ReactNode => {
     }, [
         pageableQueryParam,
         licenseId,
-        session,
     ])
 
     return (

--- a/src/app/[locale]/licenses/detail/components/Obligations.tsx
+++ b/src/app/[locale]/licenses/detail/components/Obligations.tsx
@@ -19,7 +19,6 @@ import {
     useReactTable,
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
@@ -27,7 +26,6 @@ import { Form, Spinner } from 'react-bootstrap'
 import { ErrorDetails, LicenseDetail, NestedRows, Obligation } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     licenseId?: string
@@ -38,7 +36,6 @@ interface Props {
 
 const Obligations = ({ licenseId, isEditWhitelist, whitelist, setWhitelist }: Props): ReactNode => {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [globalFilter, setGlobalFilter] = useState('')
     const [obligationData, setObligationData] = useState<Obligation[]>([])
@@ -75,7 +72,6 @@ const Obligations = ({ licenseId, isEditWhitelist, whitelist, setWhitelist }: Pr
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 setShowProcessing(true)
                 const response = await ApiUtils.GET(`licenses/${licenseId}`, signal)
                 if (response.status !== StatusCodes.OK) {
@@ -103,7 +99,6 @@ const Obligations = ({ licenseId, isEditWhitelist, whitelist, setWhitelist }: Pr
         return () => controller.abort()
     }, [
         licenseId,
-        session.data,
         isEditWhitelist,
         setWhitelist,
     ])

--- a/src/app/[locale]/licenses/edit/components/EditLicense.tsx
+++ b/src/app/[locale]/licenses/edit/components/EditLicense.tsx
@@ -13,7 +13,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound, useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageButtonHeader } from 'next-sw360'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
@@ -53,7 +52,6 @@ function EditLicense({ licenseId }: Props): ReactNode {
         checked: false,
         licenseTypeDatabaseId: '',
     })
-    const session = useSession()
     const [activeKey, setActiveKey] = useState(LicenseTabIds.DETAILS)
 
     const handleSelect = (key: string | null) => {
@@ -68,7 +66,6 @@ function EditLicense({ licenseId }: Props): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(`licenses/${licenseId}`, Object.fromEntries(params))
                 const response = await ApiUtils.GET(queryUrl, signal)
                 if (response.status === StatusCodes.UNAUTHORIZED) {

--- a/src/app/[locale]/licenses/edit/components/EditLicenseDetail.tsx
+++ b/src/app/[locale]/licenses/edit/components/EditLicenseDetail.tsx
@@ -13,13 +13,11 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Embedded, ErrorDetails, LicensePayload, LicenseType } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     inputValid: boolean
@@ -41,7 +39,6 @@ const EditLicenseDetail = ({
     const t = useTranslations('default')
     const params = useSearchParams()
     const [licenseTypes, setLicenseTypes] = useState<Array<LicenseType>>([])
-    const session = useSession()
 
     const updateField = (e: React.ChangeEvent<HTMLSelectElement | HTMLInputElement | HTMLTextAreaElement>) => {
         if (e.target.name === 'fullName') {
@@ -66,7 +63,6 @@ const EditLicenseDetail = ({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`licenseTypes`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails

--- a/src/app/[locale]/packages/components/AddMainLicenseModal.tsx
+++ b/src/app/[locale]/packages/components/AddMainLicenseModal.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -19,7 +18,6 @@ import { Button, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, LicenseDetail, Package, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     showMainLicenseModal: boolean
@@ -37,7 +35,6 @@ export default function AddMainLicenseModal({
     const t = useTranslations('default')
     const [newMainLicense, setNewMainLicense] = useState<Array<string>>()
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
-    const session = useSession()
 
     useEffect(() => {
         if (packagePayload.licenseIds && packagePayload.licenseIds.length !== 0 && newMainLicense === undefined) {
@@ -105,14 +102,12 @@ export default function AddMainLicenseModal({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -154,8 +149,6 @@ export default function AddMainLicenseModal({
 
     const handleSearch = async (signal?: AbortSignal) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const queryUrl = CommonUtils.createUrlWithParams(
                 `licenses`,
                 Object.fromEntries(

--- a/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
+++ b/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ShowInfoOnHover } from 'next-sw360'
 import { Dispatch, type FormEvent, type ReactElement, SetStateAction, useEffect, useState } from 'react'
@@ -20,7 +19,6 @@ import SearchReleasesModal from '@/components/sw360/SearchReleasesModal'
 import { ErrorDetails, Package, ReleaseDetail } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import AddMainLicenseModal from './AddMainLicenseModal'
 import DeletePackageModal from './DeletePackageModal'
 import { packageManagers } from './PackageManagers'
@@ -67,7 +65,6 @@ export default function CreateOrEditPackage({
         packageVersion: '',
     })
     const [isPackageUsed, setIsPackageUsed] = useState(false)
-    const session = useSession()
 
     const handleGoBack = () => {
         if (window.history.length > 1) {
@@ -126,16 +123,9 @@ export default function CreateOrEditPackage({
     }
 
     useEffect(() => {
-        if (isEditPage && !CommonUtils.isNullOrUndefined(packageId) && session.status !== 'loading') {
+        if (isEditPage && !CommonUtils.isNullOrUndefined(packageId)) {
             void (async () => {
                 try {
-                    const sessionData = session.data
-                    if (
-                        CommonUtils.isNullOrUndefined(sessionData) ||
-                        CommonUtils.isNullOrUndefined(sessionData?.user?.access_token)
-                    )
-                        return dispatchSessionExpiredEvent()
-
                     const response = await ApiUtils.GET(`packages/${packageId}/usage`)
                     if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
                         const err = (await response.json()) as ErrorDetails

--- a/src/app/[locale]/packages/components/Packages.tsx
+++ b/src/app/[locale]/packages/components/Packages.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTa
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { AdvancedSearch, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -24,7 +23,6 @@ import { Embedded, ErrorDetails, Package, PageableQueryParam, PaginationMeta, Us
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import DeletePackageModal from './DeletePackageModal'
 import { packageManagers } from './PackageManagers'
 
@@ -51,7 +49,6 @@ interface DeletePackageModalMetData {
 }
 
 function Packages(): ReactNode {
-    const { data: session, status } = useSession()
     const t = useTranslations('default')
     const params = useSearchParams()
     const router = useRouter()
@@ -251,15 +248,12 @@ function Packages(): ReactNode {
     )
 
     useEffect(() => {
-        if (status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
         const timeout = setTimeout(() => setShowProcessing(true), packageData.length !== 0 ? 700 : 0)
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
-
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `packages`,

--- a/src/app/[locale]/packages/detail/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/packages/detail/[id]/components/Changelog.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Nav, Tab } from 'react-bootstrap'
@@ -19,7 +18,6 @@ import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
 import { Changelogs, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedChangeLogs = Embedded<Changelogs, 'sw360:changeLogs'>
 
@@ -27,7 +25,6 @@ function ChangeLog({ packageId }: { packageId: string }): ReactNode {
     const t = useTranslations('default')
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [changeLogId, setChangeLogId] = useState('')
-    const session = useSession()
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -50,7 +47,6 @@ function ChangeLog({ packageId }: { packageId: string }): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -61,10 +57,6 @@ function ChangeLog({ packageId }: { packageId: string }): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) {
-                    dispatchSessionExpiredEvent()
-                    return
-                }
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${packageId}`,
                     Object.fromEntries(
@@ -107,7 +99,6 @@ function ChangeLog({ packageId }: { packageId: string }): ReactNode {
     }, [
         pageableQueryParam,
         packageId,
-        session,
     ])
 
     return (

--- a/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
+++ b/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
@@ -12,31 +12,40 @@
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useParams, useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Breadcrumb, ListGroup, Spinner, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ErrorDetails, Package, UserGroupType } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import ChangeLog from './Changelog'
 import Summary from './Summary'
 
 function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
     const t = useTranslations('default')
-    const { data: session, status } = useSession()
     const [summaryData, setSummaryData] = useState<Package | undefined>(undefined)
     const router = useRouter()
     const param = useParams()
     const locale = (param.locale as string) || 'en'
     const packagesPath = `/${locale}/packages`
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
 
     useEffect(() => {
-        if (status !== 'authenticated') return
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
+    useEffect(() => {
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -64,16 +73,10 @@ function PackageDetailTab({ packageId }: { packageId: string }): ReactNode {
         return () => controller.abort()
     }, [
         packageId,
-        session,
-        status,
     ])
 
     const handleEditPackage = () => {
-        if (CommonUtils.isNullOrUndefined(session)) {
-            dispatchSessionExpiredEvent()
-            return
-        }
-        if (session.user.email === summaryData?._embedded?.createdBy?.email) {
+        if (userIdentity?.email === summaryData?._embedded?.createdBy?.email) {
             MessageService.success(t('You are editing the original document'))
             router.push(`/packages/edit/${packageId}`)
         } else {

--- a/src/app/[locale]/preferences/components/TokensTable.tsx
+++ b/src/app/[locale]/preferences/components/TokensTable.tsx
@@ -12,7 +12,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import React, { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -31,7 +30,6 @@ interface Props {
 
 const TokensTable = ({ generatedToken }: Props): ReactNode => {
     const t = useTranslations('default')
-    const session = useSession()
     const [revoked, setRevoked] = useState(false)
 
     const revokeToken = async (tokenName: string) => {
@@ -127,7 +125,6 @@ const TokensTable = ({ generatedToken }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -138,7 +135,6 @@ const TokensTable = ({ generatedToken }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET('users/tokens', signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -163,7 +159,6 @@ const TokensTable = ({ generatedToken }: Props): ReactNode => {
 
         return () => controller.abort()
     }, [
-        session,
         revoked,
         generatedToken,
     ])

--- a/src/app/[locale]/projects/add/page.tsx
+++ b/src/app/[locale]/projects/add/page.tsx
@@ -14,17 +14,17 @@ import { useRouter } from 'next/navigation'
 
 import { useTranslations } from 'next-intl'
 import { Breadcrumb } from 'next-sw360'
-import { type JSX, useEffect, useState } from 'react'
+import { type JSX, useState } from 'react'
 import { Button, Col, ListGroup, Row, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import Administration from '@/components/ProjectAddSummary/Administration'
 import LinkedPackages from '@/components/ProjectAddSummary/LinkedPackages'
 import LinkedReleasesAndProjects from '@/components/ProjectAddSummary/LinkedReleasesAndProjects'
 import Summary from '@/components/ProjectAddSummary/Summary'
+import { useConfigKeyValue } from '@/contexts'
 import { ConfigKeys, InputKeyValue, Project, ProjectPayload, UserGroupType, Vendor } from '@/object-types'
 import MessageService from '@/services/message.service'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 function AddProjects(): JSX.Element {
     const router = useRouter()
@@ -92,27 +92,8 @@ function AddProjects(): JSX.Element {
         packageIds: {},
     })
 
-    const [isDependencyNetworkFeatureEnabled, setDependencyNetworkFeatureEnabled] = useState(false)
-
-    useEffect(() => {
-        ;(async () => {
-            try {
-                const response = await ApiUtils.GET('configurations')
-                if (response.status === StatusCodes.UNAUTHORIZED) {
-                    dispatchSessionExpiredEvent()
-                } else if (response.status !== StatusCodes.OK) {
-                    setDependencyNetworkFeatureEnabled(false)
-                    return
-                }
-                const config = await response.json()
-                setDependencyNetworkFeatureEnabled(
-                    config[ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP] == 'true',
-                )
-            } catch {
-                setDependencyNetworkFeatureEnabled(false)
-            }
-        })()
-    }, [])
+    const isDependencyNetworkFeatureEnabled =
+        useConfigKeyValue(ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) === 'true'
 
     const setExternalUrlsData = (externalUrls: Map<string, string>) => {
         const obj = Object.fromEntries(externalUrls)

--- a/src/app/[locale]/projects/components/LinkProjects.tsx
+++ b/src/app/[locale]/projects/components/LinkProjects.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getSortedRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useRef, useState } from 'react'
@@ -21,7 +20,6 @@ import { BsInfoCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Project, SearchResult } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedProjects = Embedded<Project, 'sw360:projects'>
 type EmbeddedSearchResults = Embedded<SearchResult, 'sw360:searchResults'>
@@ -51,7 +49,6 @@ export default function LinkProjects({
     const [byNameOnly, setByNameOnly] = useState(true)
     const topRef = useRef<HTMLDivElement | null>(null)
     const [linking, setLinking] = useState(false)
-    const session = useSession()
 
     const scrollToTop = () => {
         topRef.current?.scrollTo({
@@ -276,14 +273,13 @@ export default function LinkProjects({
     })
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const handleCheckboxes = (projectId: string) => {
@@ -302,7 +298,6 @@ export default function LinkProjects({
     const handleSearch = async (signal?: AbortSignal) => {
         try {
             setShowProcessing(true)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
 
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
                 // Search by name only using /projects endpoint
@@ -374,9 +369,6 @@ export default function LinkProjects({
                 }
 
                 // Fetch full details for each project
-                const accessToken = session.data?.user.access_token
-                if (!accessToken) return
-
                 const projectPromises = projectIds.map((id) =>
                     ApiUtils.GET(`projects/${id}`, signal)
                         .then((res) => (res.status === StatusCodes.OK ? res.json() : null))
@@ -398,7 +390,6 @@ export default function LinkProjects({
             const data = {
                 linkedProjects: Object.fromEntries(linkProjects),
             }
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
 
             const response = await ApiUtils.PATCH(`projects/${projectId}`, data)
             if (response.status !== StatusCodes.OK) {

--- a/src/app/[locale]/projects/components/Obligations/CompareObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/CompareObligation.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
 import { Button, Col, Form, Modal, OverlayTrigger, Row, Spinner, Tooltip } from 'react-bootstrap'
@@ -21,7 +20,6 @@ import { PageSizeSelector, SW360Table, TableFooter } from '@/components/sw360'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Project } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -41,7 +39,6 @@ export default function CompareObligation({
     const [pid, setPid] = useState('')
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [exactMatch, setExactMatch] = useState(false)
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<Project>[]>(
         () => [
@@ -182,14 +179,13 @@ export default function CompareObligation({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -265,8 +261,6 @@ export default function CompareObligation({
 
     const handleSearch = async (signal?: AbortSignal) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const queryUrl = CommonUtils.createUrlWithParams(
                 `projects`,
                 Object.fromEntries(

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { JSX, useEffect, useMemo, useState } from 'react'
@@ -30,7 +29,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import { ExpandableList } from './ExpandableComponents'
 
 const Capitalize = (text: string) =>
@@ -50,7 +48,6 @@ interface ProjectObligationData extends ObligationData {
 
 export default function LicenseObligation({ projectId }: { projectId: string }): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
 
     const columns = useMemo<
         ColumnDef<
@@ -221,7 +218,6 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
     const [isLoadingObligations, setIsLoadingObligations] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -232,7 +228,6 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects/${projectId}/licenseObligations`,
                     Object.fromEntries(
@@ -267,7 +262,6 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const [linkedProjects, setLinkedProjects] = useState<Project[] | undefined>(() => undefined)
@@ -280,7 +274,6 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
     const [isLoadingLinkedProjects, setIsLoadingLinkedProjects] = useState(false)
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -313,9 +306,7 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
 
         return () => controller.abort()
     }, [
-        session,
         projectId,
-        session,
     ])
 
     const getLinkedProject = (pid: string, p: ProjectInfo[], projects: Project[]) => {

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseDbObligationsModal.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseDbObligationsModal.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
 import { Modal, Spinner } from 'react-bootstrap'
@@ -50,7 +49,6 @@ export default function LicenseDbObligationsModal({
 }): ReactNode {
     const t = useTranslations('default')
     const [obligationIds, setObligationIds] = useState<string[]>([])
-    const session = useSession()
     const [loading, setLoading] = useState(false)
 
     const addObligationsToLicense = async () => {
@@ -262,7 +260,6 @@ export default function LicenseDbObligationsModal({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -273,7 +270,6 @@ export default function LicenseDbObligationsModal({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects/${projectId}/licenseDbObligations`,
                     Object.fromEntries(
@@ -326,7 +322,6 @@ export default function LicenseDbObligationsModal({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
@@ -31,7 +30,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import CompareObligation from '../CompareObligation'
 import { ExpandableList } from './ExpandableComponents'
 import LicenseDbObligationsModal from './LicenseDbObligationsModal'
@@ -52,7 +50,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
     const [showLicenseDbObligationsModal, setShowLicenseDbObligationsModal] = useState(false)
     const [showCompareObligationsModal, setShowCompareObligationsModal] = useState(false)
     const [refresh, setRefresh] = useState(false)
-    const session = useSession()
 
     const detailColumns = useMemo<
         ColumnDef<
@@ -429,7 +426,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -440,7 +436,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects/${projectId}/licenseObligations`,
                     Object.fromEntries(
@@ -491,18 +486,15 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
         refresh,
     ])
 
     useEffect(() => {
-        if (session.status === 'loading' || !selectedProjectId) return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 setShowProcessing(true)
                 const response = await ApiUtils.GET(`projects/${selectedProjectId}/licenseObligations`, signal)
                 if (response.status !== StatusCodes.OK) {
@@ -523,7 +515,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
 
         return () => controller.abort()
     }, [
-        session,
         selectedProjectId,
     ])
 

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
@@ -31,7 +30,6 @@ import {
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     projectId: string
@@ -53,7 +51,6 @@ export default function ObligationTab({
 }: Props): JSX.Element {
     const t = useTranslations('default')
     const [updateCommentModalData, setUpdateCommentModalData] = useState<UpdateCommentModalMetadata | null>(null)
-    const session = useSession()
 
     const detailColumns = useMemo<
         ColumnDef<
@@ -290,7 +287,6 @@ export default function ObligationTab({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -301,7 +297,6 @@ export default function ObligationTab({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects/${projectId}/obligation`,
                     Object.fromEntries(
@@ -358,7 +353,6 @@ export default function ObligationTab({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const detailTable = useReactTable({

--- a/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
@@ -11,16 +11,13 @@
 
 import { ColumnDef, ExpandedState, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Spinner } from 'react-bootstrap'
 import { BsCaretRightFill } from 'react-icons/bs'
 import { PaddedCell, SW360Table } from '@/components/sw360'
 import { NestedRows, TypedEntity } from '@/object-types'
-import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface ViewRelease {
     id: string
@@ -62,7 +59,6 @@ export default function ReleaseView({
     projectId: string
 }>): ReactNode {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [rowData, setRowData] = useState<
         NestedRows<TypedRelease | TypedLicense | TypedLicenseType | TypedObligation>[]
@@ -77,7 +73,6 @@ export default function ReleaseView({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -88,7 +83,6 @@ export default function ReleaseView({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}/licenseObligations?view=true`, signal)
                 const obligations: ObligationsReleaseView = await response.json()
                 const tableData: NestedRows<TypedRelease | TypedLicense | TypedObligation | TypedLicenseType>[] = []

--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -22,7 +22,6 @@ import {
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { AdvancedSearch, Breadcrumb, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
@@ -53,7 +52,7 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import ImportSBOMMetadata from '../../../../object-types/cyclonedx/ImportSBOMMetadata'
 import CreateClearingRequestModal from '../detail/[id]/components/CreateClearingRequestModal'
 import ViewClearingRequestModal from '../detail/[id]/components/ViewClearingRequestModal'
@@ -77,7 +76,6 @@ interface GroupEntry {
 
 function Project(): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
     const params = useSearchParams()
     const router = useRouter()
     const [deleteProjectId, setDeleteProjectId] = useState<string>('')
@@ -110,6 +108,20 @@ function Project(): JSX.Element {
             text: t('None'),
         },
     ])
+
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const handleDeleteProject = (projectId: string, clearingRequestId?: string, clearingState?: string) => {
         setDeleteProjectId(projectId)
@@ -432,7 +444,6 @@ function Project(): JSX.Element {
 
                     const handleSingleAttachmentDownload = async () => {
                         if (attachments.length !== 1) return
-                        if (CommonUtils.isNullOrUndefined(session.data)) return
                         const att = attachments[0]
                         await DownloadService.download(
                             `projects/${id}/attachments/${att.attachmentContentId}`,
@@ -699,13 +710,11 @@ function Project(): JSX.Element {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET('projects/groups', signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -728,12 +737,9 @@ function Project(): JSX.Element {
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -744,8 +750,6 @@ function Project(): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects`,
@@ -787,7 +791,6 @@ function Project(): JSX.Element {
     }, [
         pageableQueryParam,
         params.toString(),
-        session,
     ])
 
     useEffect(() => {
@@ -802,7 +805,6 @@ function Project(): JSX.Element {
 
     // Fetch license clearing counts in batch after project data is loaded
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         if (projectData.length === 0) {
             setLicenseClearingData({})
             return
@@ -810,8 +812,6 @@ function Project(): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
                 const projectIds = projectData
                     .map((project) => project['_links']['self']['href'].split('/').at(-1))
                     .filter((id): id is string => id !== undefined)
@@ -835,7 +835,6 @@ function Project(): JSX.Element {
         })()
     }, [
         projectData,
-        session,
     ])
 
     const table = useReactTable<ProjectWithSubRows>({
@@ -867,8 +866,8 @@ function Project(): JSX.Element {
                 expanded: expandedState,
             }),
             columnVisibility: {
-                actions: !(session.data?.user?.userGroup === UserGroupType.SECURITY_USER),
-                licenseClearing: !(session.data?.user?.userGroup === UserGroupType.SECURITY_USER),
+                actions: !(userIdentity?.userGroup === UserGroupType.SECURITY_USER),
+                licenseClearing: !(userIdentity?.userGroup === UserGroupType.SECURITY_USER),
             },
             pagination: {
                 pageIndex: pageableQueryParam.page,
@@ -936,8 +935,6 @@ function Project(): JSX.Element {
 
     const exportProjectSpreadsheet = async ({ withLinkedRelease }: { withLinkedRelease: boolean }) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const mailEnabled = mailRequestForProjectReport === 'true'
             const searchParamsString = params.toString()
             const baseUrl = withLinkedRelease
@@ -1117,20 +1114,14 @@ function Project(): JSX.Element {
                                         <button
                                             className='btn btn-primary'
                                             onClick={handleAddProject}
-                                            disabled={
-                                                session.status === 'authenticated' &&
-                                                session.data?.user?.userGroup === UserGroupType.SECURITY_USER
-                                            }
+                                            disabled={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                         >
                                             {t('Add Project')}
                                         </button>
                                         <Dropdown>
                                             <Dropdown.Toggle
                                                 variant='secondary'
-                                                hidden={
-                                                    session.status === 'authenticated' &&
-                                                    session.data?.user?.userGroup === UserGroupType.SECURITY_USER
-                                                }
+                                                hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                             >
                                                 {t('Import SBOM')}
                                             </Dropdown.Toggle>

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -21,7 +21,6 @@ import {
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
@@ -235,7 +234,6 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
     const [releaseFilter, setReleaseFilter] = useState<string>('')
     const [searchTerm, setSearchTerm] = useState<string>('')
-    const session = useSession()
     const filteredData = useMemo(
         () => (releaseFilter || searchTerm ? filterRows(data, releaseFilter, searchTerm, saveUsagesPayload) : data),
         [
@@ -280,7 +278,6 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
     }
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -313,11 +310,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
         return () => controller.abort()
     }, [
         projectId,
-        session,
     ])
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -395,7 +390,6 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
         return () => controller.abort()
     }, [
         projectId,
-        session,
     ])
 
     const columns = useMemo<ColumnDef<ExtendedNestedRows<TypedAttachment | TypedRelease | TypedProject>>[]>(

--- a/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
@@ -15,7 +15,7 @@ import { ChangeEvent, Dispatch, type JSX, SetStateAction, useState } from 'react
 import { Alert, Button, Modal } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import { ErrorDetails, VulnerabilityRatingAndActionPayload } from '@/object-types'
-import { ApiError } from '@/utils'
+import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 

--- a/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
@@ -10,13 +10,12 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ChangeEvent, Dispatch, type JSX, SetStateAction, useState } from 'react'
 import { Alert, Button, Modal } from 'react-bootstrap'
 import { BsQuestionCircle } from 'react-icons/bs'
 import { ErrorDetails, VulnerabilityRatingAndActionPayload } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
@@ -55,7 +54,6 @@ export default function ChangeVulnerabilityModal({
     const [alert, setAlert] = useState<AlertData | null>(null)
     const [loading, setLoading] = useState(false)
     const [data, setData] = useState<VulnerabilityRatingAndActionPayload>({})
-    const { data: session } = useSession()
 
     const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target
@@ -73,7 +71,6 @@ export default function ChangeVulnerabilityModal({
     const handleSubmit = async (id: string) => {
         try {
             setLoading(true)
-            if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
             const payload: VulnerabilityRatingAndActionPayload[] = [
                 ...selectedVulnerabilities.values(),
             ]

--- a/src/app/[locale]/projects/detail/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Changelog.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Nav, Tab } from 'react-bootstrap'
@@ -21,7 +20,6 @@ import ChangeLogList from '@/components/ChangeLog/ChangeLogList/ChangeLogList'
 import { Changelogs, Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, UserGroupType } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedChangeLogs = Embedded<Changelogs, 'sw360:changeLogs'>
 
@@ -35,7 +33,6 @@ function ChangeLog({
     const t = useTranslations('default')
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [changeLogId, setChangeLogId] = useState('')
-    const session = useSession()
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -58,7 +55,6 @@ function ChangeLog({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -69,7 +65,6 @@ function ChangeLog({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${projectId}`,
                     Object.fromEntries(
@@ -112,7 +107,6 @@ function ChangeLog({
     }, [
         pageableQueryParam,
         projectId,
-        session,
     ])
 
     return (

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
@@ -20,7 +20,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table, TableSearch } from 'next-sw360'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -171,7 +170,6 @@ const upperCaseWithUnderscore = (text: string | undefined) => {
 
 const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [showFilter, setShowFilter] = useState<undefined | string>()
@@ -442,7 +440,6 @@ const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
     })
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -473,7 +470,6 @@ const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
         return () => controller.abort()
     }, [
         projectId,
-        session.status,
     ])
 
     const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
@@ -21,7 +21,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { FilterComponent, PaddedCell, SW360Table, TableSearch } from 'next-sw360'
 import React, { useEffect, useMemo, useState } from 'react'
@@ -198,7 +197,6 @@ type TypedRelease = TypedEntity<ReleaseClearingState, 'release'>
 const DependencyNetworkTreeView = ({ projectId }: Props) => {
     const t = useTranslations('default')
 
-    const session = useSession()
     const [expandLevel, setExpandLevel] = useState(-1)
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -553,7 +551,6 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
     })
 
     useEffect(() => {
-        if (session.status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -587,7 +584,6 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
         return () => controller.abort()
     }, [
         projectId,
-        session.status,
     ])
 
     const fetchReleasesRecursive = (

--- a/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -22,7 +21,6 @@ import { ECCInterface, Embedded, ErrorDetails, PageableQueryParam, PaginationMet
 import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type EmbeddedProjectReleaseEcc = Embedded<ECCInterface, 'sw360:releases'>
 
@@ -37,7 +35,6 @@ const Capitalize = (text: string) =>
 
 function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<ECCInterface>[]>(
         () => [
@@ -135,7 +132,6 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -146,7 +142,6 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `projects/${projectId}/releases/ecc`,
                     Object.fromEntries(
@@ -185,7 +180,6 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -227,7 +221,6 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
 
     const exportSpreadsheet = () => {
         try {
-            if (CommonUtils.isNullOrUndefined(session)) return dispatchSessionExpiredEvent()
             const currentDate = new Date().toISOString().split('T')[0]
             const eccSpreadSheetName = `releases-${projectName}-${projectVersion}-${currentDate}.xlsx`
             const url = `reports?projectId=${projectId}&module=projectReleaseSpreadSheetWithEcc&mimetype=xlsx`

--- a/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
@@ -13,7 +13,7 @@ import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
 
 import { useTranslations } from 'next-intl'
-import { type JSX, useEffect, useState } from 'react'
+import { type JSX, useState } from 'react'
 import { Button, Dropdown, Nav, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { useConfigKeyValue, useConfigValue } from '@/contexts'
@@ -22,7 +22,6 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import CreateClearingRequestModal from './CreateClearingRequestModal'
 import DependencyNetworkListView from './DependencyNetworkListView'
 import DependencyNetworkTreeView from './DependencyNetworkTreeView'
@@ -54,35 +53,16 @@ function LicenseClearing({
     const router = useRouter()
     const [showCreateClearingRequestModal, setShowCreateClearingRequestModal] = useState(false)
     const [showViewClearingRequestModal, setShowViewClearingRequestModal] = useState(false)
-    const [isDependencyNetworkFeatureEnabled, setDependencyNetworkFeatureEnabled] = useState(false)
 
     // Configs from backend
     const mailRequestForProjectReport = useConfigKeyValue(ConfigKeys.MAIL_REQUEST_FOR_REPORT)
+    const isDependencyNetworkFeatureEnabled =
+        useConfigKeyValue(ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) === 'true'
     const clearingRequestDisabledGroups = useConfigValue(
         UIConfigKeys.UI_ORG_ECLIPSE_SW360_DISABLE_CLEARING_REQUEST_FOR_PROJECT_GROUP,
     ) as string[] | null
     const crIsAllowed = CommonUtils.isCrAllowed(businessUnit, clearingState, clearingRequestDisabledGroups, visibility)
     const disableCrButton = !crIsAllowed
-
-    useEffect(() => {
-        ;(async () => {
-            try {
-                const response = await ApiUtils.GET('configurations?changeable=false')
-                if (response.status === StatusCodes.UNAUTHORIZED) {
-                    dispatchSessionExpiredEvent()
-                } else if (response.status !== StatusCodes.OK) {
-                    setDependencyNetworkFeatureEnabled(false)
-                    return
-                }
-                const config = await response.json()
-                setDependencyNetworkFeatureEnabled(
-                    config[ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP] === 'true',
-                )
-            } catch {
-                setDependencyNetworkFeatureEnabled(false)
-            }
-        })()
-    }, [])
 
     const generateSourceCodeBundle = (withSubProjects: boolean) => {
         router.push(`/projects/generateSourceCode/${projectId}?withSubProjects=${withSubProjects ? 'true' : 'false'}`)

--- a/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
@@ -19,7 +19,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
@@ -29,8 +28,6 @@ import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW3
 import { ErrorDetails, FilterOption, Package, Project, ReleaseClearingStateMapping } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     projectId: string
@@ -70,7 +67,6 @@ const clearingStateFilterOptions: FilterOption[] = [
 
 export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
 
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [showFilter, setShowFilter] = useState<undefined | string>()
@@ -308,7 +304,6 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
     )
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -319,7 +314,6 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}/packages`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -340,12 +334,10 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
 
         return () => controller.abort()
     }, [
-        session,
         projectId,
     ])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -356,7 +348,6 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -377,7 +368,6 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
 
         return () => controller.abort()
     }, [
-        session,
         projectId,
     ])
 

--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -18,7 +18,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
@@ -282,7 +281,6 @@ export default function ListView({
     projectVersion: string
 }): JSX.Element {
     const t = useTranslations('default')
-    const { status, data: session } = useSession()
 
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [sorting, setSorting] = useState<SortingState>([])
@@ -311,34 +309,26 @@ export default function ListView({
 
     const [rowData, setRowData] = useState<(TypedProject | TypedRelease)[]>([])
 
-    const handleShowLicenseFiles = useCallback(
-        async (release: Release) => {
-            setSelectedRelease(release)
-            setShowModal(true)
-            setLicenseFiles([])
+    const handleShowLicenseFiles = useCallback(async (release: Release) => {
+        setSelectedRelease(release)
+        setShowModal(true)
+        setLicenseFiles([])
 
-            if (status === 'authenticated' && session) {
-                try {
-                    const response = await ApiUtils.GET(`releases/${release.id}/attachments`)
+        try {
+            const response = await ApiUtils.GET(`releases/${release.id}/attachments`)
 
-                    if (response.status === StatusCodes.OK) {
-                        const data = await response.json()
-                        const files =
-                            data._embedded?.['sw360:attachments']
-                                ?.filter((att: Attachment) => att.attachmentType === 'LICENSE')
-                                ?.map((att: Attachment) => att.filename) || []
-                        setLicenseFiles(files)
-                    }
-                } catch (error) {
-                    ApiUtils.reportError(error)
-                }
+            if (response.status === StatusCodes.OK) {
+                const data = await response.json()
+                const files =
+                    data._embedded?.['sw360:attachments']
+                        ?.filter((att: Attachment) => att.attachmentType === 'LICENSE')
+                        ?.map((att: Attachment) => att.filename) || []
+                setLicenseFiles(files)
             }
-        },
-        [
-            status,
-            session,
-        ],
-    )
+        } catch (error) {
+            ApiUtils.reportError(error)
+        }
+    }, [])
 
     const columns = useMemo<ColumnDef<TypedProject | TypedRelease>[]>(
         () => [
@@ -665,7 +655,6 @@ export default function ListView({
     })
 
     useEffect(() => {
-        if (status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
         const timeLimit = memoizedLicenseClearing === undefined ? 700 : 0
@@ -700,14 +689,11 @@ export default function ListView({
         })()
         return () => controller.abort()
     }, [
-        status,
         projectId,
-        session,
         columnFilters,
     ])
 
     useEffect(() => {
-        if (status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
         const timeLimit = memoizedLinkedProjects.length !== 0 ? 700 : 0
@@ -734,9 +720,7 @@ export default function ListView({
         })()
         return () => controller.abort()
     }, [
-        status,
         projectId,
-        session,
     ])
 
     useEffect(() => {

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -60,6 +60,20 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     const router = useRouter()
     const searchParams = useSearchParams()
     const DEFAULT_ACTIVE_TAB = 'summary'
+    const TABS = [
+        'summary',
+        'administration',
+        'licenseClearing',
+        'linkedPackages',
+        'obligations',
+        'ecc',
+        'vulnerabilityTrackingStatus',
+        'eventKey',
+        'attachmentUsages',
+        'vulnerabilities',
+        'changeLog',
+    ]
+
     const [activeKey, setActiveKey] = useState(DEFAULT_ACTIVE_TAB)
     const [showExportProjectSbomModal, setShowExportProjectSbomModal] = useState<boolean>(false)
     const [importSBOMMetadata, setImportSBOMMetadata] = useState<ImportSBOMMetadata>({
@@ -81,8 +95,11 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     }, [])
 
     useEffect(() => {
-        const fragment = searchParams.get('tab') ?? DEFAULT_ACTIVE_TAB
-        setActiveKey(fragment)
+        let tab = searchParams.get('tab')
+        if (tab === null || TABS.indexOf(tab) === -1) {
+            tab = DEFAULT_ACTIVE_TAB
+        }
+        setActiveKey(tab)
     }, [
         searchParams,
     ])

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Breadcrumb, ShowInfoOnHover } from 'next-sw360'
 import { type JSX, useEffect, useState } from 'react'
@@ -30,7 +29,7 @@ import {
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import ImportSBOMMetadata from '../../../../../../object-types/cyclonedx/ImportSBOMMetadata'
 import ImportSBOMModal from '../../../components/ImportSBOMModal'
 import LinkProjects from '../../../components/LinkProjects'
@@ -48,7 +47,6 @@ import VulnerabilityTrackingStatusComponent from './VulnerabilityTrackingStatus'
 
 export default function ViewProjects({ projectId }: { projectId: string }): JSX.Element {
     const t = useTranslations('default')
-    const session = useSession()
     const [summaryData, setSummaryData] = useState<SummaryDataType | undefined>(undefined)
     const [clearingDetailCount, setClearingDetailCount] = useState<ClearingDetailsCount | undefined>()
     const [obligationsTotal, setObligationsTotal] = useState<number>(0)
@@ -68,6 +66,19 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         show: false,
         importType: 'CycloneDx',
     })
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     useEffect(() => {
         const fragment = searchParams.get('tab') ?? DEFAULT_ACTIVE_TAB
@@ -82,13 +93,11 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     }
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}/summaryAdministration`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -109,16 +118,13 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         return () => controller.abort()
     }, [
         projectId,
-        session,
     ])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}/clearingDetailsCount`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -135,12 +141,10 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         return () => controller.abort()
     }, [
         projectId,
-        session,
     ])
 
     const handleEditProject = (projectId: string) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-        if (session?.data.user.email === summaryData?.['_embedded']?.['createdBy']?.['email']) {
+        if (userIdentity?.email === summaryData?.['_embedded']?.['createdBy']?.['email']) {
             MessageService.success(t('You are editing the original document'))
             router.push(`/projects/edit/${projectId}?tab=${activeKey}`)
         } else {
@@ -150,8 +154,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     }
 
     useEffect(() => {
-        if (session.status === 'loading') return
-
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -159,11 +161,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
             setObligationsLoading(true)
             setVulnerabilitiesLoading(true)
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) {
-                    dispatchSessionExpiredEvent()
-                    return
-                }
-
                 const response = await ApiUtils.GET(`projects/${projectId}/tabCounts`, signal)
                 const body = (await response.json().catch(() => ({}))) as ProjectDetailTabCounts | ErrorDetails
 
@@ -190,8 +187,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         return () => controller.abort()
     }, [
         projectId,
-        session.status,
-        session.data?.user?.access_token,
     ])
 
     const isVulnerabilitiesDisplayEnabled = summaryData?.enableVulnerabilitiesDisplay ?? false
@@ -263,10 +258,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                 <ListGroup.Item
                                     action
                                     eventKey='licenseClearing'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <div className='my-2'>{t('License Clearing')}</div>
                                 </ListGroup.Item>
@@ -279,10 +271,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                 <ListGroup.Item
                                     action
                                     eventKey='obligations'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <SidebarCountBadge
                                         badgeClassName={
@@ -301,10 +290,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                 <ListGroup.Item
                                     action
                                     eventKey='ecc'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <div className='my-2'>{t('ECC')}</div>
                                 </ListGroup.Item>
@@ -317,20 +303,14 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                 <ListGroup.Item
                                     action
                                     eventKey='attachments'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <div className='my-2'>{t('Attachments')}</div>
                                 </ListGroup.Item>
                                 <ListGroup.Item
                                     action
                                     eventKey='attachmentUsages'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <div className='my-2'>{t('Attachment Usages')}</div>
                                 </ListGroup.Item>
@@ -349,10 +329,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                 <ListGroup.Item
                                     action
                                     eventKey='changeLog'
-                                    hidden={
-                                        session.status === 'authenticated' &&
-                                        session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                    }
+                                    hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
                                     <div className='my-2'>{t('Change Log')}</div>
                                 </ListGroup.Item>
@@ -366,10 +343,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                             variant='primary'
                                             className='me-2 col-auto'
                                             onClick={() => handleEditProject(projectId)}
-                                            disabled={
-                                                session.status === 'authenticated' &&
-                                                session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                            }
+                                            disabled={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                         >
                                             {t('Edit Projects')}
                                         </Button>
@@ -377,10 +351,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                             variant='secondary'
                                             className='col-auto'
                                             onClick={() => setShow(true)}
-                                            disabled={
-                                                session.status === 'authenticated' &&
-                                                session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                            }
+                                            disabled={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                         >
                                             {t('Link to Projects')}
                                         </Button>
@@ -389,10 +360,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 variant='dark'
                                                 id='exportSBOM'
                                                 className='px-2'
-                                                hidden={
-                                                    session.status === 'authenticated' &&
-                                                    session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                                }
+                                                hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                             >
                                                 {t('Import SBOM')}
                                             </Dropdown.Toggle>
@@ -456,10 +424,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 variant='dark'
                                                 id='exportSBOM'
                                                 className='px-2'
-                                                hidden={
-                                                    session.status === 'authenticated' &&
-                                                    session?.data.user?.userGroup === UserGroupType.SECURITY_USER
-                                                }
+                                                hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                             >
                                                 {t('Export SBOM')}
                                             </Dropdown.Toggle>

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectVulnerabilities.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectVulnerabilities.tsx
@@ -11,11 +11,9 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { type JSX, useEffect, useState } from 'react'
 import { Tab, Tabs } from 'react-bootstrap'
 import { Embedded, Project, ProjectData, ProjectVulnerabilityTabType } from '@/object-types'
-import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import VulnerabilityTab from './VulnerabilityTab'
@@ -38,12 +36,9 @@ const extractLinkedProjects = (projectPayload: Project[], projectData: ProjectDa
 }
 
 export default function ProjectVulnerabilities({ projectData }: { projectData: ProjectData }): JSX.Element {
-    const { data: session } = useSession()
     const [data, setData] = useState<ProjectData[]>([])
 
     useEffect(() => {
-        if (CommonUtils.isNullOrUndefined(session)) return
-
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -69,9 +64,7 @@ export default function ProjectVulnerabilities({ projectData }: { projectData: P
         })()
 
         return () => controller.abort(signal)
-    }, [
-        session,
-    ])
+    }, [])
 
     return (
         <>

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -19,7 +19,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { FilterComponent, PaddedCell, SW360Table } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -41,6 +40,7 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import AddLicenseInfoToReleaseModal from './AddLicenseInfoToReleaseModal'
 
 const Capitalize = (text: string) =>
@@ -264,7 +264,6 @@ const tableIdToUrlParamMapper: Record<string, string> = {
 
 export default function TreeView({ projectId }: { projectId: string }): JSX.Element {
     const t = useTranslations('default')
-    const { data: session, status } = useSession()
 
     const [expandLevel, setExpandLevel] = useState(-1)
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
@@ -303,6 +302,20 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
     const showAddLicenseButton = useConfigValue(UIConfigKeys.UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON) as
         | boolean
         | null
+
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const columns = useMemo<ColumnDef<NestedRows<TypedProject | TypedRelease>>[]>(
         () => [
@@ -793,7 +806,6 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
     ])
 
     useEffect(() => {
-        if (status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -826,14 +838,11 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
 
         return () => controller.abort()
     }, [
-        status,
         projectId,
-        session,
         columnFilters,
     ])
 
     useEffect(() => {
-        if (status !== 'authenticated') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -861,9 +870,7 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
 
         return () => controller.abort()
     }, [
-        status,
         projectId,
-        session,
     ])
 
     return (
@@ -882,9 +889,9 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
                             onClick={() => setShow(true)}
                             hidden={
                                 !(
-                                    session?.user.userGroup === UserGroupType.ADMIN ||
-                                    session?.user.userGroup === UserGroupType.CLEARING_ADMIN ||
-                                    session?.user.userGroup === UserGroupType.SW360_ADMIN
+                                    userIdentity?.userGroup === UserGroupType.ADMIN ||
+                                    userIdentity?.userGroup === UserGroupType.CLEARING_ADMIN ||
+                                    userIdentity?.userGroup === UserGroupType.SW360_ADMIN
                                 )
                             }
                         >

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, ShowInfoOnHover, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -131,7 +130,6 @@ export default function VulnerabilityTab({
     tabType: ProjectVulnerabilityTabType
 }): JSX.Element {
     const t = useTranslations('default')
-    const { data: session } = useSession()
     const [totalVulnerabilities, setTotalVulnerabilities] = useState<number | null>(null)
     const hasVulnerabilityDisplay = projectData.enableVulnerabilitiesDisplay ?? false
     const [selectedVulnerabilities, setSelectedVulnerabilities] = useState<
@@ -308,7 +306,7 @@ export default function VulnerabilityTab({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (CommonUtils.isNullOrUndefined(session) || !hasVulnerabilityDisplay) return
+        if (!hasVulnerabilityDisplay) return
 
         const controller = new AbortController()
         const signal = controller.signal
@@ -384,7 +382,6 @@ export default function VulnerabilityTab({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
         hasVulnerabilityDisplay,
         projectData.id,
         tabType,
@@ -445,7 +442,7 @@ export default function VulnerabilityTab({
             )}
             <div className='mt-4 mx-5'>
                 <div className='mb-4'>
-                    <h5 className='header-underlined'>{t('Vulnerability State Information')}</h5>
+                    <h5 className='header-underlined'>{t('Vulnerability Status Information')}</h5>
                     <div className='row'>
                         <div className='col-lg-4'>{t('Security Vulnerabilities Display')}:</div>
                         <div className='col-lg-3'>

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -33,7 +32,6 @@ export default function VulnerabilityTrackingStatusComponent({
     projectData: ProjectData
 }): JSX.Element {
     const t = useTranslations('default')
-    const { data: session } = useSession()
 
     const columns = useMemo<ColumnDef<VulnerabilityTrackingStatus>[]>(
         () => [
@@ -99,7 +97,6 @@ export default function VulnerabilityTrackingStatusComponent({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (CommonUtils.isNullOrUndefined(session)) return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -143,7 +140,6 @@ export default function VulnerabilityTrackingStatusComponent({
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
+++ b/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound, useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Breadcrumb } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useState } from 'react'
@@ -34,7 +33,6 @@ import {
 import MessageService from '@/services/message.service'
 import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     projectId: string
@@ -60,7 +58,6 @@ interface LinkedReleaseData {
 function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Props): JSX.Element {
     const router = useRouter()
     const t = useTranslations('default')
-    const session = useSession()
     const [vendor, setVendor] = useState<Vendor>({
         id: '',
         fullName: '',
@@ -167,11 +164,9 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
     }
 
     const fetchUserData = useCallback(async (url: string) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         const response = await ApiUtils.GET(url)
         if (response.status === StatusCodes.OK) {
-            const data = (await response.json()) as User
-            return data
+            return (await response.json()) as User
         } else if (response.status === StatusCodes.UNAUTHORIZED) {
             MessageService.error(t('Unauthorized request'))
             return
@@ -185,7 +180,6 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
             const linkedReleasesObject: {
                 [key: string]: LinkedReleaseData
             } = {}
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             for (const l of linkedReleases) {
                 const releaseId = l['release']?.split('/').pop()
                 if (releaseId === undefined) continue
@@ -209,10 +203,8 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
     }
 
     useEffect(() => {
-        if (session.status === 'loading') return
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}`)
                 if (response.status !== StatusCodes.OK) {
                     return notFound()
@@ -383,11 +375,9 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
     }, [
         projectId,
         setProjectPayload,
-        session,
     ])
 
     const createProject = async () => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         const createProjectUrl =
             isDependencyNetworkFeatureEnabled === true
                 ? `projects/network/duplicate/${projectId}`

--- a/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
+++ b/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
@@ -163,7 +163,11 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
         })
     }
 
-    const fetchUserData = useCallback(async (url: string) => {
+    const fetchUserData = useCallback(async (email: string | undefined | null) => {
+        if (!email) {
+            return undefined
+        }
+        const url = `users/${email}`
         const response = await ApiUtils.GET(url)
         if (response.status === StatusCodes.OK) {
             return (await response.json()) as User
@@ -238,7 +242,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                 }
 
                 if (project?.projectOwner !== undefined) {
-                    const userData = await fetchUserData(`users/${project?.projectOwner}`)
+                    const userData = await fetchUserData(project?.projectOwner)
                     if (!CommonUtils.isNullOrUndefined(userData)) {
                         setProjectOwner({
                             [project?.projectOwner]: userData?.fullName ?? project?.projectOwner,
@@ -251,7 +255,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                 }
 
                 if (project?.projectResponsible !== undefined) {
-                    const userData = await fetchUserData(`users/${project?.projectResponsible}`)
+                    const userData = await fetchUserData(project?.projectResponsible)
                     if (!CommonUtils.isNullOrUndefined(userData)) {
                         setProjectManager({
                             [project?.projectResponsible]: userData?.fullName ?? project?.projectResponsible,

--- a/src/app/[locale]/projects/duplicate/[id]/page.tsx
+++ b/src/app/[locale]/projects/duplicate/[id]/page.tsx
@@ -9,11 +9,9 @@
 
 'use client'
 
-import { getServerSession } from 'next-auth/next'
-import type { JSX } from 'react'
-import authOptions from '@/app/api/auth/[...nextauth]/authOptions'
-import { ConfigKeys, Configuration } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { type JSX, use } from 'react'
+import { useConfigKeyValue } from '@/contexts'
+import { ConfigKeys } from '@/object-types'
 import DuplicateProject from './components/DuplicateProject'
 
 interface Context {
@@ -22,21 +20,14 @@ interface Context {
     }>
 }
 
-const ProjectDuplicatePage = async (props: Context): Promise<JSX.Element> => {
-    const params = await props.params
-    const projectId = params.id
-
-    const session = await getServerSession(authOptions)
-    if (CommonUtils.isNullOrUndefined(session)) {
-        return <></>
-    }
-    const response = await ApiUtils.GET('configurations', session.user.access_token)
-    const config = (await response.json()) as Configuration
-    const isDependencyNetworkFeatureEnabled = config[ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP] == 'true'
+const ProjectDuplicatePage = ({ params }: Context): JSX.Element => {
+    const resolvedParams = use(params)
+    const isDependencyNetworkFeatureEnabled =
+        useConfigKeyValue(ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) === 'true'
 
     return (
         <DuplicateProject
-            projectId={projectId}
+            projectId={resolvedParams.id}
             isDependencyNetworkFeatureEnabled={isDependencyNetworkFeatureEnabled}
         />
     )

--- a/src/app/[locale]/projects/duplicate/[id]/page.tsx
+++ b/src/app/[locale]/projects/duplicate/[id]/page.tsx
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { getServerSession } from 'next-auth/next'
 import type { JSX } from 'react'
 import authOptions from '@/app/api/auth/[...nextauth]/authOptions'

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -643,7 +643,7 @@ function EditProject({
     }
 
     const handleCancelClick = () => {
-        router.push('/projects')
+        router.push(`/projects/detail/${projectId}?tab=${activeKey ?? DEFAULT_ACTIVE_TAB}`)
     }
 
     return (

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -248,15 +248,14 @@ function EditProject({
         })
     }
 
-    const fetchUserData = useCallback(async (url: string) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
+    const fetchUserData = useCallback(async (email: string | undefined | null) => {
+        if (!email) {
+            return undefined
+        }
+        const url = `users/${email}`
         const response = await ApiUtils.GET(url)
         if (response.status === StatusCodes.OK) {
-            const data = (await response.json()) as User
-            return data
-        } else if (response.status === StatusCodes.UNAUTHORIZED) {
-            MessageService.error(t('Unauthorized request'))
-            return
+            return (await response.json()) as User
         } else {
             return undefined
         }
@@ -345,7 +344,7 @@ function EditProject({
                 }
 
                 if (project?.projectOwner !== undefined) {
-                    const userData = await fetchUserData(`users/${project?.projectOwner}`)
+                    const userData = await fetchUserData(project?.projectOwner)
                     if (!CommonUtils.isNullOrUndefined(userData)) {
                         setProjectOwner({
                             [project?.projectOwner]: userData?.fullName ?? project?.projectOwner,
@@ -358,7 +357,7 @@ function EditProject({
                 }
 
                 if (project?.projectResponsible !== undefined) {
-                    const userData = await fetchUserData(`users/${project?.projectResponsible}`)
+                    const userData = await fetchUserData(project?.projectResponsible)
                     if (!CommonUtils.isNullOrUndefined(userData)) {
                         setProjectManager({
                             [project?.projectResponsible]: userData?.fullName ?? project?.projectResponsible,
@@ -390,7 +389,7 @@ function EditProject({
                     const securityResponsiblesMap = new Map<string, string>()
                     await Promise.all(
                         project.securityResponsibles.map(async (securityResponsible) => {
-                            const userData = await fetchUserData(`users/${securityResponsible}`)
+                            const userData = await fetchUserData(securityResponsible)
                             if (!CommonUtils.isNullOrUndefined(userData)) {
                                 securityResponsiblesMap.set(
                                     securityResponsible,

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound, useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Breadcrumb } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
@@ -43,7 +42,6 @@ import {
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import DeleteProjectDialog from '../../../components/DeleteProjectDialog'
 import Obligations from '../../../components/Obligations/Obligations'
 
@@ -76,8 +74,6 @@ function EditProject({
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
     const [isLoading, setIsLoading] = useState(true)
     const [hasClearingRequest, setHasClearingRequest] = useState(false)
-
-    const session = useSession()
 
     const handleDeleteProject = () => {
         setDeleteDialogOpen(true)
@@ -267,7 +263,6 @@ function EditProject({
     }, [])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -308,13 +303,11 @@ function EditProject({
         return () => controller.abort()
     }, [
         projectId,
-        session.status,
     ])
 
     useEffect(() => {
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`projects/${projectId}`)
                 if (response.status !== StatusCodes.OK) {
                     return notFound()
@@ -528,11 +521,9 @@ function EditProject({
     }, [
         projectId,
         setProjectPayload,
-        session,
     ])
 
     const checkUpdateEligibility = async (projectId: string) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         const url = CommonUtils.createUrlWithParams(`moderationrequest/validate`, {
             entityType: 'PROJECT',
             entityId: projectId,
@@ -565,7 +556,6 @@ function EditProject({
 
     const updateProject = async (payload?: ProjectPayload) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             const dataToUpdate = payload ?? projectPayload
             const requests = [
                 ApiUtils.PATCH(

--- a/src/app/[locale]/projects/edit/[id]/page.tsx
+++ b/src/app/[locale]/projects/edit/[id]/page.tsx
@@ -9,11 +9,9 @@
 
 'use client'
 
-import { getServerSession } from 'next-auth/next'
-import type { JSX } from 'react'
-import authOptions from '@/app/api/auth/[...nextauth]/authOptions'
-import { ConfigKeys, Configuration } from '@/object-types'
-import { ApiUtils, CommonUtils } from '@/utils'
+import { type JSX, use } from 'react'
+import { useConfigKeyValue } from '@/contexts'
+import { ConfigKeys } from '@/object-types'
 import EditProject from './components/EditProject'
 
 interface Context {
@@ -22,19 +20,14 @@ interface Context {
     }>
 }
 
-const ProjectEditPage = async (props: Context): Promise<JSX.Element> => {
-    const params = await props.params
-    const projectId = params.id
-    const session = await getServerSession(authOptions)
-    if (CommonUtils.isNullOrUndefined(session)) {
-        return <></>
-    }
-    const response = await ApiUtils.GET('configurations', session.user.access_token)
-    const config = (await response.json()) as Configuration
-    const isDependencyNetworkFeatureEnabled = config[ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP] == 'true'
+const ProjectEditPage = ({ params }: Context): JSX.Element => {
+    const resolvedParams = use(params)
+    const isDependencyNetworkFeatureEnabled =
+        useConfigKeyValue(ConfigKeys.ENABLE_FLEXIBLE_PROJECT_RELEASE_RELATIONSHIP) === 'true'
+
     return (
         <EditProject
-            projectId={projectId}
+            projectId={resolvedParams.id}
             isDependencyNetworkFeatureEnabled={isDependencyNetworkFeatureEnabled}
         />
     )

--- a/src/app/[locale]/projects/edit/[id]/page.tsx
+++ b/src/app/[locale]/projects/edit/[id]/page.tsx
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { getServerSession } from 'next-auth/next'
 import type { JSX } from 'react'
 import authOptions from '@/app/api/auth/[...nextauth]/authOptions'

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ChangeEvent, Dispatch, ReactNode, SetStateAction, useEffect, useState } from 'react'
 import { Modal } from 'react-bootstrap'
@@ -22,7 +21,6 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 const relationFilterOptions: FilterOption[] = [
     {
@@ -94,7 +92,6 @@ export default function DownloadLicenseInfoModal({
     const [generatorClassName, setGeneratorClassName] = useState('DocxGenerator')
     const [withSubProject, setWithSubProject] = useState(true)
     const [selectedRelRelationship, setSelectedRelRelationship] = useState<string[]>([])
-    const session = useSession()
     const [loading, setLoading] = useState(false)
 
     useEffect(() => {
@@ -113,7 +110,6 @@ export default function DownloadLicenseInfoModal({
 
     const handleLicenseInfoDownload = async (projectId: string) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             setLoading(true)
             const response = await ApiUtils.POST(`projects/${projectId}/saveAttachmentUsages`, saveUsagesPayload)
             if (response.status !== StatusCodes.CREATED) {

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, ExpandedState, getCoreRowModel, getExpandedRowModel, useReac
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -34,7 +33,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import DownloadLicenseInfoModal from './DownloadLicenseInfoModal'
 import LicenseInfoDownloadConfirmationModal from './LicenseInfoDownloadConfirmation'
 
@@ -303,8 +301,6 @@ function GenerateLicenseInfo({
     const [showConfirmation, setShowConfirmation] = useState(false)
     const [isCalledFromProjectLicenseTab, setIsCalledFromProjectLicenseTab] = useState<boolean>(false)
     const [projectRelationships, setProjectRelationships] = useState<string[]>([])
-
-    const session = useSession()
 
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
     const [showProcessing, setShowProcessing] = useState(false)
@@ -752,7 +748,6 @@ function GenerateLicenseInfo({
     }, [])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -763,7 +758,6 @@ function GenerateLicenseInfo({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params)
                 if (Object.hasOwn(searchParams, 'withSubProjects') === false) {
                     return

--- a/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
+++ b/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, ExpandedState, getCoreRowModel, getExpandedRowModel, useReac
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { notFound, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -36,7 +35,6 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -65,8 +63,6 @@ function GenerateSourceCodeBundle({
     })
     const [loading, setLoading] = useState(false)
     const [hideWithUsage, setHideWithUsage] = useState(false)
-
-    const session = useSession()
 
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
     const [showProcessing, setShowProcessing] = useState(false)
@@ -129,7 +125,6 @@ function GenerateSourceCodeBundle({
     }
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -140,7 +135,6 @@ function GenerateSourceCodeBundle({
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params)
                 if (Object.hasOwn(searchParams, 'withSubProjects') === false) {
                     return

--- a/src/app/[locale]/reports/download/page.tsx
+++ b/src/app/[locale]/reports/download/page.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { signIn, useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useCallback, useEffect, useState } from 'react'
 import { Alert, Spinner } from 'react-bootstrap'
@@ -19,7 +18,6 @@ import ApiUtils from '@/utils/api/authenticatedApi.util'
 function ReportDownloadPage(): JSX.Element {
     const t = useTranslations('default')
     const searchParams = useSearchParams()
-    const { data: session, status } = useSession()
     const [error, setError] = useState<string | null>(null)
     const [downloading, setDownloading] = useState(false)
     const [downloaded, setDownloaded] = useState(false)
@@ -29,24 +27,9 @@ function ReportDownloadPage(): JSX.Element {
     const extendedByReleases = searchParams.get('extendedByReleases') ?? 'false'
     const projectId = searchParams.get('projectId') ?? ''
 
-    // Redirect to login if not authenticated
-    useEffect(() => {
-        if (status === 'unauthenticated') {
-            // callbackUrl preserves the full URL so after login it comes back here
-            void signIn('keycloak', {
-                callbackUrl: window.location.href,
-            })
-        }
-    }, [
-        status,
-    ])
-
     const triggerDownload = useCallback(async () => {
         if (!module || !token) {
             setError(t('Missing required parameters (module, token)'))
-            return
-        }
-        if (!session) {
             return
         }
 
@@ -96,30 +79,17 @@ function ReportDownloadPage(): JSX.Element {
         token,
         extendedByReleases,
         projectId,
-        session,
     ])
 
     useEffect(() => {
-        if (status === 'authenticated' && !downloaded && !downloading) {
+        if (!downloaded && !downloading) {
             void triggerDownload()
         }
     }, [
-        status,
         downloaded,
         downloading,
         triggerDownload,
     ])
-
-    if (status === 'loading' || status === 'unauthenticated') {
-        return (
-            <div className='container mt-5 text-center'>
-                <Spinner animation='border' />
-                <p className='mt-2'>
-                    {status === 'loading' ? t('Checking authentication') : t('Redirecting to login')}
-                </p>
-            </div>
-        )
-    }
 
     return (
         <div className='container mt-5'>

--- a/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestInfo.tsx
+++ b/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestInfo.tsx
@@ -10,11 +10,9 @@
 'use client'
 
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode } from 'react'
 import { ClearingRequestDetails } from '@/object-types'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 export default function ClearingRequestInfo({
     data,
@@ -22,54 +20,49 @@ export default function ClearingRequestInfo({
     data: ClearingRequestDetails | undefined
 }>): ReactNode | undefined {
     const t = useTranslations('default')
-    const { status } = useSession()
 
-    if (status === 'unauthenticated') {
-        dispatchSessionExpiredEvent()
-    } else {
-        return (
-            <table className='table summary-table'>
-                <thead>
-                    <tr>
-                        <th colSpan={2}>{t('Clearing Request')}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>{t('Requesting User')}:</td>
-                        <td>
-                            {data?.requestingUser !== undefined &&
-                            data?._embedded?.requestingUser?.fullName !== undefined ? (
-                                <Link href={`mailto:${data._embedded.requestingUser.email}`}>
-                                    {data._embedded.requestingUser.fullName}
-                                </Link>
-                            ) : (
-                                ''
-                            )}
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>{t('Created On')}:</td>
-                        <td>{data?._embedded?.createdOn ?? ''}</td>
-                    </tr>
-                    <tr>
-                        <td>{t('Preferred Clearing Date')}:</td>
-                        <td>{data?.requestedClearingDate ?? ''}</td>
-                    </tr>
-                    <tr>
-                        <td>{t('Business Area Line')}:</td>
-                        <td>{data?.projectBU ?? ''}</td>
-                    </tr>
-                    <tr>
-                        <td>{t('Clearing Type')}:</td>
-                        <td>{data?.clearingType ?? ''}</td>
-                    </tr>
-                    <tr>
-                        <td>{t('Requester Comment')}:</td>
-                        <td>{data?.requestingUserComment ?? ''}</td>
-                    </tr>
-                </tbody>
-            </table>
-        )
-    }
+    return (
+        <table className='table summary-table'>
+            <thead>
+                <tr>
+                    <th colSpan={2}>{t('Clearing Request')}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>{t('Requesting User')}:</td>
+                    <td>
+                        {data?.requestingUser !== undefined &&
+                        data?._embedded?.requestingUser?.fullName !== undefined ? (
+                            <Link href={`mailto:${data._embedded.requestingUser.email}`}>
+                                {data._embedded.requestingUser.fullName}
+                            </Link>
+                        ) : (
+                            ''
+                        )}
+                    </td>
+                </tr>
+                <tr>
+                    <td>{t('Created On')}:</td>
+                    <td>{data?._embedded?.createdOn ?? ''}</td>
+                </tr>
+                <tr>
+                    <td>{t('Preferred Clearing Date')}:</td>
+                    <td>{data?.requestedClearingDate ?? ''}</td>
+                </tr>
+                <tr>
+                    <td>{t('Business Area Line')}:</td>
+                    <td>{data?.projectBU ?? ''}</td>
+                </tr>
+                <tr>
+                    <td>{t('Clearing Type')}:</td>
+                    <td>{data?.clearingType ?? ''}</td>
+                </tr>
+                <tr>
+                    <td>{t('Requester Comment')}:</td>
+                    <td>{data?.requestingUserComment ?? ''}</td>
+                </tr>
+            </tbody>
+        </table>
+    )
 }

--- a/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingDecision.tsx
+++ b/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingDecision.tsx
@@ -9,13 +9,12 @@
 
 'use client'
 
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SelectUsersDialog, ShowInfoOnHover } from 'next-sw360'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 import DateField from '@/components/DateField'
 import { ClearingRequestDetails, UpdateClearingRequestPayload, UserGroupType } from '@/object-types'
-import { CommonUtils } from '@/utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 
 interface Props {
     clearingRequestData: ClearingRequestDetails | undefined
@@ -33,9 +32,21 @@ export default function EditClearingDecision({
     setUpdateClearingRequestPayload,
 }: Props): ReactNode {
     const t = useTranslations('default')
-    const { data: session } = useSession()
     const [clearingTeamData, setClearingTeamData] = useState<ClearingRequestDataMap>({})
     const [dialogOpenClearingTeam, setDialogOpenClearingTeam] = useState(false)
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const updateClearingTeamData = (user: ClearingRequestDataMap) => {
         const userEmails = Object.keys(user)
@@ -101,9 +112,7 @@ export default function EditClearingDecision({
                             name='priority'
                             value={updateClearingRequestPayload.priority}
                             onChange={updateInputField}
-                            disabled={
-                                CommonUtils.isNullOrUndefined(session) || session.user.userGroup === UserGroupType.USER
-                            }
+                            disabled={userIdentity?.userGroup === UserGroupType.USER}
                             required
                         >
                             <option value='LOW'>{t('Low')}</option>

--- a/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequestInfo.tsx
+++ b/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequestInfo.tsx
@@ -9,12 +9,11 @@
 
 'use client'
 
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SelectUsersDialog, ShowInfoOnHover } from 'next-sw360'
 import { ReactNode, useEffect, useState } from 'react'
 import { ClearingRequestDetails, UpdateClearingRequestPayload, UserGroupType } from '@/object-types'
-import { CommonUtils } from '@/utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 
 interface Props {
     clearingRequestData: ClearingRequestDetails | undefined
@@ -32,12 +31,24 @@ export default function EditClearingRequestInfo({
     setUpdateClearingRequestPayload,
 }: Props): ReactNode {
     const t = useTranslations('default')
-    const { data: session } = useSession()
     const [, setMinDate] = useState('')
     const [dialogOpenRequestingUser, setDialogOpenRequestingUser] = useState(false)
     const [requestingUserData, setRequestingUserData] = useState<{
         [k: string]: string
     }>({})
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     useEffect(() => {
         const currentDate = new Date()
@@ -80,10 +91,7 @@ export default function EditClearingRequestInfo({
                                 name='requestingUser'
                                 onClick={() => setDialogOpenRequestingUser(true)}
                                 value={updateClearingRequestPayload.requestingUser}
-                                disabled={
-                                    CommonUtils.isNullOrUndefined(session) ||
-                                    session.user.userGroup === UserGroupType.USER
-                                }
+                                disabled={userIdentity?.userGroup === UserGroupType.USER}
                             />
                             <SelectUsersDialog
                                 show={dialogOpenRequestingUser}
@@ -115,10 +123,7 @@ export default function EditClearingRequestInfo({
                                 name='clearingType'
                                 value={updateClearingRequestPayload.clearingType}
                                 onChange={updateInputField}
-                                disabled={
-                                    CommonUtils.isNullOrUndefined(session) ||
-                                    session.user.userGroup === UserGroupType.USER
-                                }
+                                disabled={userIdentity?.userGroup === UserGroupType.USER}
                                 required
                             >
                                 <option value='DEEP'>{t('Deep Level CLX')}</option>

--- a/src/app/[locale]/requests/components/BulkDeclineModerationRequestModal.tsx
+++ b/src/app/[locale]/requests/components/BulkDeclineModerationRequestModal.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -20,7 +19,6 @@ import { Form, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsInfoCircle, BsQuestionCircle } from 'react-icons/bs'
 import { ModerationRequestPayload } from '@/object-types'
 import MessageService from '@/services/message.service'
-import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
@@ -52,8 +50,6 @@ export default function BulkDeclineModerationRequestModal({
         action: '',
         comment: '',
     })
-
-    const session = useSession()
 
     const computeProgress = (responseCode: number) => {
         switch (responseCode) {
@@ -208,7 +204,6 @@ export default function BulkDeclineModerationRequestModal({
     }
 
     const rejectModerationRequest = async (singleMrId: string, updatedRejectPayload: ModerationRequestPayload) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         try {
             setShowProcessing(true)
             const hasComment = handleCommentValidation(moderationRequestPayload.comment)
@@ -279,7 +274,6 @@ export default function BulkDeclineModerationRequestModal({
     }
 
     const acceptModerationRequest = async (singleMrId: string, updatedAcceptPayload: ModerationRequestPayload) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
         try {
             setShowProcessing(true)
             const hasComment = handleCommentValidation(moderationRequestPayload.comment)

--- a/src/app/[locale]/requests/components/ClearingRequest.tsx
+++ b/src/app/[locale]/requests/components/ClearingRequest.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -30,14 +29,26 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 
 type EmbeddedClearingRequest = Embedded<ClearingRequest, 'sw360:clearingRequests'>
 
 function ClearingRequestComponent({ requestType }: { requestType: RequestType }): ReactNode | undefined {
     const t = useTranslations('default')
-    const session = useSession()
     const params = useSearchParams()
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -303,9 +314,8 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                                     className='btn-transparent'
                                     hidden={
                                         !Object.hasOwn(row.original, 'projectId') ||
-                                        !session.data ||
-                                        (session.data.user.userGroup === UserGroupType.USER &&
-                                            session.data.user.email !== row.original._embedded?.requestingUser?.email)
+                                        (userIdentity?.userGroup === UserGroupType.USER &&
+                                            userIdentity?.email !== row.original._embedded?.requestingUser?.email)
                                     }
                                 >
                                     <Link
@@ -329,7 +339,6 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
         ],
         [
             t,
-            session,
         ],
     )
     const [clearingRequestData, setClearingRequestDataData] = useState<ClearingRequest[]>(() => [])
@@ -342,7 +351,6 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -353,7 +361,6 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params.entries())
                 const statusFilter =
                     requestType === 'OPEN'
@@ -399,7 +406,6 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
     }, [
         pageableQueryParam,
         params.toString(),
-        session,
         requestType,
     ])
 

--- a/src/app/[locale]/requests/components/ClosedModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/ClosedModerationRequest.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -21,7 +20,6 @@ import { Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, ModerationRequest } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import ExpandingModeratorCell from './ExpandingModeratorCell'
 
 type EmbeddedModerationRequest = Embedded<ModerationRequest, 'sw360:moderationRequests'>
@@ -37,7 +35,6 @@ function ClosedModerationRequest(): ReactNode {
         PENDING: t('Pending'),
         REJECTED: t('REJECTED'),
     }
-    const session = useSession()
     const params = useSearchParams()
 
     const formatDate = (timestamp: number | undefined): string | null => {
@@ -135,7 +132,6 @@ function ClosedModerationRequest(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -146,7 +142,6 @@ function ClosedModerationRequest(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `moderationrequest`,
@@ -187,7 +182,6 @@ function ClosedModerationRequest(): ReactNode {
         return () => controller.abort()
     }, [
         params.toString(),
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/requests/components/OpenModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/OpenModerationRequest.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -21,7 +20,6 @@ import { Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, ModerationRequest } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import BulkDeclineModerationRequestModal from './BulkDeclineModerationRequestModal'
 import ExpandingModeratorCell from './ExpandingModeratorCell'
 
@@ -45,7 +43,6 @@ function OpenModerationRequest(): ReactNode {
         REJECTED: t('REJECTED'),
     }
 
-    const session = useSession()
     const params = useSearchParams()
 
     const formatDate = (timestamp: number | undefined): string | null => {
@@ -159,7 +156,6 @@ function OpenModerationRequest(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -170,7 +166,6 @@ function OpenModerationRequest(): ReactNode {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const searchParams = Object.fromEntries(params.entries())
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `moderationrequest`,
@@ -211,7 +206,6 @@ function OpenModerationRequest(): ReactNode {
         return () => controller.abort()
     }, [
         params.toString(),
-        session,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, getPaginationRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -19,8 +18,6 @@ import { Spinner } from 'react-bootstrap'
 import { Attachment, ErrorDetails, ModerationRequestDetails, RequestDocumentTypes } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import TableHeader from './TableHeader'
 
 type RowValue =
@@ -49,7 +46,6 @@ export default function ProposedChanges({
     const t = useTranslations('default')
     const dafaultTitle = t('BASIC FIELD CHANGES')
     const attachmentTitle = t('ATTACHMENTS')
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<RowInterface>[]>(
         () => [
@@ -382,13 +378,12 @@ export default function ProposedChanges({
     )
 
     useEffect(() => {
-        if (session.status === 'loading' || moderationRequestData === undefined) return
+        if (moderationRequestData === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 setShowProcessing(true)
                 let queryUrl = ''
                 if (moderationRequestData?.documentType == RequestDocumentTypes.COMPONENT) {
@@ -435,7 +430,6 @@ export default function ProposedChanges({
 
         return () => controller.abort()
     }, [
-        session,
         moderationRequestData,
     ])
 

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentComponent/CurrentComponentDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentComponent/CurrentComponentDetail.tsx
@@ -11,7 +11,6 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { notFound } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Col, ListGroup, Row, Tab } from 'react-bootstrap'
@@ -48,34 +47,30 @@ const CurrentComponentDetail = ({ componentId }: Props): ReactNode => {
     const [component, setComponent] = useState<Component>()
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [changeLogId, setChangeLogId] = useState('')
-    const session = useSession()
     const [activeKey, setActiveKey] = useState(CommonTabIds.SUMMARY)
 
     const handleSelect = (key: string | null) => {
         setActiveKey(key ?? CommonTabIds.SUMMARY)
     }
 
-    const fetchData = async (url: string) => {
-        const response = await ApiUtils.GET(url)
-        if (response.status == StatusCodes.OK) {
-            const data = (await response.json()) as Component & EmbeddedVulnerabilities & EmbeddedChangelogs
-            return data
-        } else if (response.status == StatusCodes.UNAUTHORIZED) {
-            dispatchSessionExpiredEvent()
-        } else {
-            notFound()
-        }
-    }
-
     useEffect(() => {
-        fetchData(`components/${componentId}`)
-            .then((component) => {
-                setComponent(component)
-            })
-            .catch((err) => console.error(err))
+        void (async () => {
+            try {
+                const response = await ApiUtils.GET(`components/${componentId}`)
+                if (response.status == StatusCodes.OK) {
+                    const data = (await response.json()) as Component & EmbeddedVulnerabilities & EmbeddedChangelogs
+                    setComponent(data)
+                } else if (response.status == StatusCodes.UNAUTHORIZED) {
+                    dispatchSessionExpiredEvent()
+                } else {
+                    notFound()
+                }
+            } catch (err) {
+                console.error(err)
+            }
+        })()
     }, [
         componentId,
-        fetchData,
     ])
 
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
@@ -99,7 +94,6 @@ const CurrentComponentDetail = ({ componentId }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -110,7 +104,6 @@ const CurrentComponentDetail = ({ componentId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${componentId}`,
                     Object.fromEntries(
@@ -153,7 +146,6 @@ const CurrentComponentDetail = ({ componentId }: Props): ReactNode => {
     }, [
         pageableQueryParam,
         componentId,
-        session,
     ])
 
     return component ? (

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentProject/CurrentProjectDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentProject/CurrentProjectDetail.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useState } from 'react'
 import { Col, ListGroup, Row, Spinner, Tab } from 'react-bootstrap'
@@ -22,7 +21,7 @@ import Summary from '@/app/[locale]/projects/detail/[id]/components/Summary'
 import VulnerabilityTrackingStatusComponent from '@/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus'
 import Attachments from '@/components/Attachments/Attachments'
 import { AdministrationDataType, ErrorDetails, SummaryDataType } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 export default function CurrentProjectDetail({
     projectId,
@@ -30,7 +29,6 @@ export default function CurrentProjectDetail({
     projectId: string
 }>): ReactNode {
     const t = useTranslations('default')
-    const { data: session, status } = useSession()
     const [summaryData, setSummaryData] = useState<SummaryDataType | undefined>(undefined)
     const [administrationData, setAdministrationData] = useState<AdministrationDataType | undefined>(undefined)
 
@@ -39,7 +37,6 @@ export default function CurrentProjectDetail({
         const signal = controller.signal
 
         void (async () => {
-            if (CommonUtils.isNullOrUndefined(session)) return
             try {
                 const response = await ApiUtils.GET(`projects/${projectId}/summaryAdministration`, signal)
                 if (response.status !== StatusCodes.OK) {
@@ -64,8 +61,6 @@ export default function CurrentProjectDetail({
         return () => controller.abort()
     }, [
         projectId,
-        session,
-        status,
     ])
 
     return (

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Col, ListGroup, Row, Tab } from 'react-bootstrap'
@@ -50,7 +49,6 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
     const [embeddedAttachments, setEmbeddedAttachments] = useState<Array<Attachment>>([])
     const [changelogTab, setChangelogTab] = useState('list-change')
     const [changeLogId, setChangeLogId] = useState('')
-    const session = useSession()
     const [activeKey, setActiveKey] = useState(CommonTabIds.SUMMARY)
     const t = useTranslations('default')
     const isNestedReleaseEnabled = useConfigKeyValue(ConfigKeys.IS_NESTED_RELEASE_ENABLED)
@@ -117,7 +115,6 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -128,7 +125,6 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `changelog/document/${releaseId}`,
                     Object.fromEntries(
@@ -171,7 +167,6 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
     }, [
         pageableQueryParam,
         releaseId,
-        session,
     ])
 
     return release ? (

--- a/src/app/[locale]/search/components/KeywordSearch.tsx
+++ b/src/app/[locale]/search/components/KeywordSearch.tsx
@@ -10,7 +10,6 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, ReactNode, SetStateAction, useReducer, useState } from 'react'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
@@ -181,7 +180,6 @@ function KeywordSearch({
 
     const [searchOptions, dispatch] = useReducer(reducer, initialState)
     const [searchText, setSearchText] = useState('')
-    const session = useSession()
 
     function appendTypeMasksToParams(searchOptions: SEARCH_STATE, params = new URLSearchParams()) {
         const entries = Object.entries(searchOptions)
@@ -200,8 +198,6 @@ function KeywordSearch({
         }, 300)
 
         try {
-            if (session.status !== 'authenticated') return
-
             const params = appendTypeMasksToParams(
                 searchOptions,
                 new URLSearchParams({

--- a/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
+++ b/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
@@ -13,7 +13,6 @@ import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tansta
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { AdvancedSearch, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { ReactNode, useEffect, useMemo, useState } from 'react'
@@ -29,6 +28,7 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import DeleteVulnerabilityModal from './DeleteVulnerabilityModal'
 
 type EmbeddedVulnerabilities = Embedded<Vulnerability, 'sw360:vulnerabilityApiDTOes'>
@@ -39,7 +39,6 @@ function Vulnerabilities(): ReactNode {
     const [numVulnerabilities, setNumVulnerabilities] = useState<null | number>(0)
     const [vulnerabilityToBeDeleted, setVulnerabilityToBeDeleted] = useState<null | string>(null)
     const router = useRouter()
-    const { data: session, status } = useSession()
     const [reloadKey, setReloadKey] = useState(1)
     const [pageableQueryParam, setPageableQueryParam] = useState<PageableQueryParam>({
         page: 0,
@@ -52,6 +51,20 @@ function Vulnerabilities(): ReactNode {
         totalPages: 0,
         number: 0,
     })
+
+    const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
+        null,
+    )
+
+    useEffect(() => {
+        void (async () => {
+            try {
+                setUserIdentity(await getAuthenticatedUserIdentity())
+            } catch {
+                setUserIdentity(null)
+            }
+        })()
+    }, [])
 
     const onDeleteClick = (id: string) => {
         setVulnerabilityToBeDeleted(id)
@@ -211,7 +224,6 @@ function Vulnerabilities(): ReactNode {
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -263,7 +275,6 @@ function Vulnerabilities(): ReactNode {
     }, [
         pageableQueryParam,
         params.toString(),
-        session,
     ])
 
     useEffect(() => {
@@ -284,7 +295,7 @@ function Vulnerabilities(): ReactNode {
         // table state config
         state: {
             columnVisibility: {
-                actions: !(session?.user?.userGroup === UserGroupType.SECURITY_USER),
+                actions: !(userIdentity?.userGroup === UserGroupType.SECURITY_USER),
             },
             pagination: {
                 pageIndex: pageableQueryParam.page,
@@ -374,10 +385,7 @@ function Vulnerabilities(): ReactNode {
                                     <button
                                         className='btn btn-primary col-auto'
                                         onClick={handleAddVulnerability}
-                                        disabled={
-                                            status === 'authenticated' &&
-                                            session?.user?.userGroup === UserGroupType.SECURITY_USER
-                                        }
+                                        disabled={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                     >
                                         {t('Add Vulnerability')}
                                     </button>

--- a/src/components/AccessControl/AccessControl.tsx
+++ b/src/components/AccessControl/AccessControl.tsx
@@ -7,27 +7,35 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-import { useSession } from 'next-auth/react'
+'use client'
+
 import { useTranslations } from 'next-intl'
-import { Spinner } from 'react-bootstrap'
+import { type ComponentType, type FC, useEffect, useState } from 'react'
 import { UserGroupType } from '@/object-types'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 
 export function AccessControl<P extends object>(
-    WrappedComponent: React.ComponentType<P>,
+    WrappedComponent: ComponentType<P>,
     notAllowedGroups: UserGroupType[] = [],
-): React.FC<P> {
-    const ProtectedComponent: React.FC<P> = (props) => {
-        const { data: session, status } = useSession()
+): FC<P> {
+    const ProtectedComponent: FC<P> = (props) => {
         const t = useTranslations('default')
+        const [userIdentity, setUserIdentity] = useState<Awaited<
+            ReturnType<typeof getAuthenticatedUserIdentity>
+        > | null>(null)
 
-        if (status === 'loading') {
-            return (
-                <div className='col-12 d-flex justify-content-center align-items-center'>
-                    <Spinner className='spinner' />
-                </div>
-            )
-        }
-        if (status === 'authenticated' && notAllowedGroups.includes(session?.user?.userGroup)) {
+        useEffect(() => {
+            void (async () => {
+                try {
+                    setUserIdentity(await getAuthenticatedUserIdentity())
+                } catch {
+                    setUserIdentity(null)
+                }
+            })()
+        }, [])
+
+        const userGroup = userIdentity?.userGroup
+        if (userGroup !== undefined && notAllowedGroups.includes(userGroup)) {
             return (
                 <div className='container page-content'>
                     <div

--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -34,17 +33,13 @@ type EmbeddedAttachments = Embedded<Attachment, 'sw360:attachments'>
 function Attachments({ documentId, documentType }: { documentId: string; documentType: string }): JSX.Element {
     const t = useTranslations('default')
     const [importStatusData, setImportStatusData] = useState<ImportSummary | null>(null)
-    const session = useSession()
 
     const handleAttachmentDownload = async (attachmentId: string, attachmentName: string) => {
-        if (CommonUtils.isNullOrUndefined(session.data)) return
         await DownloadService.download(`${documentType}/${documentId}/attachments/${attachmentId}`, attachmentName)
     }
 
     const handleImportStatusView = async (attachmentId: string) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return
-
             const res = await ApiUtils.GET(`${documentType}/${documentId}/attachments/${attachmentId}`)
 
             if (res.status === StatusCodes.OK) {
@@ -257,7 +252,6 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -268,7 +262,6 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return
                 const response = await ApiUtils.GET(`${documentType}/${documentId}/attachments`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -302,9 +295,7 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     const table = useReactTable({
         data: memoizedData,

--- a/src/components/Attachments/EditAttachments.tsx
+++ b/src/components/Attachments/EditAttachments.tsx
@@ -9,9 +9,10 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import { Modal } from 'react-bootstrap'
@@ -150,7 +151,6 @@ function EditAttachments<T>({ documentId, documentType, documentPayload, setDocu
     }>({})
     const [dialogOpenSelectAttachment, setDialogOpenSelectAttachment] = useState(false)
     const handleClickSelectAttachment = useCallback(() => setDialogOpenSelectAttachment(true), [])
-    const session = useSession()
     const [updateCommentModalData, setUpdateCommentModalData] = useState<UpdateCommentModalMetadata | null>(null)
 
     const [attachmentsData, setAttachmentsData] = useState<Attachment[]>(() => [])
@@ -189,7 +189,6 @@ function EditAttachments<T>({ documentId, documentType, documentPayload, setDocu
     )
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -200,7 +199,6 @@ function EditAttachments<T>({ documentId, documentType, documentPayload, setDocu
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return
                 const response = await ApiUtils.GET(`${documentType}/${documentId}/attachments`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -234,9 +232,7 @@ function EditAttachments<T>({ documentId, documentType, documentPayload, setDocu
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     useEffect(() => {
         setDocumentPayload({

--- a/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
+++ b/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Alert, Button, Col, Form, Modal, OverlayTrigger, Row, Spinner, Tooltip } from 'react-bootstrap'
@@ -31,7 +30,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     releaseId?: string
@@ -55,7 +53,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const [byNameOnly, setByNameOnly] = useState(true)
     const [selectedProject, setSelectedProject] = useState<Project>()
     const [selectedProjectIds, setSelectedProjectIds] = useState<string[]>([])
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<Project>[]>(
         () => [
@@ -215,14 +212,13 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -299,7 +295,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const handleSearch = async (signal?: AbortSignal) => {
         try {
             setShowProcessing(true)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
 
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
                 // Search by name only using /projects endpoint
@@ -371,9 +366,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
                 }
 
                 // Fetch full details for each project
-                const accessToken = session.data?.user.access_token
-                if (!accessToken) return
-
                 const projectPromises = projectIds.map((id) =>
                     ApiUtils.GET(`projects/${id}`, signal)
                         .then((res) => (res.status === StatusCodes.OK ? res.json() : null))
@@ -413,8 +405,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
 
     const handleLinkToProject = async () => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const response = await ApiUtils.PATCH(
                 `projects/${selectedProject?._links.self.href.split('/').at(-1)}/releases`,
                 [
@@ -439,8 +429,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const getLinkedProjects = async (signal: AbortSignal) => {
         setShowLinkedProjectsProcessing(true)
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const response = await ApiUtils.GET(`releases/usedBy/${releaseId}`, signal)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails
@@ -463,7 +451,7 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     }
 
     useEffect(() => {
-        if (session.status === 'loading' || !withLinkedProject || !show) return
+        if (!withLinkedProject || !show) return
         const controller = new AbortController()
         const signal = controller.signal
         void getLinkedProjects(signal)
@@ -474,13 +462,10 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     ])
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
                 const response = await ApiUtils.GET(`releases/${releaseId}`, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -502,7 +487,7 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
 
     return (
         <>
-            {session.status === 'authenticated' && (
+            {
                 <Modal
                     show={show}
                     onHide={handleCloseDialog}
@@ -703,7 +688,7 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
                         )}
                     </Modal.Footer>
                 </Modal>
-            )}
+            }
         </>
     )
 }

--- a/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
+++ b/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
@@ -11,7 +11,6 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { SW360Table } from 'next-sw360'
 import React, { type JSX, useEffect, useMemo, useState } from 'react'
@@ -19,8 +18,6 @@ import { Button, Col, Form, Modal, Row, Spinner } from 'react-bootstrap'
 import { ErrorDetails } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import CommonUtils from '@/utils/common.utils'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     show: boolean
@@ -43,7 +40,6 @@ interface Department {
 export default function DepartmentModal({ show, setShow, department, setDepartment }: Props): JSX.Element {
     const t = useTranslations('default')
     const [selectingDepartment, setSelectingDepartment] = useState<string>(department || '')
-    const session = useSession()
 
     const columns = useMemo<ColumnDef<Department>[]>(
         () => [
@@ -97,7 +93,6 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -108,7 +103,6 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET('users/groupList', signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
@@ -140,9 +134,7 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
         })()
 
         return () => controller.abort()
-    }, [
-        session,
-    ])
+    }, [])
 
     const table = useReactTable({
         data: memoizedData,

--- a/src/components/ResourcesUsing/ResourcesUsing.tsx
+++ b/src/components/ResourcesUsing/ResourcesUsing.tsx
@@ -9,13 +9,13 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { type JSX, useEffect, useState } from 'react'
 import { DocumentTypes, ErrorDetails, Resources } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import ComponentsUsing from './ComponentsUsing'
 import ProjectsUsing from './ProjectsUsing'
 
@@ -27,19 +27,16 @@ interface Props {
 
 const ResourcesUsing = ({ documentId, documentType, documentName }: Props): JSX.Element => {
     const [resourcesUsing, setResourceUsing] = useState<Resources | undefined>(undefined)
-    const session = useSession()
 
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
         void (async () => {
             try {
                 setShowProcessing(true)
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const response = await ApiUtils.GET(`${documentType}/usedBy/${documentId}`, signal)
                 if (response.status === StatusCodes.NO_CONTENT) {
                     return
@@ -64,7 +61,6 @@ const ResourcesUsing = ({ documentId, documentType, documentName }: Props): JSX.
     }, [
         documentId,
         documentType,
-        session,
     ])
 
     return (

--- a/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
+++ b/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -21,7 +20,6 @@ import { BsInfoCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, LinkedPackageData, Package, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface HasLinkedPackages {
     linkedPackages?: Record<string, LinkedPackageData>
@@ -46,7 +44,6 @@ export default function LinkPackagesModal<T extends HasLinkedPackages>({
     const [linkPackages, setLinkPackages] = useState<Map<string, LinkedPackageData>>(new Map())
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [exactMatch, setExactMatch] = useState(false)
-    const session = useSession()
 
     useEffect(() => {
         setLinkPackages(new Map(Object.entries(payload.linkedPackages ?? payload.packageIds ?? {})))
@@ -157,14 +154,13 @@ export default function LinkPackagesModal<T extends HasLinkedPackages>({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -206,8 +202,6 @@ export default function LinkPackagesModal<T extends HasLinkedPackages>({
 
     const handleSearch = async (signal?: AbortSignal) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const queryUrl = CommonUtils.createUrlWithParams(
                 `packages`,
                 Object.fromEntries(

--- a/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
+++ b/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -30,7 +29,6 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface AlertData {
     variant: string
@@ -57,7 +55,6 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [exactMatch, setExactMatch] = useState(false)
     const [byNameOnly, setByNameOnly] = useState(true)
-    const session = useSession()
 
     useEffect(() => {
         setLinkProjects(new Map(Object.entries(projectPayload.linkedProjects ?? {})))
@@ -208,14 +205,13 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -292,7 +288,6 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
     const handleSearch = async (signal?: AbortSignal) => {
         try {
             setShowProcessing(true)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
 
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
                 // Search by name only using /projects endpoint
@@ -364,9 +359,6 @@ export default function LinkProjectsModal({ projectPayload, setProjectPayload, s
                 }
 
                 // Fetch full details for each project
-                const accessToken = session.data?.user.access_token
-                if (!accessToken) return
-
                 const projectPromises = projectIds.map((id) =>
                     ApiUtils.GET(`projects/${id}`, signal)
                         .then((res) => (res.status === StatusCodes.OK ? res.json() : null))

--- a/src/components/sw360/SearchLicensesDialog/LicensesDialog.tsx
+++ b/src/components/sw360/SearchLicensesDialog/LicensesDialog.tsx
@@ -12,14 +12,12 @@
 
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Button, Form, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, LicenseDetail, PageableQueryParam, PaginationMeta } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import { PageSizeSelector, SW360Table, TableFooter } from '../Table/Components'
 
 interface Props {
@@ -39,7 +37,6 @@ const LicensesDialog = ({ show, setShow, selectLicenses, releaseLicenses }: Prop
         [k: string]: string
     }>(releaseLicenses)
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
-    const session = useSession()
 
     const handleCheckbox = (item: LicenseDetail) => {
         const copiedLicenses = {
@@ -106,8 +103,6 @@ const LicensesDialog = ({ show, setShow, selectLicenses, releaseLicenses }: Prop
 
     const handleSearch = async (signal?: AbortSignal) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const queryUrl = CommonUtils.createUrlWithParams(
                 `licenses`,
                 Object.fromEntries(
@@ -148,14 +143,13 @@ const LicensesDialog = ({ show, setShow, selectLicenses, releaseLicenses }: Prop
     }
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const handleClickSelectLicenses = () => {

--- a/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
+++ b/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
@@ -13,7 +13,6 @@
 
 import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table, TableSearch } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -22,7 +21,6 @@ import { BsCheck2Square } from 'react-icons/bs'
 import { Embedded, ErrorDetails, LicensePayload, NestedRows, Obligation } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     show: boolean
@@ -38,7 +36,6 @@ type EmbeddedObligations = Embedded<Obligation, 'sw360:obligations'>
 
 const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayload }: Props): JSX.Element => {
     const t = useTranslations('default')
-    const session = useSession()
     const [search, setSearch] = useState<{
         search: string
     }>({
@@ -168,7 +165,6 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading') return
         const controller = new AbortController()
         const signal = controller.signal
 
@@ -179,7 +175,6 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
 
         void (async () => {
             try {
-                if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
                 const queryUrl = CommonUtils.createUrlWithParams(
                     `obligations`,
                     Object.fromEntries(
@@ -226,7 +221,6 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
 
         return () => controller.abort()
     }, [
-        session,
         search,
     ])
 

--- a/src/components/sw360/SearchReleasesModal.tsx
+++ b/src/components/sw360/SearchReleasesModal.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import {
     ClientSidePageSizeSelector,
@@ -29,7 +28,6 @@ import { BsInfoCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseDetail, SearchResult } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface SearchReleasesModalProps {
     show: boolean
@@ -61,7 +59,6 @@ export default function SearchReleasesModal({
     const [exactMatch, setExactMatch] = useState(false)
     const [byNameOnly, setByNameOnly] = useState(true)
     const [onlySubProjectReleases, setOnlySubProjectReleases] = useState(false)
-    const session = useSession()
 
     const handleSelectRelease = (releaseDetail: ReleaseDetail) => {
         if (!multiSelect) {
@@ -193,14 +190,13 @@ export default function SearchReleasesModal({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -249,7 +245,6 @@ export default function SearchReleasesModal({
     const handleSearch = async (signal?: AbortSignal) => {
         try {
             setShowProcessing(true)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
 
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
                 // Search by name only using /releases endpoint
@@ -321,9 +316,6 @@ export default function SearchReleasesModal({
                 }
 
                 // Fetch full details for each release
-                const accessToken = session.data?.user.access_token
-                if (!accessToken) return
-
                 const releasePromises = releaseIds.map((id) =>
                     ApiUtils.GET(`releases/${id}`, signal)
                         .then((res) => (res.status === StatusCodes.OK ? res.json() : null))
@@ -343,8 +335,6 @@ export default function SearchReleasesModal({
         setOnlySubProjectReleases(true)
         setShowProcessing(true)
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const response = await ApiUtils.GET(`projects/${projectId}/subProjects/releases`)
             if (response.status !== StatusCodes.OK) {
                 const err = (await response.json()) as ErrorDetails

--- a/src/components/sw360/SearchUsersDialog/SelectUsersDialog.tsx
+++ b/src/components/sw360/SearchUsersDialog/SelectUsersDialog.tsx
@@ -14,7 +14,6 @@
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { type JSX, useEffect, useMemo, useState } from 'react'
@@ -23,7 +22,6 @@ import { BsInfoCircle } from 'react-icons/bs'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, User } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 interface Props {
     show: boolean
@@ -50,7 +48,6 @@ const SelectUsersDialog = ({
     }>({})
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [exactMatch, setExactMatch] = useState(false)
-    const session = useSession()
 
     useEffect(() => {
         setSelectingUsers(selectedUsers)
@@ -182,14 +179,13 @@ const SelectUsersDialog = ({
     const [showProcessing, setShowProcessing] = useState(false)
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         handleSearch(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({
@@ -265,8 +261,6 @@ const SelectUsersDialog = ({
 
     const handleSearch = async (signal?: AbortSignal) => {
         try {
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
-
             const queryUrl = CommonUtils.createUrlWithParams(
                 `users`,
                 Object.fromEntries(

--- a/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+++ b/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
@@ -12,7 +12,6 @@
 
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
-import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -20,7 +19,6 @@ import { Button, Form, Modal, Spinner } from 'react-bootstrap'
 import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Vendor } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
-import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 import AddVendorDialog from './AddVendor'
 
 interface Props {
@@ -53,7 +51,6 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
         setSearchText(undefined)
         setVendorData([])
     }
-    const session = useSession()
     const [selectedVendor, setSelectedVendor] = useState<Vendor>(vendor)
 
     const columns = useMemo<ColumnDef<Vendor>[]>(
@@ -132,7 +129,6 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     const searchVendor = async (signal?: AbortSignal) => {
         try {
             setShowProcessing(true)
-            if (CommonUtils.isNullOrUndefined(session.data)) return dispatchSessionExpiredEvent()
             const queryUrl = CommonUtils.createUrlWithParams(
                 `vendors`,
                 Object.fromEntries(
@@ -172,14 +168,13 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     }
 
     useEffect(() => {
-        if (session.status === 'loading' || searchText === undefined) return
+        if (searchText === undefined) return
         const controller = new AbortController()
         const signal = controller.signal
         void searchVendor(signal)
         return () => controller.abort()
     }, [
         pageableQueryParam,
-        session,
     ])
 
     const table = useReactTable({

--- a/src/utils/api/authenticatedUser.util.ts
+++ b/src/utils/api/authenticatedUser.util.ts
@@ -13,24 +13,17 @@ import { getSession } from 'next-auth/react'
 import { ApiError } from '@/utils'
 import CommonUtils from '@/utils/common.utils'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
+import { SW360User } from '../../../nextauth'
 
-export interface AuthenticatedUserIdentity {
-    email: string
-    name: string
-}
-
-export const getAuthenticatedUserIdentity = async (): Promise<AuthenticatedUserIdentity> => {
+export const getAuthenticatedUserIdentity = async (): Promise<SW360User> => {
     const session = await getSession()
 
-    if (CommonUtils.isNullOrUndefined(session)) {
+    if (CommonUtils.isNullOrUndefined(session) || !session.user) {
         dispatchSessionExpiredEvent()
         throw new ApiError('Session has expired', {
             code: 'UNAUTHORIZED',
         })
     }
 
-    return {
-        email: session.user?.email ?? '',
-        name: session.user?.name ?? '',
-    }
+    return session.user
 }


### PR DESCRIPTION
Add the 'use client' to app files which are using ApiUtils to make API calls. Also update check-client-directives.mjs with this check.

This PR includes files missed in https://github.com/eclipse-sw360/sw360-frontend/pull/1787

This PR also removes missed `useSession` and `getSession` from #1774