### PR TITLE
fix(ci): Fix biome update workflow commit case

### DIFF
--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -91,6 +91,6 @@ jobs:
             echo "No changes from biome migrate"
           else
             git add biome.json
-            git commit -m "chore: update biome schema to match CLI version"
+            git commit -m "chore: Update biome schema to match CLI version"
             git push origin HEAD:${{ github.head_ref }}
           fi


### PR DESCRIPTION
Fix the workflow working on biome update CIs by fixing the casing of commit message.

See: #1804
Job: https://github.com/eclipse-sw360/sw360-frontend/actions/runs/27858711865/job/82450876224?pr=1804#step:11:63