### PR TITLE
Toggle SBOM Import and Update Backend Config

### DIFF
--- a/src/app/[locale]/admin/configurations/components/FeatureConfigurations.tsx
+++ b/src/app/[locale]/admin/configurations/components/FeatureConfigurations.tsx
@@ -16,6 +16,7 @@ import { StatusCodes } from 'http-status-codes'
 import { useTranslations } from 'next-intl'
 import { PageButtonHeader, PageSpinner } from 'next-sw360'
 import { type JSX, useCallback, useEffect, useState } from 'react'
+import { useSW360BackendConfigContext } from '@/contexts'
 import { ConfigKeys, Configuration, ConfigurationContainers } from '@/object-types'
 import MessageService from '@/services/message.service'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
@@ -31,6 +32,7 @@ const FeatureConfigurations = (): JSX.Element => {
     const t = useTranslations('default')
     const [currentConfig, setCurrentConfig] = useState<Configuration | undefined>(undefined)
     const apiEndpoint = `configurations/container/${ConfigurationContainers.SW360_CONFIGURATION}`
+    const { refreshConfig } = useSW360BackendConfigContext()
 
     const fetchSw360Config = useCallback(async () => {
         const response = await ApiUtils.GET(apiEndpoint)
@@ -64,6 +66,7 @@ const FeatureConfigurations = (): JSX.Element => {
         }
         const response = await ApiUtils.PATCH(apiEndpoint, currentConfig)
         if (response.status == StatusCodes.OK) {
+            refreshConfig()
             MessageService.success(t('Update backend configurations successfully'))
         } else if (response.status == StatusCodes.UNAUTHORIZED) {
             dispatchSessionExpiredEvent()

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -18,16 +18,19 @@ import { Button, Col, Dropdown, ListGroup, Row, Spinner, Tab } from 'react-boots
 import Attachments from '@/components/Attachments/Attachments'
 import LinkProjectsModal from '@/components/sw360/LinkedProjectsModal/LinkProjectsModal'
 import SidebarCountBadge from '@/components/sw360/SidebarCountBadge'
+import { useConfigKeyValue } from '@/contexts'
 import {
     ActionType,
     AdministrationDataType,
     ClearingDetailsCount,
+    ConfigKeys,
     ErrorDetails,
     LinkedProjectData,
     Project,
     ProjectDetailTabCounts,
     ProjectPayload,
     SummaryDataType,
+    UserGroupPriority,
     UserGroupType,
 } from '@/object-types'
 import MessageService from '@/services/message.service'
@@ -84,6 +87,11 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         show: false,
         importType: 'CycloneDx',
     })
+    const sbomImportExportAccessUserRole = useConfigKeyValue(ConfigKeys.SBOM_IMPORT_EXPORT_ACCESS_USER_ROLE)
+    const normalizedSbomImportExportAccessUserRole: UserGroupType =
+        sbomImportExportAccessUserRole && sbomImportExportAccessUserRole in UserGroupType
+            ? (sbomImportExportAccessUserRole as UserGroupType)
+            : UserGroupType.VIEWER
     const [userIdentity, setUserIdentity] = useState<Awaited<ReturnType<typeof getAuthenticatedUserIdentity>> | null>(
         null,
     )
@@ -406,90 +414,94 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                         >
                                             {t('Link to Projects')}
                                         </Button>
-                                        <Dropdown className='col-auto'>
-                                            <Dropdown.Toggle
-                                                variant='dark'
-                                                id='exportSBOM'
-                                                className='px-2'
-                                                hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
-                                            >
-                                                {t('Import SBOM')}
-                                            </Dropdown.Toggle>
-                                            <Dropdown.Menu>
-                                                <Dropdown.Item
-                                                    onClick={(e) => {
-                                                        e.stopPropagation()
-                                                        setImportSBOMMetadata({
-                                                            importType: 'CycloneDx',
-                                                            show: true,
-                                                            projectId: projectId,
-                                                            doNotReplace: false,
-                                                        })
-                                                    }}
-                                                >
-                                                    <span
-                                                        style={{
-                                                            display: 'inline-flex',
-                                                            alignItems: 'center',
-                                                            gap: '6px',
-                                                        }}
-                                                    >
-                                                        {t('replace existing releases and packages')}
-                                                        <ShowInfoOnHover
-                                                            text={t(
-                                                                'This will remove all current releases and packages and replace them with data from the SBOM',
-                                                            )}
-                                                        />
-                                                    </span>
-                                                </Dropdown.Item>
-                                                <Dropdown.Item
-                                                    onClick={(e) => {
-                                                        e.stopPropagation()
-                                                        setImportSBOMMetadata({
-                                                            importType: 'CycloneDx',
-                                                            show: true,
-                                                            projectId: projectId,
-                                                            doNotReplace: true,
-                                                        })
-                                                    }}
-                                                >
-                                                    <span
-                                                        style={{
-                                                            display: 'inline-flex',
-                                                            alignItems: 'center',
-                                                            gap: '6px',
-                                                        }}
-                                                    >
-                                                        {t('Add new releases and packages')}
-                                                        <ShowInfoOnHover
-                                                            text={t(
-                                                                'Adds new data from the SBOM without modifying existing releases and packages',
-                                                            )}
-                                                        />
-                                                    </span>
-                                                </Dropdown.Item>
-                                            </Dropdown.Menu>
-                                        </Dropdown>
-                                        <Dropdown className='col-auto'>
-                                            <Dropdown.Toggle
-                                                variant='dark'
-                                                id='exportSBOM'
-                                                className='px-2'
-                                                hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
-                                            >
-                                                {t('Export SBOM')}
-                                            </Dropdown.Toggle>
-                                            <Dropdown.Menu>
-                                                <Dropdown.Item
-                                                    onClick={(e) => {
-                                                        e.stopPropagation()
-                                                        setShowExportProjectSbomModal(true)
-                                                    }}
-                                                >
-                                                    {t('CycloneDX')}
-                                                </Dropdown.Item>
-                                            </Dropdown.Menu>
-                                        </Dropdown>
+                                        {userIdentity?.userGroup &&
+                                            UserGroupPriority[userIdentity.userGroup] <=
+                                                UserGroupPriority[normalizedSbomImportExportAccessUserRole] && (
+                                                <>
+                                                    <Dropdown className='col-auto'>
+                                                        <Dropdown.Toggle
+                                                            variant='dark'
+                                                            id='exportSBOM'
+                                                            className='px-2'
+                                                        >
+                                                            {t('Import SBOM')}
+                                                        </Dropdown.Toggle>
+                                                        <Dropdown.Menu>
+                                                            <Dropdown.Item
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    setImportSBOMMetadata({
+                                                                        importType: 'CycloneDx',
+                                                                        show: true,
+                                                                        projectId: projectId,
+                                                                        doNotReplace: false,
+                                                                    })
+                                                                }}
+                                                            >
+                                                                <span
+                                                                    style={{
+                                                                        display: 'inline-flex',
+                                                                        alignItems: 'center',
+                                                                        gap: '6px',
+                                                                    }}
+                                                                >
+                                                                    {t('replace existing releases and packages')}
+                                                                    <ShowInfoOnHover
+                                                                        text={t(
+                                                                            'This will remove all current releases and packages and replace them with data from the SBOM',
+                                                                        )}
+                                                                    />
+                                                                </span>
+                                                            </Dropdown.Item>
+                                                            <Dropdown.Item
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    setImportSBOMMetadata({
+                                                                        importType: 'CycloneDx',
+                                                                        show: true,
+                                                                        projectId: projectId,
+                                                                        doNotReplace: true,
+                                                                    })
+                                                                }}
+                                                            >
+                                                                <span
+                                                                    style={{
+                                                                        display: 'inline-flex',
+                                                                        alignItems: 'center',
+                                                                        gap: '6px',
+                                                                    }}
+                                                                >
+                                                                    {t('Add new releases and packages')}
+                                                                    <ShowInfoOnHover
+                                                                        text={t(
+                                                                            'Adds new data from the SBOM without modifying existing releases and packages',
+                                                                        )}
+                                                                    />
+                                                                </span>
+                                                            </Dropdown.Item>
+                                                        </Dropdown.Menu>
+                                                    </Dropdown>
+                                                    <Dropdown className='col-auto'>
+                                                        <Dropdown.Toggle
+                                                            variant='dark'
+                                                            id='exportSBOM'
+                                                            className='px-2'
+                                                        >
+                                                            {t('Export SBOM')}
+                                                        </Dropdown.Toggle>
+                                                        <Dropdown.Menu>
+                                                            <Dropdown.Item
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation()
+                                                                    setShowExportProjectSbomModal(true)
+                                                                }}
+                                                            >
+                                                                {t('CycloneDX')}
+                                                            </Dropdown.Item>
+                                                        </Dropdown.Menu>
+                                                    </Dropdown>
+                                                </>
+                                            )}
                                     </Row>
                                 </Col>
                                 <Col

--- a/src/object-types/enums/UserGroupPriority.ts
+++ b/src/object-types/enums/UserGroupPriority.ts
@@ -1,0 +1,22 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+enum UserGroupPriority {
+    SW360_ADMIN = 1,
+    ADMIN = 1,
+    CLEARING_ADMIN = 2,
+    CLEARING_EXPERT = 2,
+    ECC_ADMIN = 2,
+    SECURITY_ADMIN = 2,
+    SECURITY_USER = 2,
+    USER = 3,
+    VIEWER = 4,
+}
+
+export default UserGroupPriority

--- a/src/object-types/index.ts
+++ b/src/object-types/index.ts
@@ -50,6 +50,7 @@ import ReleaseClearingStateMapping from './enums/ReleaseClearingStateMapping'
 import RequestDocumentTypes from './enums/RequestDocumentTypes'
 import RequestType from './enums/RequestType'
 import { ArrayTypeUIConfigKeys, UIConfigKeys } from './enums/UIConfigKeys'
+import UserGroupPriority from './enums/UserGroupPriority'
 import UserGroupType from './enums/UserGroupType'
 import VulnerabilitiesVerificationState from './enums/VulnerabilitiesVerificationState'
 import ErrorDetails from './error'
@@ -275,6 +276,7 @@ export {
     RequestDocumentTypes,
     RequestType,
     UIConfigKeys,
+    UserGroupPriority,
     UserGroupType,
     VulnerabilitiesVerificationState,
 }


### PR DESCRIPTION
1. Added logic to enable/disable import/export sbom buttons on project details page based on backend config.
2. Right after updation of the backend config, the frontend still used the old config until the timely 15 min refresh. Added a refresh just after update.