### PR TITLE
fix(licenseclearing): Remove redundant api calls in license clearing

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
@@ -9,18 +9,26 @@
 
 'use client'
 
+import { type ColumnFiltersState } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
 
 import { useTranslations } from 'next-intl'
-import { type JSX, useState } from 'react'
+import { type JSX, useEffect, useState } from 'react'
 import { Button, Dropdown, Nav, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { useConfigKeyValue, useConfigValue } from '@/contexts'
-import { ConfigKeys, UIConfigKeys, UserGroupType } from '@/object-types'
+import {
+    ConfigKeys,
+    ErrorDetails,
+    LicenseClearing as LicenseClearingData,
+    Project,
+    UIConfigKeys,
+    UserGroupType,
+} from '@/object-types'
 import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
-import { CommonUtils } from '@/utils'
+import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import CreateClearingRequestModal from './CreateClearingRequestModal'
 import DependencyNetworkListView from './DependencyNetworkListView'
@@ -28,6 +36,12 @@ import DependencyNetworkTreeView from './DependencyNetworkTreeView'
 import ListView from './ListView'
 import TreeView from './TreeView'
 import ViewClearingRequestModal from './ViewClearingRequestModal'
+
+const tableIdToUrlParamMapper: Record<string, string> = {
+    type: 'componentType',
+    relation: 'releaseRelation',
+    state: 'clearingState',
+}
 
 function LicenseClearing({
     projectId,
@@ -53,6 +67,12 @@ function LicenseClearing({
     const router = useRouter()
     const [showCreateClearingRequestModal, setShowCreateClearingRequestModal] = useState(false)
     const [showViewClearingRequestModal, setShowViewClearingRequestModal] = useState(false)
+    const [licenseClearingData, setLicenseClearingData] = useState<LicenseClearingData | undefined>(undefined)
+    const [linkedProjectsData, setLinkedProjectsData] = useState<Project[]>([])
+    const [isLoadingLicenseClearing, setIsLoadingLicenseClearing] = useState<boolean>(true)
+    const [isLoadingLinkedProjects, setIsLoadingLinkedProjects] = useState<boolean>(true)
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+    const isLoadingClearingData = isLoadingLicenseClearing || isLoadingLinkedProjects
 
     // Configs from backend
     const mailRequestForProjectReport = useConfigKeyValue(ConfigKeys.MAIL_REQUEST_FOR_REPORT)
@@ -63,6 +83,80 @@ function LicenseClearing({
     ) as string[] | null
     const crIsAllowed = CommonUtils.isCrAllowed(businessUnit, clearingState, clearingRequestDisabledGroups, visibility)
     const disableCrButton = !crIsAllowed
+
+    useEffect(() => {
+        const controller = new AbortController()
+        const signal = controller.signal
+
+        setIsLoadingLinkedProjects(true)
+
+        void (async () => {
+            try {
+                const linkedProjectsResponse = await ApiUtils.GET(
+                    `projects/${projectId}/linkedProjects?transitive=true`,
+                    signal,
+                )
+                if (linkedProjectsResponse.status !== StatusCodes.OK) {
+                    const err = (await linkedProjectsResponse.json()) as ErrorDetails
+                    throw new ApiError(err.message, {
+                        status: linkedProjectsResponse.status,
+                    })
+                }
+
+                const linkedProjects = (await linkedProjectsResponse.json()) as {
+                    _embedded?: {
+                        'sw360:projects'?: Project[]
+                    }
+                }
+
+                setLinkedProjectsData(linkedProjects._embedded?.['sw360:projects'] ?? [])
+            } catch (error) {
+                ApiUtils.reportError(error)
+            } finally {
+                setIsLoadingLinkedProjects(false)
+            }
+        })()
+
+        return () => controller.abort()
+    }, [
+        projectId,
+    ])
+
+    useEffect(() => {
+        const controller = new AbortController()
+        const signal = controller.signal
+
+        setIsLoadingLicenseClearing(true)
+
+        void (async () => {
+            try {
+                const filterParams = columnFilters
+                    .map((f) => (f.value as string[]).map((v) => `${tableIdToUrlParamMapper[f.id]}=${v}`).join('&'))
+                    .filter((param) => param !== '')
+                    .join('&')
+
+                const url = `projects/${projectId}/licenseClearing?transitive=true${filterParams ? `&${filterParams}` : ''}`
+                const response = await ApiUtils.GET(url, signal)
+                if (response.status !== StatusCodes.OK) {
+                    const err = (await response.json()) as ErrorDetails
+                    throw new ApiError(err.message, {
+                        status: response.status,
+                    })
+                }
+
+                setLicenseClearingData((await response.json()) as LicenseClearingData)
+            } catch (error) {
+                ApiUtils.reportError(error)
+            } finally {
+                setIsLoadingLicenseClearing(false)
+            }
+        })()
+
+        return () => controller.abort()
+    }, [
+        projectId,
+        columnFilters,
+    ])
 
     const generateSourceCodeBundle = (withSubProjects: boolean) => {
         router.push(`/projects/generateSourceCode/${projectId}?withSubProjects=${withSubProjects ? 'true' : 'false'}`)
@@ -220,7 +314,14 @@ function LicenseClearing({
                         {isDependencyNetworkFeatureEnabled ? (
                             <DependencyNetworkTreeView projectId={projectId} />
                         ) : (
-                            <TreeView projectId={projectId} />
+                            <TreeView
+                                projectId={projectId}
+                                licenseClearingData={licenseClearingData}
+                                linkedProjectsData={linkedProjectsData}
+                                isLoadingClearingData={isLoadingClearingData}
+                                columnFilters={columnFilters}
+                                setColumnFilters={setColumnFilters}
+                            />
                         )}
                     </Tab.Pane>
                     <Tab.Pane eventKey='list-view'>
@@ -231,6 +332,11 @@ function LicenseClearing({
                                 projectId={projectId}
                                 projectName={projectName}
                                 projectVersion={projectVersion}
+                                licenseClearingData={licenseClearingData}
+                                linkedProjectsData={linkedProjectsData}
+                                isLoadingClearingData={isLoadingClearingData}
+                                columnFilters={columnFilters}
+                                setColumnFilters={setColumnFilters}
                             />
                         )}
                     </Tab.Pane>

--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -20,11 +20,11 @@ import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table } from 'next-sw360'
-import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
+import { Dispatch, type JSX, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { FaFile, FaPencilAlt } from 'react-icons/fa'
-import { Embedded, ErrorDetails, FilterOption, LicenseClearing, Project, Release, TypedEntity } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
+import { FilterOption, LicenseClearing, Project, Release, TypedEntity } from '@/object-types'
+import { CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 
 interface Attachment {
@@ -34,8 +34,6 @@ interface Attachment {
 
 const Capitalize = (text: string) =>
     text.split('_').reduce((s, c) => s + ' ' + (c.charAt(0) + c.substring(1).toLocaleLowerCase()), '')
-
-type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
 interface ListViewProject extends Project {
     path?: string
@@ -229,12 +227,6 @@ const extractLinkedReleases = (
     }
 }
 
-const tableIdToUrlParamMapper: Record<string, string> = {
-    type: 'componentType',
-    relation: 'releaseRelation',
-    state: 'clearingState',
-}
-
 const comparator = (a: TypedProject | TypedRelease, b: TypedProject | TypedRelease): number => {
     if (a.type === 'release' && b.type === 'project') {
         return -1
@@ -275,14 +267,23 @@ export default function ListView({
     projectId,
     projectName,
     projectVersion,
+    licenseClearingData,
+    linkedProjectsData,
+    isLoadingClearingData,
+    columnFilters,
+    setColumnFilters,
 }: {
     projectId: string
     projectName: string
     projectVersion: string
+    licenseClearingData?: LicenseClearing
+    linkedProjectsData: Project[]
+    isLoadingClearingData: boolean
+    columnFilters: ColumnFiltersState
+    setColumnFilters: Dispatch<SetStateAction<ColumnFiltersState>>
 }): JSX.Element {
     const t = useTranslations('default')
 
-    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
     const [sorting, setSorting] = useState<SortingState>([])
     const [showFilter, setShowFilter] = useState<undefined | string>()
 
@@ -308,6 +309,14 @@ export default function ListView({
     )
 
     const [rowData, setRowData] = useState<(TypedProject | TypedRelease)[]>([])
+
+    useEffect(() => {
+        setLicenseClearing(licenseClearingData)
+        setLinkedProjects(linkedProjectsData)
+    }, [
+        licenseClearingData,
+        linkedProjectsData,
+    ])
 
     const handleShowLicenseFiles = useCallback(async (release: Release) => {
         setSelectedRelease(release)
@@ -655,72 +664,9 @@ export default function ListView({
     })
 
     useEffect(() => {
-        const controller = new AbortController()
-        const signal = controller.signal
-        const timeLimit = memoizedLicenseClearing === undefined ? 700 : 0
-        const timeout = setTimeout(() => {
-            setShowProcessing(true)
-        }, timeLimit)
-
-        void (async () => {
-            try {
-                const filterParams = columnFilters
-                    .map((f) => (f.value as string[]).map((v) => `${tableIdToUrlParamMapper[f.id]}=${v}`).join('&'))
-                    .filter((param) => param !== '')
-                    .join('&')
-
-                const url = `projects/${projectId}/licenseClearing?transitive=true${filterParams ? '&' + filterParams : ''}`
-                const response = await ApiUtils.GET(url, signal)
-
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-                const licenseClearingData = (await response.json()) as LicenseClearing
-                setLicenseClearing(licenseClearingData)
-            } catch (error) {
-                ApiUtils.reportError(error)
-            } finally {
-                clearTimeout(timeout)
-                setShowProcessing(false)
-            }
-        })()
-        return () => controller.abort()
+        setShowProcessing(isLoadingClearingData)
     }, [
-        projectId,
-        columnFilters,
-    ])
-
-    useEffect(() => {
-        const controller = new AbortController()
-        const signal = controller.signal
-        const timeLimit = memoizedLinkedProjects.length !== 0 ? 700 : 0
-        const timeout = setTimeout(() => {
-            setShowProcessing(true)
-        }, timeLimit)
-        void (async () => {
-            try {
-                const response = await ApiUtils.GET(`projects/${projectId}/linkedProjects?transitive=true`, signal)
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-                const linkedProjectsData = (await response.json()) as LinkedProjects
-                setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
-            } catch (error) {
-                ApiUtils.reportError(error)
-            } finally {
-                clearTimeout(timeout)
-                setShowProcessing(false)
-            }
-        })()
-        return () => controller.abort()
-    }, [
-        projectId,
+        isLoadingClearingData,
     ])
 
     useEffect(() => {

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -17,7 +17,6 @@ import {
     getExpandedRowModel,
     useReactTable,
 } from '@tanstack/react-table'
-import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { FilterComponent, PaddedCell, SW360Table } from 'next-sw360'
@@ -27,8 +26,6 @@ import { BsPencil } from 'react-icons/bs'
 import ExpandableTextList from '@/components/ExpandableList/ExpandableTextLink'
 import { useConfigValue } from '@/contexts'
 import {
-    Embedded,
-    ErrorDetails,
     FilterOption,
     LicenseClearing,
     NestedRows,
@@ -38,15 +35,12 @@ import {
     UIConfigKeys,
     UserGroupType,
 } from '@/object-types'
-import { ApiError, CommonUtils } from '@/utils'
-import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { CommonUtils } from '@/utils'
 import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import AddLicenseInfoToReleaseModal from './AddLicenseInfoToReleaseModal'
 
 const Capitalize = (text: string) =>
     text.split('_').reduce((s, c) => s + ' ' + (c.charAt(0) + c.substring(1).toLocaleLowerCase()), '')
-
-type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
 type TypedProject = TypedEntity<Project, 'project'>
 
@@ -256,27 +250,29 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
     return rows
 }
 
-const tableIdToUrlParamMapper: Record<string, string> = {
-    type: 'componentType',
-    relation: 'releaseRelation',
-    state: 'clearingState',
-}
-
-export default function TreeView({ projectId }: { projectId: string }): JSX.Element {
+export default function TreeView({
+    projectId,
+    licenseClearingData,
+    linkedProjectsData,
+    isLoadingClearingData,
+    columnFilters,
+    setColumnFilters,
+}: {
+    projectId: string
+    licenseClearingData?: LicenseClearing
+    linkedProjectsData: Project[]
+    isLoadingClearingData: boolean
+    columnFilters: ColumnFiltersState
+    setColumnFilters: Dispatch<SetStateAction<ColumnFiltersState>>
+}): JSX.Element {
     const t = useTranslations('default')
 
     const [expandLevel, setExpandLevel] = useState(-1)
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
-    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
-
     const [show, setShow] = useState<boolean>(false)
-    // Track loading state for each API call separately
-    const [isLoadingLicenseClearing, setIsLoadingLicenseClearing] = useState(true)
-    const [isLoadingLinkedProjects, setIsLoadingLinkedProjects] = useState(true)
     const [isDataReady, setIsDataReady] = useState(false)
 
-    // Show processing until both API calls complete AND data is ready to render
-    const showProcessing = isLoadingLicenseClearing || isLoadingLinkedProjects || !isDataReady
+    const showProcessing = isLoadingClearingData || !isDataReady
     const [showFilter, setShowFilter] = useState<undefined | string>()
 
     const [linkedProjects, setLinkedProjects] = useState<Project[]>(() => [])
@@ -297,6 +293,14 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
 
     const [rowData, setRowData] = useState<NestedRows<TypedProject | TypedRelease>[]>([])
     const [searchTerm, setSearchTerm] = useState('')
+
+    useEffect(() => {
+        setLicenseClearing(licenseClearingData)
+        setLinkedProjects(linkedProjectsData)
+    }, [
+        licenseClearingData,
+        linkedProjectsData,
+    ])
 
     // Configs from backend
     const showAddLicenseButton = useConfigValue(UIConfigKeys.UI_ENABLE_ADD_LICENSE_INFO_TO_RELEASE_BUTTON) as
@@ -677,13 +681,17 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
     })
 
     useEffect(() => {
-        if (memoizedLicenseClearing === undefined) return
+        if (memoizedLicenseClearing === undefined) {
+            setIsDataReady(!isLoadingClearingData)
+            return
+        }
         buildTable(setRowData, memoizedLicenseClearing, memoizedLinkedProjects)
         // Mark data as ready only after setting row data
         setIsDataReady(true)
     }, [
         memoizedLicenseClearing,
         memoizedLinkedProjects,
+        isLoadingClearingData,
     ])
 
     useEffect(() => {
@@ -803,74 +811,6 @@ export default function TreeView({ projectId }: { projectId: string }): JSX.Elem
     }, [
         table,
         expandLevel,
-    ])
-
-    useEffect(() => {
-        const controller = new AbortController()
-        const signal = controller.signal
-
-        // Reset data ready state when starting new fetch
-        setIsLoadingLicenseClearing(true)
-        setIsDataReady(false)
-
-        void (async () => {
-            try {
-                const url = `projects/${projectId}/licenseClearing?transitive=true&${columnFilters
-                    .map((f) => (f.value as string[]).map((v) => `${tableIdToUrlParamMapper[f.id]}=${v}`).join('&'))
-                    .join('&')}`
-                const response = await ApiUtils.GET(url, signal)
-
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-
-                const licenseClearingData = (await response.json()) as LicenseClearing
-                setLicenseClearing(licenseClearingData)
-            } catch (error) {
-                ApiUtils.reportError(error)
-            } finally {
-                setIsLoadingLicenseClearing(false)
-            }
-        })()
-
-        return () => controller.abort()
-    }, [
-        projectId,
-        columnFilters,
-    ])
-
-    useEffect(() => {
-        const controller = new AbortController()
-        const signal = controller.signal
-
-        setIsLoadingLinkedProjects(true)
-
-        void (async () => {
-            try {
-                const response = await ApiUtils.GET(`projects/${projectId}/linkedProjects?transitive=true`, signal)
-
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-
-                const linkedProjectsData = (await response.json()) as LinkedProjects
-                setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
-            } catch (error) {
-                ApiUtils.reportError(error)
-            } finally {
-                setIsLoadingLinkedProjects(false)
-            }
-        })()
-
-        return () => controller.abort()
-    }, [
-        projectId,
     ])
 
     return (


### PR DESCRIPTION
There are two sets of api calls being made for the same data, one for tree view and one for list view. The api calls were moved to a parent component and the data was passed to the child to avoid a set of redundant api calls.