### PR TITLE
fix(Project): Fixed vendor selection upon edit

### DIFF
--- a/src/app/[locale]/admin/vendors/components/AddVendor.tsx
+++ b/src/app/[locale]/admin/vendors/components/AddVendor.tsx
@@ -68,7 +68,6 @@ export default function AddVendor(): JSX.Element {
                         <button
                             type='submit'
                             className='btn btn-primary col-auto me-2'
-                            disabled={status !== 'authenticated'}
                         >
                             {t('Create Vendor')}
                         </button>

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -404,12 +404,10 @@ function EditProject({
                 }
 
                 if (project['_embedded']?.['sw360:vendors']?.[0] !== undefined) {
-                    const vendorData = project['_embedded']['sw360:vendors'][0]
+                    const selectedVendor = project['_embedded']['sw360:vendors'][0]
                     setVendor({
-                        id: vendorData.id ?? '',
-                        fullName: vendorData.fullName ?? '',
-                        shortName: vendorData.shortName ?? '',
-                        url: vendorData.url ?? '',
+                        ...selectedVendor,
+                        id: project.vendorId ?? selectedVendor.id ?? '',
                     })
                 }
 

--- a/src/components/ProjectAddSummary/component/Summary/GeneralInformation.tsx
+++ b/src/components/ProjectAddSummary/component/Summary/GeneralInformation.tsx
@@ -88,7 +88,7 @@ export default function GeneralInformation({
         setVendor(vendorResponse)
         setProjectPayload({
             ...projectPayload,
-            vendorId: vendorResponse._links?.self.href.split('/').at(-1),
+            vendorId: vendorResponse._links?.self.href.split('/').at(-1) ?? vendorResponse.id ?? '',
         })
     }
 

--- a/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+++ b/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
@@ -34,6 +34,28 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     const t = useTranslations('default')
     const [showAddVendor, setShowAddVendor] = useState(false)
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
+
+    const getVendorIdentifier = (vendorData?: Vendor): string => {
+        if (!vendorData) return ''
+        return vendorData._links?.self.href.split('/').at(-1) ?? vendorData.id ?? ''
+    }
+
+    const isVendorMatched = (currentVendor?: Vendor, comparedVendor?: Vendor): boolean => {
+        const currentIdentifier = getVendorIdentifier(currentVendor)
+        const comparedIdentifier = getVendorIdentifier(comparedVendor)
+
+        if (currentIdentifier !== '' && comparedIdentifier !== '') {
+            return currentIdentifier === comparedIdentifier
+        }
+
+        return (
+            (currentVendor?.fullName ?? '') !== '' &&
+            (currentVendor?.fullName ?? '') === (comparedVendor?.fullName ?? '') &&
+            (currentVendor?.shortName ?? '') === (comparedVendor?.shortName ?? '') &&
+            (currentVendor?.url ?? '') === (comparedVendor?.url ?? '')
+        )
+    }
+
     const handleCloseDialog = () => {
         setShow(!show)
         setSelectedVendor(vendor)
@@ -53,6 +75,12 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     }
     const [selectedVendor, setSelectedVendor] = useState<Vendor>(vendor)
 
+    useEffect(() => {
+        setSelectedVendor(vendor)
+    }, [
+        vendor,
+    ])
+
     const columns = useMemo<ColumnDef<Vendor>[]>(
         () => [
             {
@@ -60,11 +88,7 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
                 cell: ({ row }) => (
                     <Form.Check
                         type='radio'
-                        checked={
-                            selectedVendor !== null &&
-                            row.original._links?.self.href.split('/').at(-1) ===
-                                selectedVendor._links?.self.href.split('/').at(-1)
-                        }
+                        checked={isVendorMatched(row.original, selectedVendor)}
                         onChange={() => setSelectedVendor(row.original)}
                     ></Form.Check>
                 ),


### PR DESCRIPTION

### Summary
This PR fixes vendor selection consistency in project edit and vendor dialog flows.

- Preserves vendor identity reliably by preferring `vendorId` and falling back to vendor object id when needed.
- Improves vendor matching logic in the vendor search dialog to compare stable identifiers first, then use safe field-based fallback.
- Syncs dialog selected vendor state when incoming vendor prop changes.
- Ensures vendor id is always set in project payload using link id fallback to direct vendor id.
- Removes unnecessary disabled state on the create vendor submit button.

### Issue Link
Issue:  #1815 

How this solves it:
- Fixes cases where vendor selection was not retained correctly during project edit.
- Prevents mismatch when vendor data comes from different shapes (`_links.self.href` vs `id`).


### Suggest Reviewer
@GMishx @deo002 

### How To Test?
1. Open a project that already has a vendor assigned.
2. Go to Edit Project and verify the existing vendor appears selected.
3. Open the vendor search dialog and verify the correct row is pre-selected.
4. Select a different vendor, save, and verify the updated vendor persists after reload.
5. Create/select vendor via the add-summary flow and verify payload contains a valid `vendorId`.
6. Check that creating a vendor is still possible from the vendor dialog flow.

### Backend Related PR
https://github.com/eclipse-sw360/sw360/pull/4311