### PR TITLE
fix(UI): Preserve selected release in package link modal on reopen

### DIFF
--- a/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
+++ b/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
@@ -97,11 +97,21 @@ export default function CreateOrEditPackage({
     const handleSelectRelease = (selectedReleases: ReleaseDetail[]) => {
         if (selectedReleases.length > 0) {
             const release = selectedReleases[0]
+            const selectedRelease = {
+                ...release,
+                id: release.id ?? '',
+            } as ReleaseDetail & {
+                id: string
+            }
             setPackagePayload((prev) => ({
                 ...prev,
-                releaseId: release.id ?? '',
+                releaseId: selectedRelease.id,
+                _embedded: {
+                    ...prev._embedded,
+                    'sw360:release': selectedRelease,
+                },
             }))
-            setReleaseNameVersion(`${release.name} (${release.version})`)
+            setReleaseNameVersion(`${selectedRelease.name} (${selectedRelease.version})`)
         }
     }
 
@@ -158,6 +168,13 @@ export default function CreateOrEditPackage({
                 setShow={setShowLinkedReleasesModal}
                 onSelect={handleSelectRelease}
                 multiSelect={false}
+                preSelectedReleases={
+                    packagePayload._embedded?.['sw360:release']
+                        ? [
+                              packagePayload._embedded['sw360:release'] as unknown as ReleaseDetail,
+                          ]
+                        : []
+                }
             />
             <AddMainLicenseModal
                 showMainLicenseModal={showMainLicenseModal}
@@ -428,6 +445,9 @@ export default function CreateOrEditPackage({
                                         setPackagePayload((prev) => ({
                                             ...prev,
                                             releaseId: '',
+                                            _embedded: prev._embedded
+                                                ? (({ 'sw360:release': _removed, ...rest }) => rest)(prev._embedded)
+                                                : prev._embedded,
                                         }))
                                     }}
                                 >

--- a/src/components/sw360/SearchReleasesModal.tsx
+++ b/src/components/sw360/SearchReleasesModal.tsx
@@ -34,6 +34,7 @@ interface SearchReleasesModalProps {
     setShow: (show: boolean) => void
     onSelect: (releases: ReleaseDetail[]) => void
     multiSelect?: boolean
+    preSelectedReleases?: ReleaseDetail[]
     projectId?: string
     showExactMatch?: boolean
     showSubProjectReleases?: boolean
@@ -50,6 +51,7 @@ export default function SearchReleasesModal({
     setShow,
     onSelect,
     multiSelect = true,
+    preSelectedReleases = [],
     projectId,
     showSubProjectReleases = false,
 }: SearchReleasesModalProps): JSX.Element {
@@ -115,14 +117,19 @@ export default function SearchReleasesModal({
             {
                 id: 'componentName',
                 header: t('Component Name'),
-                cell: ({ row }) => (
-                    <Link
-                        className='text-link'
-                        href={`/components/detail/${row.original['_links']['sw360:component']['href'].split('/').pop() ?? ''}`}
-                    >
-                        {row.original.name}
-                    </Link>
-                ),
+                cell: ({ row }) => {
+                    const componentId = row.original['_links']?.['sw360:component']?.['href']?.split('/').pop()
+                    return componentId ? (
+                        <Link
+                            className='text-link'
+                            href={`/components/detail/${componentId}`}
+                        >
+                            {row.original.name}
+                        </Link>
+                    ) : (
+                        <>{row.original.name}</>
+                    )
+                },
                 meta: {
                     width: '20%',
                 },
@@ -188,6 +195,29 @@ export default function SearchReleasesModal({
         ],
     )
     const [showProcessing, setShowProcessing] = useState(false)
+
+    useEffect(() => {
+        if (!show || !preSelectedReleases || preSelectedReleases.length === 0) {
+            return
+        }
+
+        setSelectedReleases(preSelectedReleases)
+        setReleaseData(preSelectedReleases)
+        setPaginationMeta({
+            size: preSelectedReleases.length,
+            totalElements: preSelectedReleases.length,
+            totalPages: 1,
+            number: 0,
+        })
+        setPageableQueryParam((prev) => ({
+            ...prev,
+            page: 0,
+            page_entries: Math.max(prev.page_entries, preSelectedReleases.length),
+        }))
+    }, [
+        show,
+        preSelectedReleases,
+    ])
 
     useEffect(() => {
         if (searchText === undefined) return


### PR DESCRIPTION
**Summary**

This PR fixes the Link Releases modal to preserve and display previously selected releases when reopening the dialog during package creation/editing.


>   Preserves release selection state by passing full ReleaseDetail objects instead of just IDs to the modal.
>   Eliminates redundant API calls that were fetching release details unnecessarily on modal reopen.
> Adds safe optional chaining (?.) for accessing release links to prevent runtime errors when embedded data is incomplete.
>  Syncs modal selected release state when incoming preselected releases prop changes.
> Improves performance by leveraging already-loaded release data from parent component state.

**Issue Link**

**Issue:** : #1820 

**Suggest Reviewer**
@GMishx @deo002

**How To Test?**

1: Go to the "Package" tab.
2: Create a new package, add a release, and then save the package.
3: Edit the package and click on the "Package" field. The "Link Release" window will open, showing the pre-selected release.
4: You can either select a different release or keep the existing one (you can save or cancel at this point).