### PR TITLE
fix(search): Fix pagination on search page

### DIFF
--- a/src/app/[locale]/search/components/KeywordSearch.tsx
+++ b/src/app/[locale]/search/components/KeywordSearch.tsx
@@ -11,7 +11,7 @@
 
 import { StatusCodes } from 'http-status-codes'
 import { useTranslations } from 'next-intl'
-import { Dispatch, ReactNode, SetStateAction, useReducer, useState } from 'react'
+import { Dispatch, ReactNode, SetStateAction, useEffect, useReducer, useState } from 'react'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { BsInfoCircle } from 'react-icons/bs'
 import icons from '@/assets/icons/icons.svg'
@@ -158,11 +158,13 @@ function KeywordSearch({
     setShowProcessing,
     setPaginationMeta,
     pageableQueryParam,
+    setPageableQueryParam,
 }: {
     setData: Dispatch<SetStateAction<SearchResult[]>>
     setShowProcessing: Dispatch<SetStateAction<boolean>>
     setPaginationMeta: Dispatch<SetStateAction<PaginationMeta | undefined>>
     pageableQueryParam: PageableQueryParam
+    setPageableQueryParam: Dispatch<SetStateAction<PageableQueryParam>>
 }): ReactNode {
     const t = useTranslations('default')
 
@@ -230,6 +232,14 @@ function KeywordSearch({
             setShowProcessing(false)
         }
     }
+
+    useEffect(() => {
+        if (searchText.trim() !== '') {
+            handleSearch()
+        }
+    }, [
+        pageableQueryParam,
+    ])
 
     return (
         <>
@@ -417,7 +427,7 @@ function KeywordSearch({
                                 >
                                     <use href={`${icons.src}#oblig`}></use>
                                 </svg>{' '}
-                                {'Obligations'}
+                                {t('Obligations')}
                             </label>
                         </div>
                         <div className='form-check mt-1'>
@@ -443,7 +453,7 @@ function KeywordSearch({
                                 >
                                     <use href={`${icons.src}#user`}></use>
                                 </svg>{' '}
-                                {'Users'}
+                                {t('Users')}
                             </label>
                         </div>
                         <div className='form-check mt-1'>
@@ -469,7 +479,7 @@ function KeywordSearch({
                                 >
                                     <use href={`${icons.src}#vendor`}></use>
                                 </svg>{' '}
-                                {'Vendors'}
+                                {t('Vendors')}
                             </label>
                         </div>
                         <div className='form-check mt-1'>
@@ -488,7 +498,7 @@ function KeywordSearch({
                                 className='form-check-label fw-medium'
                                 htmlFor='keyboard-check-entire-document'
                             >
-                                {'Entire Document'}
+                                {t('Entire Document')}
                             </label>
                         </div>
                         <div className='row mt-2'>
@@ -506,7 +516,7 @@ function KeywordSearch({
                                         })
                                     }
                                 >
-                                    {'Toggle'}
+                                    {t('Toggle')}
                                 </button>
                                 <button
                                     type='button'
@@ -517,7 +527,7 @@ function KeywordSearch({
                                         })
                                     }
                                 >
-                                    {'Deselect All'}
+                                    {t('Deselect All')}
                                 </button>
                             </div>
                         </div>
@@ -525,7 +535,12 @@ function KeywordSearch({
                             <button
                                 type='button'
                                 className='btn btn-sm btn-primary'
-                                onClick={() => void handleSearch()}
+                                onClick={() =>
+                                    setPageableQueryParam({
+                                        ...pageableQueryParam,
+                                        page: 0,
+                                    })
+                                }
                             >
                                 {t('Search')}
                             </button>

--- a/src/app/[locale]/search/components/SearchPage.tsx
+++ b/src/app/[locale]/search/components/SearchPage.tsx
@@ -214,6 +214,7 @@ export default function Search(): ReactNode {
                             setShowProcessing={setShowProcessing}
                             setPaginationMeta={setPaginationMeta}
                             pageableQueryParam={pageableQueryParam}
+                            setPageableQueryParam={setPageableQueryParam}
                         />
                     </div>
                     <div className='col'>

--- a/src/components/sw360/Table/Components.tsx
+++ b/src/components/sw360/Table/Components.tsx
@@ -207,6 +207,7 @@ export function PageSizeSelector({
     const setPageSize = (sz: number) =>
         setPageableQueryParam({
             ...pageableQueryParam,
+            page: 0,
             page_entries: sz,
         })
     return (


### PR DESCRIPTION
- Fix pagination on Search Page
- The error "The given page index is bigger than the actual number of pages" was being thrown when I navigate to a page further up and then change the page size. For example, let the total no. of page entries be 200. Let the page size be 10. So, when I go to page 4 and then change the page size to 100, I get the error above as page 4 does not have any entries to show. Fixed this as well.