### PR TITLE
feat(language): Persist UI language preference

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -18,6 +18,11 @@ export const routing = defineRouting({
     localePrefix: {
         mode: 'never',
     },
+    // Persist the user's selected language across sessions in the same browser.
+    // Currently the maxAge is set to one year, which means the preference will be remembered for one year.
+    localeCookie: {
+        maxAge: 60 * 60 * 24 * 365,
+    },
 })
 
 export const { Link, redirect, usePathname, useRouter } = createNavigation(routing)


### PR DESCRIPTION

### Description

Users from non-English locales who changed their UI language found it reverted to their browser's native language after closing and reopening the app. The selected language was stored in the `NEXT_LOCALE` cookie, which — with this project's `localePrefix: 'never'` setup — defaulted to a session cookie (cleared on browser close). On the next visit, locale resolution fell back to the Accept-Language header, undoing the user's choice.

### Current Implantation (Temp)

Set an explicit `maxAge` on the locale cookie in `routing.ts`, converting `NEXT_LOCALE` from a session cookie into a persistent one (1 year validity).

This is the officially recommended approach in the `next-intl docs` for the `localePrefix: 'never'` mode. No backend, auth, or API changes required.

### Known limitations

The preference is stored client-side, so it does not follow the user across:

 - A different device
 - A different browser (Chrome → Firefox)
 - Cleared cookies / privacy tools

### Robust resolution (backend)

True cross-device persistence requires storing the preference on the user account:

1. Add a `preferredLanguage` field to the `sw360user` model (backend, Thrift + REST)
2. Return it on `GET` to `/users/profile` and accept it on `PATCH` to  `/users/profile`
3. Frontend: read it at login (seed the cookie from the account) and write it on language change

Closes : https://github.com/eclipse-sw360/sw360-frontend/issues/1837