### PR TITLE
fix(CI): Fixed pnpm setup in github workflow

### DIFF
--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -40,7 +40,10 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          # Pinned to 11.11.0: A bare "11" resolves to 11.12.0, whose self-installer
+          # crashes action-setup with "Cannot use 'in' operator to search for
+          # 'integrity' in undefined". Need to Bump once pnpm/action-setup#276 is fixed upstream.
+          version: 11.11.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -32,7 +32,10 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          # Pinned to 11.11.0: A bare "11" resolves to 11.12.0, whose self-installer
+          # crashes action-setup with "Cannot use 'in' operator to search for
+          # 'integrity' in undefined". Need to Bump once pnpm/action-setup#276 is fixed upstream.
+          version: 11.11.0
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
### Issue addressed

Fixed the CI pipeline failure for `pnpm-setup` stage

### Description

The error in CI is shown below :

**pnpm-setup**

```
Running self-installer...
  
  added 1 package, and audited 2 packages in 2s
  
  1 package is looking for funding
    run `npm fund` for details
  
  1 high severity vulnerability
  
  To address all issues, run:
    npm audit fix --force
  
  Run `npm audit` for details.
  Checking for updates...
  Switching pnpm from v11.7.0 to v11.12.0...
  Error:  Cannot use 'in' operator to search for 'integrity' in undefined
  
  pnpm: Cannot use 'in' operator to search for 'integrity' in undefined
      at createFullPkgId (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:154891:19)
      at lockfileToDepGraph (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:154840:20)
      at hashDependencyPaths (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179640:17)
      at iteratePkgsForVirtualStore (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179594:44)
      at iteratePkgsForVirtualStore.next (<anonymous>)
      at buildGraphFromPackages (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179699:43)
      at lockfileToDepGraph2 (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:179656:73)
      at headlessInstall (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:185801:288)
      at async installFromLockfile (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:238383:3)
      at async installPnpmToGlobalDir (file:///home/runner/setup-pnpm/node_modules/pnpm/dist/pnpm.mjs:238350:7)
Error: Something went wrong, self-installer exits with code 1
```
### Fix
Stop `pnpm` to self-update to latest version `11.12.0` and hardcode to latest stable version `11.11.0`
And as of now, this issue is already reported in `pnpm/pnpm` and `pnpm/action-setup` repository.

 `pnpm/pnpm` : https://github.com/pnpm/pnpm/issues/12959
 `pnpm/action-setup` : https://github.com/pnpm/action-setup/issues/276

### Action for later :

Once the issue is fixed, revert the pnpm version: 11 in both `.github/workflows/biome-schema-update.yml` and `.github/workflows/build_deploy.yml`