### PR TITLE
fix(css): Fixed table content  alignment issue

### DIFF
--- a/src/app/[locale]/home/components/MyProjectsWidget.tsx
+++ b/src/app/[locale]/home/components/MyProjectsWidget.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
@@ -102,7 +104,7 @@ export default function MyProjectsWidget(): ReactNode {
                 accessorKey: 'description',
                 cell: (info) => info.getValue(),
                 meta: {
-                    width: '50%',
+                    width: '48%',
                 },
             },
             {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -646,10 +646,15 @@ body {
     font-size: medium;
     font-weight: bold;
     flex-grow: 1;
+    margin: 0;
+    height: 24px;
+    display: flex;
+    align-items: center;
 }
 
 .tableHeader {
     display: flex;
+    align-items: center;
     margin-left: 5px;
     padding-right: 10px;
     padding-top: 20px;
@@ -1499,12 +1504,12 @@ input[checked] + .slider:before {
 }
 
 .sw360-table td {
-    padding: 12px !important;
+    padding: 8px 12px !important;
     vertical-align: middle;
 }
 
 .sw360-table th {
-    padding: 12px !important;
+    padding: 8px 12px !important;
     vertical-align: middle;
 }
 
@@ -1522,7 +1527,7 @@ input[checked] + .slider:before {
 
     overflow: hidden;
 
-    height: calc(2 * 1lh); /* exactly 2 lines, always */
+    max-height: calc(2 * 1lh); /* clamp to at most 2 lines, but shrink to content */
 }
 
 .table-text-link {


### PR DESCRIPTION
This PR fixes the horizontal alignment and vertical text alignment of the home page widget tables (My Projects, My Components, and the other `SW360Table`-based widgets).

Previously:

- Cell text was top-aligned instead of vertically centered, and rows were taller than needed.
- The **My Projects** and **My Components** tables did not line up horizontally, because the My Projects header contains an inline filter `Dropdown` toggle (a Bootstrap `.btn`) that is taller than plain text, pushing its table down relative to My Components.

Changes:

- `src/styles/globals.css`
  - Reduced `.sw360-table` cell padding (`12px` → `8px 12px`) to slightly reduce row height.
  - Gave `.tableHeaderTitle` a fixed `height: 24px`, `margin: 0`, and `display: flex; align-items: center`, and added `align-items: center` to `.tableHeader`, so the header height is identical whether or not the filter dropdown is present. This keeps the two side-by-side tables aligned horizontally.
- `src/app/[locale]/home/components/MyProjectsWidget.tsx`
  - Added the required `'use client'` directive (component uses hooks and makes API calls).

Issue: https://github.com/eclipse-sw360/sw360-frontend/issues/1858

### Suggest Reviewer

> @GMishx @amritkv 

### How To Test?

1. Run the app and log in.
2. Open the home page.
3. Verify the **My Projects** and **My Components** tables are aligned horizontally (header rows and body rows line up across both tables).
4. Verify cell text is vertically centered within rows and row height is compact.

