### PR TITLE
fix(Vendor): Vendor preselection in vendor search in the project component edit page

### DIFF
--- a/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
+++ b/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
@@ -44,7 +44,7 @@ function UpdateReleaseModal({
     useEffect(() => {
         setVendor(release?.vendor ?? {})
     }, [
-        release,
+        release?.id,
     ])
 
     function handleClose() {
@@ -57,7 +57,8 @@ function UpdateReleaseModal({
     const handleEditRelease = async (release: Release | null) => {
         if (release === null) return
         try {
-            const response = await ApiUtils.PATCH(`releases/${release.id}`, release)
+            const { vendor: _vendor, ...releasePayload } = release
+            const response = await ApiUtils.PATCH(`releases/${release.id}`, releasePayload)
 
             if (response.status == StatusCodes.OK) {
                 setAlert({

--- a/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+++ b/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
@@ -150,7 +150,8 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     )
     const [showProcessing, setShowProcessing] = useState(false)
 
-    const searchVendor = async (signal?: AbortSignal) => {
+    const searchVendor = async (signal?: AbortSignal, overrideSearchText?: string) => {
+        const effectiveSearchText = overrideSearchText ?? searchText
         try {
             setShowProcessing(true)
             const queryUrl = CommonUtils.createUrlWithParams(
@@ -158,9 +159,9 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
                 Object.fromEntries(
                     Object.entries({
                         ...pageableQueryParam,
-                        ...(searchText !== undefined && searchText !== ''
+                        ...(effectiveSearchText !== undefined && effectiveSearchText !== ''
                             ? {
-                                  searchText: searchText,
+                                  searchText: effectiveSearchText,
                               }
                             : {}),
                     }).map(([key, value]) => [
@@ -199,6 +200,18 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
         return () => controller.abort()
     }, [
         pageableQueryParam,
+    ])
+
+    useEffect(() => {
+        if (!show) return
+        const vendorName = vendor.fullName ?? ''
+        if (vendorName === '') return
+        setSelectedVendor(vendor)
+        setVendorData([
+            vendor,
+        ])
+    }, [
+        show,
     ])
 
     const table = useReactTable({
@@ -279,6 +292,8 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
     const handleClickSelectVendor = () => {
         setVendor(selectedVendor)
         setShow(!show)
+        setSearchText(undefined)
+        setVendorData([])
     }
 
     return (


### PR DESCRIPTION
This PR fixes the vendor search popup (`VendorDialog`) so that the currently saved vendor is shown and pre-selected when the dialog is opened from an edit screen.

Previously:

- When a component/project/release already had a saved vendor, clicking the vendor text box in the edit screen opened the **Search Vendor** popup with an empty results table. The saved vendor was neither listed nor highlighted, so the user could not see which vendor was currently set.

Changes:

- `src/components/sw360/SearchVendorsModal/VendorDialog.tsx`
  - Added an optional `overrideSearchText` parameter to `searchVendor` so a search can run immediately with a given term without waiting for the `searchText` state to update.
  - Added a `useEffect` on `show` that, when the dialog opens with a saved vendor, pre-selects that vendor and runs a search by its full name so the saved vendor appears in the results table and its radio button is pre-selected.
  - The visible search text box is intentionally left empty (not prefilled), while the saved vendor still loads in the list.

Because `VendorDialog` is shared, this fix applies to the component (`GeneralInfoComponent`), project (`ProjectAddSummary/GeneralInformation`), and release (`ReleaseSummary`) edit screens.

Issue: <!-- add the issue number here, e.g. #1234 -->

### Suggest Reviewer

> @amritkv , @deo002 

### How To Test?

1. Run the app and log in.
2. Open a component (or project/release) that already has a saved default vendor and go to its edit screen.
3. Click the vendor text box to open the **Search Vendor** popup.
4. Verify the saved vendor is listed in the results table and its radio button is already selected.
5. Verify the search text box at the top of the popup is empty (not prefilled).
6. Verify searching, resetting, selecting a different vendor, and clearing the vendor still work as before.