### PR TITLE
fix(Attchment): Fixed attachment update status keyword

### DIFF
--- a/src/components/Attachments/EditAttachments.tsx
+++ b/src/components/Attachments/EditAttachments.tsx
@@ -358,7 +358,7 @@ function EditAttachments<T>({ documentId, documentType, documentPayload, setDocu
                                         >
                                             <option
                                                 className='textlabel'
-                                                value='NOT_CHECKED'
+                                                value='NOTCHECKED'
                                             >
                                                 {t('NOT_CHECKED')}
                                             </option>


### PR DESCRIPTION
Fixed the enum for attachment status `Not Checked` while updating an Attachment.

Currently the enum `NOT_CHECKED` is sent for the status value `Not Checked` in the payload of update attachments but backend expects it as `NOTCHECKED`.

This PR fixes this bug.

Linked backend PR : https://github.com/eclipse-sw360/sw360/pull/4374