### PR TITLE
Revert "fix(UI): Show ECC pill in red when open ECC exists"

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -58,9 +58,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     const [obligationsTotal, setObligationsTotal] = useState<number>(0)
     const [obligationsNonOpenCount, setObligationsNonOpenCount] = useState<number>(0)
     const [obligationsLoading, setObligationsLoading] = useState<boolean>(false)
-    const [eccClassifiedCount, setEccClassifiedCount] = useState<number>(0)
-    const [eccOpenCount, setEccOpenCount] = useState<number>(0)
-    const [eccLoading, setEccLoading] = useState<boolean>(false)
     const [vulnerabilitiesTotal, setVulnerabilitiesTotal] = useState<number>(0)
     const [vulnerabilitiesRatedCount, setVulnerabilitiesRatedCount] = useState<number>(0)
     const [vulnerabilitiesLoading, setVulnerabilitiesLoading] = useState<boolean>(false)
@@ -220,7 +217,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
 
         const fetchCounts = async () => {
             setObligationsLoading(true)
-            setEccLoading(true)
             setVulnerabilitiesLoading(true)
             try {
                 const response = await ApiUtils.GET(`projects/${projectId}/tabCounts`, signal)
@@ -235,15 +231,12 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 const data = body as ProjectDetailTabCounts
                 setObligationsTotal(data.obligationCount)
                 setObligationsNonOpenCount(data.obligationNonOpenCount)
-                setEccClassifiedCount(Math.max(0, data.eccClassifiedCount))
-                setEccOpenCount(Math.max(0, data.eccOpenCount))
                 setVulnerabilitiesTotal(Math.max(0, data.vulnerabilityCount))
                 setVulnerabilitiesRatedCount(Math.max(0, data.vulnerabilityRatedCount))
             } catch (error) {
                 ApiUtils.reportError(error)
             } finally {
                 setObligationsLoading(false)
-                setEccLoading(false)
                 setVulnerabilitiesLoading(false)
             }
         }
@@ -267,15 +260,6 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
     const vulnerabilitiesCountValue = isVulnerabilitiesDisplayEnabled
         ? `${vulnerabilitiesRatedCount} / ${vulnerabilitiesTotal}`
         : '?/?'
-
-    const eccBadgeClassName =
-        eccOpenCount > 0
-            ? 'obligations-badge--danger'
-            : eccClassifiedCount > 0
-              ? 'obligations-badge--success'
-              : 'obligations-badge'
-
-    const eccCountValue = `${eccOpenCount} / ${eccClassifiedCount}`
 
     return (
         <>
@@ -370,13 +354,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                     eventKey='ecc'
                                     hidden={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                 >
-                                    <SidebarCountBadge
-                                        badgeClassName={eccBadgeClassName}
-                                        countId='eccCount'
-                                        isLoading={eccLoading}
-                                        label={t('ECC')}
-                                        value={eccCountValue}
-                                    />
+                                    <div className='my-2'>{t('ECC')}</div>
                                 </ListGroup.Item>
                                 <ListGroup.Item
                                     action

--- a/src/object-types/ProjectDetailTabCounts.ts
+++ b/src/object-types/ProjectDetailTabCounts.ts
@@ -12,8 +12,6 @@ interface ProjectDetailTabCounts {
     vulnerabilityRatedCount: number
     obligationCount: number
     obligationNonOpenCount: number
-    eccClassifiedCount: number
-    eccOpenCount: number
 }
 
 export default ProjectDetailTabCounts


### PR DESCRIPTION
Reverts eclipse-sw360/sw360-frontend#1854 since the backend branch is not yet merged and this causes confusion for the user.