### PR TITLE
Fix issues caused in urls of user detail and edit page by special symbols in email

### DIFF
--- a/.github/instructions/sw360_frontend.instructions.md
+++ b/.github/instructions/sw360_frontend.instructions.md
@@ -464,7 +464,7 @@ const columns = useMemo<ColumnDef<User>[]>(() => [
         header: t('Email'),
         enableSorting: true,
         cell: ({ row }) => (
-            <Link href={`/admin/users/${row.original.id}`}>
+            <Link href={`/admin/users/details?id=${encodeURIComponent(row.original.id)}`}>
                 {row.original.email}
             </Link>
         ),

--- a/src/app/[locale]/admin/users/components/UserAdministration.tsx
+++ b/src/app/[locale]/admin/users/components/UserAdministration.tsx
@@ -117,10 +117,11 @@ export default function UserAdminstration(): JSX.Element {
                 header: t('Email'),
                 enableSorting: true,
                 cell: ({ row }) => {
+                    const userId = CommonUtils.getIdFromUrl(row.original._links?.self.href)
                     return (
                         <Link
                             className='text-link'
-                            href={`/admin/users/details/${CommonUtils.getIdFromUrl(row.original._links?.self.href)}`}
+                            href={`/admin/users/details?id=${encodeURIComponent(userId)}`}
                         >
                             {row.original.email}
                         </Link>
@@ -189,11 +190,12 @@ export default function UserAdminstration(): JSX.Element {
                 id: 'actions',
                 header: t('Actions'),
                 cell: ({ row }) => {
+                    const userId = CommonUtils.getIdFromUrl(row.original._links?.self.href)
                     return (
                         <span className='d-flex justify-content-evenly'>
                             <OverlayTrigger overlay={<Tooltip>{t('Edit')}</Tooltip>}>
                                 <Link
-                                    href={`/admin/users/edit/${CommonUtils.getIdFromUrl(row.original._links?.self.href)}`}
+                                    href={`/admin/users/edit?id=${encodeURIComponent(userId)}`}
                                     className='overlay-trigger'
                                 >
                                     <BsPencil
@@ -209,11 +211,7 @@ export default function UserAdminstration(): JSX.Element {
                             >
                                 <span
                                     className='d-inline-block'
-                                    onClick={() =>
-                                        handleEditSecondaryDepartmentAndRoles(
-                                            CommonUtils.getIdFromUrl(row.original._links?.self.href),
-                                        )
-                                    }
+                                    onClick={() => handleEditSecondaryDepartmentAndRoles(userId)}
                                 >
                                     <BsFiles
                                         className='btn-icon overlay-trigger cursor-pointer'

--- a/src/app/[locale]/admin/users/details/page.tsx
+++ b/src/app/[locale]/admin/users/details/page.tsx
@@ -12,25 +12,30 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { notFound, useParams } from 'next/navigation'
+import { notFound, useSearchParams } from 'next/navigation'
 
 import { useTranslations } from 'next-intl'
 import { type JSX, useEffect, useState } from 'react'
 import { PageButtonHeader, PageSpinner } from '@/components/sw360'
 import { User } from '@/object-types'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import CommonUtils from '@/utils/common.utils'
 import { dispatchSessionExpiredEvent } from '@/utils/sessionExpiry.utils'
 
 const UserDetailPage = (): JSX.Element => {
-    const params = useParams<{
-        id: string
-    }>()
+    const searchParams = useSearchParams()
+    const userId = searchParams.get('id')
     const t = useTranslations('default')
     const [user, setUser] = useState<User | undefined>(undefined)
 
     useEffect(() => {
+        if (CommonUtils.isNullEmptyOrUndefinedString(userId)) {
+            notFound()
+            return
+        }
+
         ;(async () => {
-            const response = await ApiUtils.GET(`users/byid/${params.id}`)
+            const response = await ApiUtils.GET(`users/byid/${userId}`)
             if (response.status === StatusCodes.UNAUTHORIZED) {
                 return dispatchSessionExpiredEvent()
             } else if (response.status !== StatusCodes.OK) {
@@ -39,10 +44,17 @@ const UserDetailPage = (): JSX.Element => {
             const user = (await response.json()) as User
             setUser(user)
         })()
-    }, [])
+    }, [
+        userId,
+    ])
+
+    if (CommonUtils.isNullEmptyOrUndefinedString(userId)) {
+        return notFound()
+    }
+
     const headerbuttons = {
         'Edit User': {
-            link: `/admin/users/edit/${params.id}`,
+            link: `/admin/users/edit?id=${encodeURIComponent(userId)}`,
             type: 'primary',
             name: t('Edit User'),
         },

--- a/src/app/[locale]/admin/users/edit/components/ToggleUserActiveModal.tsx
+++ b/src/app/[locale]/admin/users/edit/components/ToggleUserActiveModal.tsx
@@ -9,6 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { StatusCodes } from 'http-status-codes'
 import { useRouter } from 'next/navigation'
 

--- a/src/app/[locale]/admin/users/edit/page.tsx
+++ b/src/app/[locale]/admin/users/edit/page.tsx
@@ -11,7 +11,7 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
-import { notFound, useParams, useRouter } from 'next/navigation'
+import { notFound, useRouter, useSearchParams } from 'next/navigation'
 
 import { useTranslations } from 'next-intl'
 import { PageSpinner } from 'next-sw360'
@@ -27,9 +27,8 @@ import ToggleUserActiveModal from './components/ToggleUserActiveModal'
 
 const AdminEditUserPage = (): JSX.Element => {
     const router = useRouter()
-    const params = useParams<{
-        id: string
-    }>()
+    const searchParams = useSearchParams()
+    const userId = searchParams.get('id')
     const t = useTranslations('default')
     const [userPayload, setUserPayload] = useState<UserPayload>({
         email: '',
@@ -46,9 +45,14 @@ const AdminEditUserPage = (): JSX.Element => {
     const [showToggleActiveModal, setShowToggleActiveModal] = useState(false)
 
     useEffect(() => {
+        if (CommonUtils.isNullEmptyOrUndefinedString(userId)) {
+            notFound()
+            return
+        }
+
         void (async () => {
             try {
-                const queryUrl = `users/byid/${params.id}`
+                const queryUrl = `users/byid/${userId}`
                 const response = await ApiUtils.GET(queryUrl)
                 if (response.status === StatusCodes.UNAUTHORIZED) {
                     return dispatchSessionExpiredEvent()
@@ -72,7 +76,13 @@ const AdminEditUserPage = (): JSX.Element => {
                 console.error(e)
             }
         })()
-    }, [])
+    }, [
+        userId,
+    ])
+
+    if (CommonUtils.isNullEmptyOrUndefinedString(userId)) {
+        return notFound()
+    }
 
     const handleUpdateUser = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -81,10 +91,10 @@ const AdminEditUserPage = (): JSX.Element => {
             if (CommonUtils.isNullEmptyOrUndefinedString(userPayload.password)) {
                 delete userPayload.password
             }
-            const response = await ApiUtils.PATCH(`users/${params.id}`, userPayload)
+            const response = await ApiUtils.PATCH(`users/${userId}`, userPayload)
             if (response.status === StatusCodes.OK) {
                 MessageService.success(t('Your request completed successfully'))
-                router.push(`/admin/users/details/${params.id}`)
+                router.push(`/admin/users/details?id=${encodeURIComponent(userId)}`)
             } else if (response.status === StatusCodes.UNAUTHORIZED) {
                 MessageService.success(t('Session has expired'))
                 return dispatchSessionExpiredEvent()
@@ -106,7 +116,7 @@ const AdminEditUserPage = (): JSX.Element => {
     }
 
     const handleCancel = () => {
-        router.push(`/admin/users/details/${params.id}`)
+        router.push(`/admin/users/details?id=${encodeURIComponent(userId)}`)
     }
 
     return !CommonUtils.isNullEmptyOrUndefinedString(userPayload.email) ? (
@@ -149,7 +159,7 @@ const AdminEditUserPage = (): JSX.Element => {
                 />
             </form>
             <ToggleUserActiveModal
-                userId={params.id}
+                userId={userId}
                 isUserDeactived={isUserDeactived}
                 showToggleActiveModal={showToggleActiveModal}
                 setShowToggleActiveModal={setShowToggleActiveModal}

--- a/src/components/sw360/SearchUsersDialog/SelectUsersDialog.tsx
+++ b/src/components/sw360/SearchUsersDialog/SelectUsersDialog.tsx
@@ -114,10 +114,11 @@ const SelectUsersDialog = ({
                 header: t('Email'),
                 enableSorting: true,
                 cell: ({ row }) => {
+                    const userId = CommonUtils.getIdFromUrl(row.original._links?.self.href)
                     return (
                         <Link
                             className='text-link'
-                            href={`/admin/users/details/${CommonUtils.getIdFromUrl(row.original._links?.self.href)}`}
+                            href={`/admin/users/details?id=${encodeURIComponent(userId)}`}
                         >
                             {row.original.email}
                         </Link>


### PR DESCRIPTION
Some users have emails as ids as urls such as 'http://localhost:3000/admin/users/details/user@sw360.org'. Special symbols in email such as '@' and '.' cause issues in email parsing of nextjs. While '@' can be replaced with %40, we have no replacement of '.', so 'http://localhost:3000/admin/users/details/user%40sw360.org' does not work either. The only option is to make it a query param rather than query slug. The license detail and edit pages also use query params for ids due to the same reason(presence of '.'s and other symbols in license names).

So, now, the url is 'http://localhost:3000/admin/users/edit?id=user%40sw360.org'

<img width="1832" height="1062" alt="image" src="https://github.com/user-attachments/assets/7600f607-731d-4b31-8c5d-edbbbe313ec8" />
