### PR TITLE
fix(project): Permission check while editing project

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -203,17 +203,50 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
         projectId,
     ])
 
-    const handleEditProject = (projectId: string) => {
-        if (
-            userIdentity?.email === summaryData?.['_embedded']?.['createdBy']?.['email'] ||
-            userIdentity?.userGroup === UserGroupType.ADMIN
-        ) {
-            MessageService.info(t('You are editing the original document'))
-            router.push(`/projects/edit/${projectId}?tab=${activeKey}`)
-        } else {
-            MessageService.info(t('You will create a moderation request if you update'))
-            router.push(`/projects/edit/${projectId}?tab=${activeKey}`)
+    const checkUpdateEligibility = async (projectId: string) => {
+        const url = CommonUtils.createUrlWithParams(`moderationrequest/validate`, {
+            entityType: 'PROJECT',
+            entityId: projectId,
+        })
+        const response = await ApiUtils.POST(url, {})
+        switch (response.status) {
+            case StatusCodes.UNAUTHORIZED:
+                MessageService.warn(t('Unauthorized request'))
+                return 'DENIED'
+            case StatusCodes.FORBIDDEN:
+                MessageService.warn(t('Access Denied'))
+                return 'DENIED'
+            case StatusCodes.BAD_REQUEST:
+                MessageService.warn(t('Invalid input or missing required parameters'))
+                return 'DENIED'
+            case StatusCodes.INTERNAL_SERVER_ERROR:
+                MessageService.error(t('Internal server error'))
+                return 'DENIED'
+            case StatusCodes.OK:
+                MessageService.info(t('You can write to the entity'))
+                return 'OK'
+            case StatusCodes.ACCEPTED:
+                MessageService.info(t('You are allowed to perform write with MR'))
+                return 'ACCEPTED'
+            default:
+                MessageService.error(t('Error while processing'))
+                return 'DENIED'
         }
+    }
+
+    const preRequisite = async () => {
+        try {
+            const isEligible = await checkUpdateEligibility(projectId)
+            if (isEligible === 'OK' || isEligible === 'ACCEPTED') {
+                handleEditProject(projectId)
+            }
+        } catch (error) {
+            ApiUtils.reportError(error)
+        }
+    }
+
+    const handleEditProject = (projectId: string) => {
+        router.push(`/projects/edit/${projectId}?tab=${activeKey}`)
     }
 
     useEffect(() => {
@@ -411,7 +444,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                         <Button
                                             variant='primary'
                                             className='me-2 col-auto'
-                                            onClick={() => handleEditProject(projectId)}
+                                            onClick={() => void preRequisite()}
                                             disabled={userIdentity?.userGroup === UserGroupType.SECURITY_USER}
                                         >
                                             {t('Edit Projects')}

--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -612,24 +612,21 @@ function EditProject({
             }
             const responses = await Promise.all(requests)
             for (const r of responses) {
-                if (
-                    !(
-                        r.status === StatusCodes.OK ||
-                        r.status === StatusCodes.CREATED ||
-                        r.status === StatusCodes.ACCEPTED
+                if (r.status === StatusCodes.OK || r.status === StatusCodes.CREATED) {
+                    MessageService.success(
+                        t('Project') + ` ${dataToUpdate.name} (${dataToUpdate.version}) ` + t('updated successfully'),
                     )
-                ) {
+                    router.push(`/projects/detail/${projectId}`)
+                } else if (r.status === StatusCodes.ACCEPTED) {
+                    MessageService.success(t('Moderation request is created'))
+                    router.push(`/projects/detail/${projectId}`)
+                } else {
                     const err = (await r.json()) as ErrorDetails
                     throw new ApiError(err.message, {
                         status: r.status,
                     })
                 }
             }
-
-            MessageService.success(
-                t('Project') + ` ${dataToUpdate.name} (${dataToUpdate.version}) ` + t('updated successfully'),
-            )
-            router.push(`/projects/detail/${projectId}`)
         } catch (error: unknown) {
             ApiUtils.reportError(error)
         }


### PR DESCRIPTION
Fixes in this PR :

 - Added permission check while routing from `Project Detail` page to `Edit Project` page
 - Fixed API response status code-based banner message while updating a project