### PR TITLE
fix(dept): Allow depts other than the ones in list

### DIFF
--- a/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
+++ b/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
@@ -41,6 +41,12 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
     const t = useTranslations('default')
     const [selectingDepartment, setSelectingDepartment] = useState<string>(department || '')
 
+    useEffect(() => {
+        setSelectingDepartment(department || '')
+    }, [
+        department,
+    ])
+
     const columns = useMemo<ColumnDef<Department>[]>(
         () => [
             {
@@ -51,7 +57,7 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
                             className='form-check-input'
                             type='radio'
                             checked={row.original.departmentName == selectingDepartment}
-                            onClick={() => handleDepartmentSelect(row.original.departmentName)}
+                            onChange={() => handleDepartmentSelect(row.original.departmentName)}
                         />
                     </div>
                 ),
@@ -179,7 +185,7 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
                                         type='text'
                                         name='department'
                                         value={selectingDepartment}
-                                        readOnly
+                                        onChange={(e) => handleDepartmentSelect(e.target.value)}
                                     />
                                 </Col>
                             </Row>


### PR DESCRIPTION
### Description
Currently, the new UI does not allow writing other department/group name in the Department Selector. This is undesired behavior. This field should be modifiable for the user.

I have made it modifiable.

### Test
<img width="881" height="407" alt="image" src="https://github.com/user-attachments/assets/29b6fe9f-5d0d-4933-92ba-bc63e8ac645f" />

<img width="857" height="89" alt="image" src="https://github.com/user-attachments/assets/552f4a3c-9878-422c-a2ae-27eb4052703b" />
