### PR TITLE
Make all releases and moderators visible

### DIFF
--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ExpandableComponents.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ExpandableComponents.tsx
@@ -127,6 +127,7 @@ export function ExpandableList({
                                 size={20}
                             />{' '}
                             {previewString}
+                            {'...'}
                         </div>
                     )}
                 </div>

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -562,10 +562,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
             }
             return row.depth === 0
         },
-
-        meta: {
-            rowHeightConstant: true,
-        },
     })
 
     detailTable.getRowModel().rows.forEach((row) => {
@@ -618,10 +614,6 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                 }
             }
             return row.depth === 0
-        },
-
-        meta: {
-            rowHeightConstant: true,
         },
     })
 

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
@@ -398,10 +398,6 @@ export default function ObligationTab({
             }
             return row.depth === 0
         },
-
-        meta: {
-            rowHeightConstant: true,
-        },
     })
 
     detailTable.getRowModel().rows.forEach((row) => {
@@ -454,10 +450,6 @@ export default function ObligationTab({
                 }
             }
             return row.depth === 0
-        },
-
-        meta: {
-            rowHeightConstant: true,
         },
     })
 

--- a/src/app/[locale]/requests/components/ClosedModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/ClosedModerationRequest.tsx
@@ -190,10 +190,6 @@ function ClosedModerationRequest(): ReactNode {
         getCoreRowModel: getCoreRowModel(),
 
         getPaginationRowModel: getPaginationRowModel(),
-
-        meta: {
-            rowHeightConstant: true,
-        },
     })
 
     return (

--- a/src/app/[locale]/requests/components/OpenModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/OpenModerationRequest.tsx
@@ -214,10 +214,6 @@ function OpenModerationRequest(): ReactNode {
         getCoreRowModel: getCoreRowModel(),
 
         getPaginationRowModel: getPaginationRowModel(),
-
-        meta: {
-            rowHeightConstant: true,
-        },
     })
 
     const handleCheckboxes = (moderationRequestId: string, documentName: string) => {


### PR DESCRIPTION
In Obligations tables in Project details/edit page, not all releases were visible after opening the dropdown. Same with moderation requests page. Fixed this issue.

<img width="1591" height="198" alt="image" src="https://github.com/user-attachments/assets/9ea92f11-cca0-4a45-b4f9-ffafe5a2b208" />

<img width="1628" height="194" alt="image" src="https://github.com/user-attachments/assets/9525b808-7030-4f67-9c18-ba1d0d3c66e4" />

<img width="1574" height="168" alt="image" src="https://github.com/user-attachments/assets/70fd23e0-a909-4207-a008-6c47fa0df1da" />
