### PR TITLE
fix(license): Fixed lincese text alignment

### DIFF
--- a/src/app/[locale]/licenses/detail/components/Text.tsx
+++ b/src/app/[locale]/licenses/detail/components/Text.tsx
@@ -1,5 +1,6 @@
 // Copyright (C) TOSHIBA CORPORATION, 2023. Part of the SW360 Frontend Project.
 // Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -30,7 +31,7 @@ const Text = ({ license }: Props): ReactNode => {
                 <tbody>
                     <tr>
                         <td>
-                            <pre>{license.text ?? ''}</pre>
+                            <pre className='change-text'>{license.text ?? ''}</pre>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
### Description

Fixed the license text table alignment at license detail page. 
If any line of the license text contains more character than screen width, it doesn't wrap the text in the box. It gives you a horizontal scroller to see the complete line in the text.

### Screenshot :

Rest of the texts in the box is blurred intentionally.

<img width="1879" height="851" alt="image" src="https://github.com/user-attachments/assets/9a83dbda-1a46-4f07-8a18-a0635b0685e7" />
