### PR TITLE
fix(Release): Auto fill vendor data from component

### DIFF
--- a/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
+++ b/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
@@ -187,9 +187,17 @@ function AddRelease({ componentId }: Props): ReactNode {
                     return notFound()
                 }
                 const component: Component = (await response.json()) as Component
+                const defaultVendor = component._embedded?.defaultVendor
+                if (defaultVendor) {
+                    setVendor({
+                        id: component.defaultVendorId,
+                        fullName: defaultVendor.fullName ?? '',
+                    })
+                }
                 setReleasePayload({
                     ...releasePayload,
                     name: component.name,
+                    vendorId: component.defaultVendorId ?? releasePayload.vendorId,
                 })
                 if (component.componentType === 'COTS') {
                     setWithCotsDetails(true)

--- a/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+++ b/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
@@ -210,6 +210,26 @@ const VendorDialog = ({ show, setShow, setVendor, vendor }: Props): JSX.Element 
         setVendorData([
             vendor,
         ])
+
+        const vendorId = getVendorIdentifier(vendor)
+        if (vendorId === '') return
+        if ((vendor.shortName ?? '') !== '' && (vendor.url ?? '') !== '') return
+
+        const controller = new AbortController()
+        void (async () => {
+            try {
+                const response = await ApiUtils.GET(`vendors/${vendorId}`, controller.signal)
+                if (response.status !== StatusCodes.OK) return
+                const fullVendor = (await response.json()) as Vendor
+                setSelectedVendor(fullVendor)
+                setVendorData([
+                    fullVendor,
+                ])
+            } catch (error) {
+                ApiUtils.reportError(error)
+            }
+        })()
+        return () => controller.abort()
     }, [
         show,
     ])


### PR DESCRIPTION
This PR fixes two related vendor pre-selection issues in the release/component flows:

1. **Vendor not pre-filled when adding a release from a component** – When clicking *Add Release* from a component that already has a default vendor, the vendor field was left empty. Now the component's `defaultVendor` / `defaultVendorId` are read on load and used to pre-populate both the displayed vendor field and the release payload's `vendorId`.

2. **Missing Short Name and URL in the Search Vendor popup** – When a vendor was already selected (in create/update release and update component), the Search Vendor dialog seeded its table with only `id` and `fullName`, leaving the *Short Name* and *URL* columns blank. The dialog now fetches the full vendor via `GET vendors/{id}` when those fields are missing, so all columns render correctly.

Issue: https://github.com/eclipse-sw360/sw360-frontend/issues/1911

### Suggest Reviewer

> @amritkv @deo002 .

<!-- e.g. @reviewer -->

### How To Test?

**Vendor auto-fill from component:**

1. Open a component that has a default vendor set.
2. Click *Add Release*.
3. Confirm the vendor field is pre-populated with the component's default vendor and is saved on creation.
4. Repeat with a component that has no default vendor and confirm the field stays empty.

**Search Vendor popup details:**

1. Open create/update release or update component with a vendor already selected.
2. Click the vendor field to open the *Search Vendor* dialog.
3. Confirm the pre-selected vendor row shows the Full Name, Short Name, and URL (previously Short Name and URL were blank).
