### PR TITLE
fix(ci): Fixed post perform codeql analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
 
             # Initializes the CodeQL tools for scanning.
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+              uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
               with:
                   languages: ${{ matrix.language }}
                   build-mode: ${{ matrix.build-mode }}


### PR DESCRIPTION
Fixed post perform codeql analysis error by updating the CodeQL's version to latest `v4.37.3` `Initialize CodeQL` step.