### PR TITLE
fix(home): Fixed mySubscription update on refresh

### DIFF
--- a/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
+++ b/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
@@ -48,7 +48,10 @@ function MySubscriptionsWidget(): ReactNode {
         setLoading(true)
         fetchData('components/mySubscriptions')
             .then((components) => {
-                if (components === undefined) return
+                if (components === undefined) {
+                    setComponentData([])
+                    return
+                }
                 if (
                     !CommonUtils.isNullOrUndefined(components['_embedded']) &&
                     !CommonUtils.isNullOrUndefined(components['_embedded']['sw360:components'])
@@ -61,7 +64,10 @@ function MySubscriptionsWidget(): ReactNode {
             .catch((err) => console.error(err))
         fetchData('releases/mySubscriptions')
             .then((releases) => {
-                if (releases === undefined) return
+                if (releases === undefined) {
+                    setReleaseData([])
+                    return
+                }
                 if (
                     !CommonUtils.isNullOrUndefined(releases['_embedded']) &&
                     !CommonUtils.isNullOrUndefined(releases['_embedded']['sw360:releases'])


### PR DESCRIPTION
Currently on click of refresh button at Home page under `My Subscription` tab, it doesn't update the list of subscribed components or releases.

#### Steps to re-produce :

 - Step 1 : Subscribe any component or release
 - Step 2 : Refresh the `My Subscriptions` tab at Home page
 - Step 3 : The subscribed component or release appears under `My Subscriptions`
 - Step 4 : Un-Subscribe the component or release, subscribed at Step 1
 - Step 5 : Refresh the `My Subscriptions` tab at Home page and it's not updating the list of subscribed items. It should show all the subscribed and un-subscribed components or releases
 
With this PR this issue is fixed.
 