### PR TITLE
feat(search): use new fiter fields

### DIFF
--- a/src/app/[locale]/search/components/KeywordSearch.tsx
+++ b/src/app/[locale]/search/components/KeywordSearch.tsx
@@ -172,15 +172,15 @@ function KeywordSearch({
     const querySearchText = searchParams.get('searchText')?.trim() ?? ''
 
     const initialState: SEARCH_STATE = {
-        project: false,
-        component: false,
-        license: false,
-        release: false,
-        obligation: false,
-        user: false,
-        vendor: false,
+        project: true,
+        component: true,
+        license: true,
+        release: true,
+        obligation: true,
+        user: true,
+        vendor: true,
         entireDocument: true,
-        package: false,
+        package: true,
     }
 
     const [searchOptions, dispatch] = useReducer(reducer, initialState)

--- a/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
+++ b/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
@@ -19,15 +19,7 @@ import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Alert, Button, Col, Form, Modal, OverlayTrigger, Row, Spinner, Tooltip } from 'react-bootstrap'
 import { BsCheck2, BsInfoCircle } from 'react-icons/bs'
 import { PageSizeSelector, SW360Table, TableFooter } from '@/components/sw360'
-import {
-    Embedded,
-    ErrorDetails,
-    PageableQueryParam,
-    PaginationMeta,
-    Project,
-    ReleaseDetail,
-    SearchResult,
-} from '@/object-types'
+import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, Project, ReleaseDetail } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 
@@ -38,7 +30,6 @@ interface Props {
 }
 
 type EmbeddedProjects = Embedded<Project, 'sw360:projects'>
-type EmbeddedSearchResults = Embedded<SearchResult, 'sw360:searchResults'>
 
 const Capitalize = (text: string) =>
     text.split('_').reduce((s, c) => s + ' ' + (c.charAt(0) + c.substring(1).toLocaleLowerCase()), '')
@@ -48,7 +39,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
     const [linkingReleaseName, setLinkingReleaseName] = useState('')
     const [withLinkedProject, setWithLinkedProject] = useState(true)
     const [showMessage, setShowMessage] = useState(false)
-    const [exactMatch, setExactMatch] = useState(false)
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [byNameOnly, setByNameOnly] = useState(true)
     const [selectedProject, setSelectedProject] = useState<Project>()
@@ -296,84 +286,46 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
         try {
             setShowProcessing(true)
 
+            let filterFieldName: string
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
-                // Search by name only using /projects endpoint
-                const queryUrl = CommonUtils.createUrlWithParams(
-                    `projects`,
-                    Object.fromEntries(
-                        Object.entries({
-                            ...pageableQueryParam,
-                            ...(searchText && searchText !== ''
-                                ? {
-                                      name: searchText,
-                                      luceneSearch: !exactMatch,
-                                  }
-                                : {}),
-                            allDetails: true,
-                        }).map(([key, value]) => [
-                            key,
-                            String(value),
-                        ]),
-                    ),
-                )
-                const response = await ApiUtils.GET(queryUrl, signal)
-                if (response.status !== StatusCodes.OK) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-
-                const data = (await response.json()) as EmbeddedProjects
-                setPaginationMeta(data.page)
-                setProjectData(
-                    CommonUtils.isNullOrUndefined(data['_embedded']['sw360:projects'])
-                        ? []
-                        : data['_embedded']['sw360:projects'],
-                )
+                filterFieldName = 'name'
             } else {
-                // Full-text search using /search endpoint
-                const params = new URLSearchParams()
-                if (searchText && searchText !== '') {
-                    params.append('searchText', searchText)
-                }
-                params.append('typeMasks', 'project')
-                if (!exactMatch) {
-                    params.append('typeMasks', 'document')
-                }
-                Object.entries(pageableQueryParam)
-                    .filter(([k]) => k !== 'sort')
-                    .forEach(([key, value]) => params.append(key, String(value)))
-
-                const response = await ApiUtils.GET(`search?${params.toString()}`, signal)
-                if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-
-                const data = (await response.json()) as EmbeddedSearchResults
-                setPaginationMeta(data.page)
-
-                // Fetch full project details for search results
-                const searchResults = data['_embedded']?.['sw360:searchResults'] ?? []
-                const projectIds = searchResults.filter((r) => r.type === 'project').map((r) => r.id)
-
-                if (projectIds.length === 0) {
-                    setProjectData([])
-                    return
-                }
-
-                // Fetch full details for each project
-                const projectPromises = projectIds.map((id) =>
-                    ApiUtils.GET(`projects/${id}`, signal)
-                        .then((res) => (res.status === StatusCodes.OK ? res.json() : null))
-                        .catch(() => null),
-                )
-                const projects = (await Promise.all(projectPromises)).filter((p): p is Project => p !== null)
-                setProjectData(projects)
+                filterFieldName = 'searchText'
             }
+            // Search using /projects endpoint
+            const queryUrl = CommonUtils.createUrlWithParams(
+                `projects`,
+                Object.fromEntries(
+                    Object.entries({
+                        ...pageableQueryParam,
+                        ...(searchText && searchText !== ''
+                            ? {
+                                  [filterFieldName]: searchText,
+                                  luceneSearch: true,
+                              }
+                            : {}),
+                        allDetails: true,
+                    }).map(([key, value]) => [
+                        key,
+                        String(value),
+                    ]),
+                ),
+            )
+            const response = await ApiUtils.GET(queryUrl, signal)
+            if (response.status !== StatusCodes.OK) {
+                const err = (await response.json()) as ErrorDetails
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
+            }
+
+            const data = (await response.json()) as EmbeddedProjects
+            setPaginationMeta(data.page)
+            setProjectData(
+                CommonUtils.isNullOrUndefined(data['_embedded']['sw360:projects'])
+                    ? []
+                    : data['_embedded']['sw360:projects'],
+            )
         } catch (error) {
             ApiUtils.reportError(error)
         } finally {
@@ -542,41 +494,6 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
                                     <Form.Group>
                                         <Form.Check
                                             inline
-                                            name='exact-match'
-                                            type='checkbox'
-                                            id='exact-match'
-                                            checked={exactMatch}
-                                            onChange={() => setExactMatch(!exactMatch)}
-                                        />
-                                        <Form.Label className='pt-2'>
-                                            {t('Restricted Search')}{' '}
-                                            <OverlayTrigger
-                                                overlay={
-                                                    <Tooltip>
-                                                        <div>
-                                                            {t(
-                                                                'In case By Name Only is unchecked checking this will search for elements with name and description matching the input Otherwise the entire document will be searched',
-                                                            )}
-                                                        </div>
-                                                        {t(
-                                                            'In case By Name Only is checked Checking this will search for elements with name exactly matching the input',
-                                                        )}
-                                                        .
-                                                    </Tooltip>
-                                                }
-                                                placement='top'
-                                            >
-                                                <sup>
-                                                    <BsInfoCircle size={20} />
-                                                </sup>
-                                            </OverlayTrigger>
-                                        </Form.Label>
-                                    </Form.Group>
-                                </Col>
-                                <Col xs='auto'>
-                                    <Form.Group>
-                                        <Form.Check
-                                            inline
                                             name='by-name-only'
                                             type='checkbox'
                                             id='by-name-only'
@@ -588,8 +505,13 @@ const LinkReleaseToProjectModal = ({ releaseId, show, setShow }: Props): JSX.Ele
                                             <OverlayTrigger
                                                 overlay={
                                                     <Tooltip>
+                                                        <div>
+                                                            {t(
+                                                                'Keep this checkbox checked to search elements only by name field',
+                                                            )}
+                                                        </div>
                                                         {t(
-                                                            'The search result will display elements with name matching the input',
+                                                            'Uncheck it to search for elements where other fields like description matches the search terms',
                                                         )}
                                                     </Tooltip>
                                                 }

--- a/src/components/sw360/SearchReleasesModal.tsx
+++ b/src/components/sw360/SearchReleasesModal.tsx
@@ -25,7 +25,7 @@ import {
 import { type JSX, useEffect, useMemo, useState } from 'react'
 import { Button, Col, Form, Modal, OverlayTrigger, Row, Spinner, Tooltip } from 'react-bootstrap'
 import { BsInfoCircle } from 'react-icons/bs'
-import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseDetail, SearchResult } from '@/object-types'
+import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseDetail } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 
@@ -36,12 +36,10 @@ interface SearchReleasesModalProps {
     multiSelect?: boolean
     preSelectedReleases?: ReleaseDetail[]
     projectId?: string
-    showExactMatch?: boolean
     showSubProjectReleases?: boolean
 }
 
 type EmbeddedReleases = Embedded<ReleaseDetail, 'sw360:releases'>
-type EmbeddedSearchResults = Embedded<SearchResult, 'sw360:searchResults'>
 
 const Capitalize = (text: string) =>
     text.split('_').reduce((s, c) => s + ' ' + (c.charAt(0) + c.substring(1).toLocaleLowerCase()), '')
@@ -58,7 +56,6 @@ export default function SearchReleasesModal({
     const t = useTranslations('default')
     const [selectedReleases, setSelectedReleases] = useState<Array<ReleaseDetail>>([])
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
-    const [exactMatch, setExactMatch] = useState(false)
     const [byNameOnly, setByNameOnly] = useState(true)
     const [onlySubProjectReleases, setOnlySubProjectReleases] = useState(false)
 
@@ -276,103 +273,55 @@ export default function SearchReleasesModal({
         try {
             setShowProcessing(true)
 
+            let filterFieldName: string
             if (byNameOnly || CommonUtils.isNullEmptyOrUndefinedString(searchText)) {
-                // Search by name only using /releases endpoint
-                const queryUrl = CommonUtils.createUrlWithParams(
-                    `releases`,
-                    Object.fromEntries(
-                        Object.entries({
-                            ...pageableQueryParam,
-                            ...(searchText && searchText !== ''
-                                ? {
-                                      name: searchText,
-                                      luceneSearch: !exactMatch,
-                                  }
-                                : {}),
-                            allDetails: true,
-                        }).map(([key, value]) => [
-                            key,
-                            String(value),
-                        ]),
-                    ),
-                )
-                const response = await ApiUtils.GET(queryUrl, signal)
-                if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-                if (response.status === StatusCodes.NO_CONTENT) {
-                    setPaginationMeta({
-                        size: 0,
-                        totalElements: 0,
-                        totalPages: 0,
-                        number: 0,
-                    })
-                    setReleaseData([])
-                    return
-                }
-                const data = (await response.json()) as EmbeddedReleases
-                setPaginationMeta(data.page)
-                setReleaseData(
-                    CommonUtils.isNullOrUndefined(data['_embedded']['sw360:releases'])
-                        ? []
-                        : data['_embedded']['sw360:releases'],
-                )
+                filterFieldName = 'name'
             } else {
-                // Full-text search using /search endpoint
-                const params = new URLSearchParams()
-                if (searchText && searchText !== '') {
-                    params.append('searchText', searchText)
-                }
-                params.append('typeMasks', 'release')
-                if (!exactMatch) {
-                    params.append('typeMasks', 'document')
-                }
-                Object.entries(pageableQueryParam)
-                    .filter(([k]) => k !== 'sort')
-                    .forEach(([key, value]) => params.append(key, String(value)))
-
-                const response = await ApiUtils.GET(`search?${params.toString()}`, signal)
-                if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
-                    const err = (await response.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: response.status,
-                    })
-                }
-
-                if (response.status === StatusCodes.NO_CONTENT) {
-                    setPaginationMeta({
-                        size: 0,
-                        totalElements: 0,
-                        totalPages: 0,
-                        number: 0,
-                    })
-                    setReleaseData([])
-                    return
-                }
-                const data = (await response.json()) as EmbeddedSearchResults
-                setPaginationMeta(data.page)
-
-                // Fetch full release details for search results
-                const searchResults = data['_embedded']?.['sw360:searchResults'] ?? []
-                const releaseIds = searchResults.filter((r) => r.type === 'release').map((r) => r.id)
-
-                if (releaseIds.length === 0) {
-                    setReleaseData([])
-                    return
-                }
-
-                // Fetch full details for each release
-                const releasePromises = releaseIds.map((id) =>
-                    ApiUtils.GET(`releases/${id}`, signal)
-                        .then((res) => (res.status === StatusCodes.OK ? res.json() : null))
-                        .catch(() => null),
-                )
-                const releases = (await Promise.all(releasePromises)).filter((r): r is ReleaseDetail => r !== null)
-                setReleaseData(releases)
+                filterFieldName = 'searchText'
             }
+            // Search using /releases endpoint
+            const queryUrl = CommonUtils.createUrlWithParams(
+                `releases`,
+                Object.fromEntries(
+                    Object.entries({
+                        ...pageableQueryParam,
+                        ...(searchText && searchText !== ''
+                            ? {
+                                  [filterFieldName]: searchText,
+                                  luceneSearch: true,
+                              }
+                            : {}),
+                        allDetails: true,
+                    }).map(([key, value]) => [
+                        key,
+                        String(value),
+                    ]),
+                ),
+            )
+            const response = await ApiUtils.GET(queryUrl, signal)
+            if (response.status !== StatusCodes.OK && response.status !== StatusCodes.NO_CONTENT) {
+                const err = (await response.json()) as ErrorDetails
+                throw new ApiError(err.message, {
+                    status: response.status,
+                })
+            }
+            if (response.status === StatusCodes.NO_CONTENT) {
+                setPaginationMeta({
+                    size: 0,
+                    totalElements: 0,
+                    totalPages: 0,
+                    number: 0,
+                })
+                setReleaseData([])
+                return
+            }
+            const data = (await response.json()) as EmbeddedReleases
+            setPaginationMeta(data.page)
+            setReleaseData(
+                CommonUtils.isNullOrUndefined(data['_embedded']['sw360:releases'])
+                    ? []
+                    : data['_embedded']['sw360:releases'],
+            )
         } catch (error) {
             ApiUtils.reportError(error)
         } finally {
@@ -409,7 +358,6 @@ export default function SearchReleasesModal({
         setShow(false)
         setReleaseData([])
         setSelectedReleases([])
-        setExactMatch(false)
         setByNameOnly(true)
         setOnlySubProjectReleases(false)
         setPaginationMeta({
@@ -468,41 +416,6 @@ export default function SearchReleasesModal({
                             </Col>
                         )}
                         <Col xs='auto'>
-                            <Form.Group controlId='exact-match-group'>
-                                <Form.Check
-                                    inline
-                                    name='exact-match'
-                                    type='checkbox'
-                                    id='exact-match-release'
-                                    checked={exactMatch}
-                                    onChange={() => setExactMatch(!exactMatch)}
-                                />
-                                <Form.Label className='pt-2'>
-                                    {t('Restricted Search')}{' '}
-                                    <OverlayTrigger
-                                        overlay={
-                                            <Tooltip>
-                                                <div>
-                                                    {t(
-                                                        'In case By Name Only is unchecked checking this will search for elements with name and description matching the input Otherwise the entire document will be searched',
-                                                    )}
-                                                </div>
-                                                {t(
-                                                    'In case By Name Only is checked Checking this will search for elements with name exactly matching the input',
-                                                )}
-                                                .
-                                            </Tooltip>
-                                        }
-                                        placement='top'
-                                    >
-                                        <sup>
-                                            <BsInfoCircle size={20} />
-                                        </sup>
-                                    </OverlayTrigger>
-                                </Form.Label>
-                            </Form.Group>
-                        </Col>
-                        <Col xs='auto'>
                             <Form.Group controlId='by-name-only-group'>
                                 <Form.Check
                                     inline
@@ -517,8 +430,13 @@ export default function SearchReleasesModal({
                                     <OverlayTrigger
                                         overlay={
                                             <Tooltip>
+                                                <div>
+                                                    {t(
+                                                        'Keep this checkbox checked to search elements only by name field',
+                                                    )}
+                                                </div>
                                                 {t(
-                                                    'The search result will display elements with name matching the input',
+                                                    'Uncheck it to search for elements where other fields like description matches the search terms',
                                                 )}
                                             </Tooltip>
                                         }

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -9,7 +9,7 @@
 
 import { test as setup, expect, Page } from '@playwright/test'
 import { config } from '../config'
-import { testUsers, createAllTestUsers, deleteAllTestUsers } from './helpers/testUserSetup'
+import { testUsers, createAllTestUsers } from './helpers/testUserSetup'
 
 /**
  * Authentication Setup

--- a/tests/e2e/search/fixtures.ts
+++ b/tests/e2e/search/fixtures.ts
@@ -46,7 +46,7 @@ export const fixtures = {
         project: '/projects/detail/',
         component: '/components/detail/',
         release: '/components/releases/detail/',
-        license: '/licenses/detail/',
+        license: '/licenses/detail?=',
         package: '/packages/detail/',
         obligation: '/obligations/detail/',
     },

--- a/tests/e2e/search/searchFilters.test.ts
+++ b/tests/e2e/search/searchFilters.test.ts
@@ -20,61 +20,63 @@ test.describe('Search Filters', () => {
         await expect(page.locator(selectors.checkboxes.entireDocument)).toBeChecked()
     })
 
-    test('TC17: Projects checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.projects)).not.toBeChecked()
-    })
-
-    test('TC18: Components checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.components)).not.toBeChecked()
-    })
-
-    test('TC19: Licenses checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.licenses)).not.toBeChecked()
-    })
-
-    test('TC20: Releases checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.releases)).not.toBeChecked()
-    })
-
-    test('TC21: Packages checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.packages)).not.toBeChecked()
-    })
-
-    test('TC22: Obligations checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.obligations)).not.toBeChecked()
-    })
-
-    test('TC23: Users checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.users)).not.toBeChecked()
-    })
-
-    test('TC24: Vendors checkbox is unchecked by default', async ({ page }) => {
-        await expect(page.locator(selectors.checkboxes.vendors)).not.toBeChecked()
-    })
-
-    test('TC25: Clicking Projects checkbox toggles it on', async ({ page }) => {
-        await page.locator(selectors.checkboxes.projects).check()
+    test('TC17: Projects checkbox is checked by default', async ({ page }) => {
         await expect(page.locator(selectors.checkboxes.projects)).toBeChecked()
     })
 
-    test('TC26: Clicking a checked checkbox toggles it off', async ({ page }) => {
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+    test('TC18: Components checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.components)).toBeChecked()
+    })
+
+    test('TC19: Licenses checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.licenses)).toBeChecked()
+    })
+
+    test('TC20: Releases checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.releases)).toBeChecked()
+    })
+
+    test('TC21: Packages checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.packages)).toBeChecked()
+    })
+
+    test('TC22: Obligations checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.obligations)).toBeChecked()
+    })
+
+    test('TC23: Users checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.users)).toBeChecked()
+    })
+
+    test('TC24: Vendors checkbox is checked by default', async ({ page }) => {
+        await expect(page.locator(selectors.checkboxes.vendors)).toBeChecked()
+    })
+
+    test('TC25: Clicking Projects checkbox toggles it off', async ({ page }) => {
+        await page.locator(selectors.checkboxes.projects).click()
+        await expect(page.locator(selectors.checkboxes.projects)).not.toBeChecked()
+    })
+
+    test('TC26: Clicking a checked checkbox toggles it', async ({ page }) => {
+        await page.locator(selectors.checkboxes.entireDocument).click()
         await expect(page.locator(selectors.checkboxes.entireDocument)).not.toBeChecked()
     })
 
     test('TC27: Toggle button inverts all checkbox states', async ({ page }) => {
-        // Initially: entireDocument=checked, all others=unchecked
+        // Initially: entireDocument=unchecked, users=unchecked, all others=checked
+        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.checkboxes.users).uncheck()
         await page.click(selectors.buttons.toggle)
-        // After toggle: entireDocument=unchecked, all others=checked
-        await expect(page.locator(selectors.checkboxes.entireDocument)).not.toBeChecked()
-        await expect(page.locator(selectors.checkboxes.projects)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.components)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.licenses)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.releases)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.packages)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.obligations)).toBeChecked()
+        // After toggle: entireDocument=checked, users=checked, all others=unchecked
+        await expect(page.locator(selectors.checkboxes.entireDocument)).toBeChecked()
+        await expect(page.locator(selectors.checkboxes.projects)).not.toBeChecked()
+        await expect(page.locator(selectors.checkboxes.components)).not.toBeChecked()
+        await expect(page.locator(selectors.checkboxes.licenses)).not.toBeChecked()
+        await expect(page.locator(selectors.checkboxes.releases)).not.toBeChecked()
+        await expect(page.locator(selectors.checkboxes.packages)).not.toBeChecked()
+        await expect(page.locator(selectors.checkboxes.obligations)).not.toBeChecked()
         await expect(page.locator(selectors.checkboxes.users)).toBeChecked()
-        await expect(page.locator(selectors.checkboxes.vendors)).toBeChecked()
+        await expect(page.locator(selectors.checkboxes.vendors)).not.toBeChecked()
     })
 
     test('TC28: Deselect All button unchecks all checkboxes', async ({ page }) => {

--- a/tests/e2e/search/searchNavigation.test.ts
+++ b/tests/e2e/search/searchNavigation.test.ts
@@ -20,7 +20,7 @@ test.describe('Search Navigation', () => {
     })
 
     test('TC46: Clicking a project result link navigates to project detail', async ({ page }) => {
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.projects).check()
         await performSearch(page, fixtures.keywords.generic)
 
@@ -34,7 +34,7 @@ test.describe('Search Navigation', () => {
     })
 
     test('TC47: Clicking a component result link navigates to component detail', async ({ page }) => {
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.components).check()
         await performSearch(page, fixtures.keywords.generic)
 
@@ -48,7 +48,7 @@ test.describe('Search Navigation', () => {
     })
 
     test('TC48: Clicking a license result link navigates to license detail', async ({ page }) => {
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.licenses).check()
         await performSearch(page, fixtures.keywords.license)
 
@@ -56,8 +56,8 @@ test.describe('Search Navigation', () => {
         if (count > 0) {
             const link = page.locator(`${selectors.results.table} tbody a.text-link`).first()
             await link.click()
-            await page.waitForURL(/\/licenses\/detail\//, { timeout: 15000 })
-            await expect(page).toHaveURL(/\/licenses\/detail\//)
+            await page.waitForURL(/\/licenses\/detail\?id=/, { timeout: 15000 })
+            await expect(page).toHaveURL(/\/licenses\/detail\?id=/)
         }
     })
 
@@ -87,7 +87,7 @@ test.describe('Search Navigation', () => {
         const fullCount = await getResultCount(page)
 
         // Now restrict to only projects
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.projects).check()
         await performSearch(page, fixtures.keywords.generic)
         const filteredCount = await getResultCount(page)

--- a/tests/e2e/search/searchResults.test.ts
+++ b/tests/e2e/search/searchResults.test.ts
@@ -145,7 +145,7 @@ test.describe.serial('Search Results', () => {
     test('TC39: Search with Projects filter only shows project results', async ({ page }) => {
         test.skip(!searchAvailable, 'Skipped - Nouveau search not available')
         // Uncheck Entire Document and check only Projects
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.projects).check()
 
         await performSearch(page, seededSearchTerm)
@@ -159,7 +159,7 @@ test.describe.serial('Search Results', () => {
 
     test('TC40: Search with Components filter shows component links', async ({ page }) => {
         test.skip(!searchAvailable, 'Skipped - Nouveau search not available')
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.components).check()
 
         await performSearch(page, fixtures.keywords.generic)
@@ -173,7 +173,7 @@ test.describe.serial('Search Results', () => {
 
     test('TC41: Search with Licenses filter shows license links', async ({ page }) => {
         test.skip(!searchAvailable, 'Skipped - Nouveau search not available')
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.licenses).check()
 
         await performSearch(page, fixtures.keywords.license)
@@ -181,13 +181,13 @@ test.describe.serial('Search Results', () => {
         if (count > 0) {
             const links = page.locator(`${selectors.results.table} tbody a.text-link`)
             const firstHref = await links.first().getAttribute('href')
-            expect(firstHref).toContain('/licenses/detail/')
+            expect(firstHref).toContain('/licenses/detail?id=')
         }
     })
 
     test('TC42: Search with Users filter shows user names as text (no links)', async ({ page }) => {
         test.skip(!searchAvailable, 'Skipped - Nouveau search not available')
-        await page.locator(selectors.checkboxes.entireDocument).uncheck()
+        await page.locator(selectors.buttons.deselectAll).click()
         await page.locator(selectors.checkboxes.users).check()
 
         await performSearch(page, 'sw360')


### PR DESCRIPTION
Update the remaining pop-up to use the new `searchText` parameter added as part of https://github.com/eclipse-sw360/sw360/pull/4424

This PR should be merged after #1919 only.