### PR TITLE
fix(ci): Remove untrusted head_ref interpolation

### DIFF
--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -95,5 +95,5 @@ jobs:
           else
             git add biome.json
             git commit -m "chore: Update biome schema to match CLI version"
-            git push origin HEAD:${{ github.head_ref }}
+            git push
           fi


### PR DESCRIPTION
### Summary

This PR removes an unsafe interpolation pattern in the Biome auto-migrate workflow.

### What changed

- Updated `.github/workflows/biome-schema-update.yml`
- Replaced:
  - `git push origin HEAD:${{ github.head_ref }}`
- With:
  - `git push`

### Why

Security scanning flagged the inline use of `github.head_ref` in a shell script as a **critical script-injection risk**.  
This change removes that dangerous pattern while preserving the intended behavior (pushing migration commits back to the checked-out Dependabot PR branch).

### Scope

- CI workflow-only change
- No application/runtime code changes