### PR TITLE
fix(component): Correct homepage URL placeholder

### DIFF
--- a/src/components/GeneralInfoComponent/GeneralInfoComponent.tsx
+++ b/src/components/GeneralInfoComponent/GeneralInfoComponent.tsx
@@ -242,7 +242,7 @@ const GeneralInfoComponent = ({ componentPayload, setComponentPayload, vendor, s
                             <input
                                 type='URL'
                                 className='form-control'
-                                placeholder={t('Will be set automatically')}
+                                placeholder={t('Enter Homepage URL')}
                                 id='tag'
                                 aria-describedby='Tag'
                                 name='homepage'


### PR DESCRIPTION
## Summary

- Correct the Homepage URL placeholder on the Edit Component page.
- Replace the misleading “Will be set automatically” placeholder with “Enter Homepage URL”.

Fixes #1913 

## Testing

- `git diff --check`
- `pnpm exec biome check src/components/GeneralInfoComponent/GeneralInfoComponent.tsx`