### PR TITLE
fix(date): Fix min and max date for date selector

### DIFF
--- a/src/app/[locale]/vulnerabilities/components/VulnerabilityDetail.tsx
+++ b/src/app/[locale]/vulnerabilities/components/VulnerabilityDetail.tsx
@@ -265,6 +265,8 @@ function VulnerabilityDetail({
                                     cvssDate: val,
                                 }))
                             }
+                            minDate={null}
+                            maxDate={new Date()}
                         />
                     </div>
                     <div className='col-lg-3'>
@@ -306,6 +308,8 @@ function VulnerabilityDetail({
                                     publishDate: val,
                                 }))
                             }
+                            minDate={null}
+                            maxDate={new Date()}
                         />
                     </div>
                     <div className='col-lg-3'>
@@ -344,6 +348,8 @@ function VulnerabilityDetail({
                                     lastExternalUpdateDate: val,
                                 }))
                             }
+                            minDate={null}
+                            maxDate={new Date()}
                         />
                     </div>
                     <div className='col-lg-3'>

--- a/src/components/ProjectAddSummary/component/Administration/LifeCycle.tsx
+++ b/src/components/ProjectAddSummary/component/Administration/LifeCycle.tsx
@@ -82,6 +82,8 @@ export default function Lifecycle({ projectPayload, setProjectPayload }: Props):
                                     systemTestStart: val,
                                 })
                             }
+                            minDate={null}
+                            maxDate={null}
                         />
                     </div>
                     <div className='col-lg-4'>
@@ -98,6 +100,8 @@ export default function Lifecycle({ projectPayload, setProjectPayload }: Props):
                                     systemTestEnd: val,
                                 })
                             }
+                            minDate={null}
+                            maxDate={null}
                         />
                     </div>
                 </div>
@@ -116,6 +120,8 @@ export default function Lifecycle({ projectPayload, setProjectPayload }: Props):
                                     deliveryStart: val,
                                 })
                             }
+                            minDate={null}
+                            maxDate={null}
                         />
                     </div>
                     <div className='col-lg-4'>
@@ -132,6 +138,8 @@ export default function Lifecycle({ projectPayload, setProjectPayload }: Props):
                                     phaseOutSince: val,
                                 })
                             }
+                            minDate={null}
+                            maxDate={null}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
Add the `minDate` and `maxDate` to `DateField` in Vulnerabilities to allow adding dates from past and in Project Administration to allow agreeable dates in past and future.