### PR TITLE
fix(Project): Fixed linked release loading on duplicate

### DIFF
--- a/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
+++ b/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
@@ -63,6 +63,8 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
         fullName: '',
     })
 
+    const [isReleaseLoading, setIsReleaseLoading] = useState(false)
+
     const [externalUrls, setExternalUrls] = useState<InputKeyValue[]>([])
 
     const [externalIds, setExternalIds] = useState<InputKeyValue[]>([])
@@ -101,8 +103,6 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
         description: '',
         domain: '',
         vendorId: '',
-        modifiedOn: '',
-        modifiedBy: '',
         additionalData: {},
         ownerAccountingUnit: '',
         ownerGroup: '',
@@ -181,6 +181,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
 
     const setObjectToMap = async (linkedReleases: LinkedReleaseProps[]) => {
         try {
+            setIsReleaseLoading(true)
             const linkedReleasesObject: {
                 [key: string]: LinkedReleaseData
             } = {}
@@ -202,7 +203,9 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                 linkedReleases: linkedReleasesObject,
             }))
         } catch (e) {
-            console.error(e)
+            ApiUtils.reportError(e)
+        } finally {
+            setIsReleaseLoading(false)
         }
     }
 
@@ -300,8 +303,6 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                     tag: project.tag ?? '',
                     description: project.description ?? '',
                     domain: project.domain ?? '',
-                    modifiedOn: project.modifiedOn ?? '',
-                    modifiedBy: project.modifiedBy ?? '',
                     externalIds: project.externalIds ?? {},
                     externalUrls: project.externalUrls ?? {},
                     additionalData: project.additionalData ?? {},
@@ -373,7 +374,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                 setProjectPayload(projectPayloadData)
                 setIsDuplicateProjectFetched(true)
             } catch (e) {
-                console.error(e)
+                ApiUtils.reportError(e)
             }
         })()
     }, [
@@ -470,6 +471,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                                                     type='submit'
                                                     className='me-2 col-auto'
                                                     onClick={() => void createProject()}
+                                                    disabled={isReleaseLoading}
                                                 >
                                                     {t('Create Project')}
                                                 </Button>
@@ -538,6 +540,7 @@ function DuplicateProject({ projectId, isDependencyNetworkFeatureEnabled }: Prop
                                                         isDependencyNetworkFeatureEnabled={
                                                             isDependencyNetworkFeatureEnabled
                                                         }
+                                                        isReleaseLoading={isReleaseLoading}
                                                     />
                                                 )}
                                             </Tab.Pane>

--- a/src/components/ProjectAddSummary/LinkedReleasesAndProjects.tsx
+++ b/src/components/ProjectAddSummary/LinkedReleasesAndProjects.tsx
@@ -21,6 +21,7 @@ interface Props {
     existingReleaseData?: Map<string, LinkedReleaseData>
     setProjectPayload: React.Dispatch<React.SetStateAction<ProjectPayload>>
     isDependencyNetworkFeatureEnabled: boolean
+    isReleaseLoading?: boolean
 }
 
 interface LinkedReleaseData {
@@ -36,6 +37,7 @@ export default function LinkedReleasesAndProjects({
     projectPayload,
     setProjectPayload,
     isDependencyNetworkFeatureEnabled,
+    isReleaseLoading = false,
 }: Props): JSX.Element {
     return (
         <>
@@ -54,6 +56,7 @@ export default function LinkedReleasesAndProjects({
                     <LinkedReleases
                         projectPayload={projectPayload}
                         setProjectPayload={setProjectPayload}
+                        isReleaseLoading={isReleaseLoading}
                     />
                 )}
             </div>

--- a/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx
+++ b/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx
@@ -12,7 +12,6 @@
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { useTranslations } from 'next-intl'
 import { type JSX, useCallback, useEffect, useMemo, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
 import { FaTrashAlt } from 'react-icons/fa'
 import { SW360Table } from '@/components/sw360'
 import SearchReleasesModal from '@/components/sw360/SearchReleasesModal'
@@ -21,9 +20,14 @@ import { LinkedReleaseData, ProjectPayload, ReleaseDetail } from '@/object-types
 interface Props {
     projectPayload: ProjectPayload
     setProjectPayload: React.Dispatch<React.SetStateAction<ProjectPayload>>
+    isReleaseLoading?: boolean
 }
 
-export default function LinkedReleases({ projectPayload, setProjectPayload }: Props): JSX.Element {
+export default function LinkedReleases({
+    projectPayload,
+    setProjectPayload,
+    isReleaseLoading = false,
+}: Props): JSX.Element {
     const t = useTranslations('default')
     const [showLinkedReleasesModal, setShowLinkedReleasesModal] = useState(false)
     const [tableData, setTableData] = useState<
@@ -300,16 +304,10 @@ export default function LinkedReleases({ projectPayload, setProjectPayload }: Pr
                     </h6>
                 </div>
                 <div className='mb-3'>
-                    {table ? (
-                        <SW360Table
-                            table={table}
-                            showProcessing={false}
-                        />
-                    ) : (
-                        <div className='col-12 mt-1 text-center'>
-                            <Spinner className='spinner' />
-                        </div>
-                    )}
+                    <SW360Table
+                        table={table}
+                        showProcessing={isReleaseLoading}
+                    />
                 </div>
                 <div
                     className='row'


### PR DESCRIPTION
This PR fixes the issues listed below:
 - Removed the `modifiedBy` and `modifiedOn` field from payload of duplicate project creation as it'll handled by backend
 - Made the `Create Project` button disabled until all the linked releases are loaded at duplicate project page
 - Introduced the `Processing...` info on the linked release table while the linked releases are loading