### PR TITLE
fix(UI): Resolve global search API call issue and display filtered result

### DIFF
--- a/src/app/[locale]/search/components/KeywordSearch.tsx
+++ b/src/app/[locale]/search/components/KeywordSearch.tsx
@@ -10,6 +10,7 @@
 'use client'
 
 import { StatusCodes } from 'http-status-codes'
+import { useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useReducer, useState } from 'react'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
@@ -167,6 +168,8 @@ function KeywordSearch({
     setPageableQueryParam: Dispatch<SetStateAction<PageableQueryParam>>
 }): ReactNode {
     const t = useTranslations('default')
+    const searchParams = useSearchParams()
+    const querySearchText = searchParams.get('searchText')?.trim() ?? ''
 
     const initialState: SEARCH_STATE = {
         project: false,
@@ -181,7 +184,21 @@ function KeywordSearch({
     }
 
     const [searchOptions, dispatch] = useReducer(reducer, initialState)
-    const [searchText, setSearchText] = useState('')
+    const [searchText, setSearchText] = useState(querySearchText)
+
+    useEffect(() => {
+        if (querySearchText === searchText) {
+            return
+        }
+
+        setSearchText(querySearchText)
+        setPageableQueryParam((prev) => ({
+            ...prev,
+            page: 0,
+        }))
+    }, [
+        querySearchText,
+    ])
 
     function appendTypeMasksToParams(searchOptions: SEARCH_STATE, params = new URLSearchParams()) {
         const entries = Object.entries(searchOptions)

--- a/src/components/sw360/Navbar/Navbar.tsx
+++ b/src/components/sw360/Navbar/Navbar.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link'
 import { useParams, useRouter, useSelectedLayoutSegment } from 'next/navigation'
 import { useSession } from 'next-auth/react'
 import { LocaleSwitcher, Logo, ProfileDropdown } from 'next-sw360'
-import { type JSX, useState } from 'react'
+import { type FormEvent, type JSX, useState } from 'react'
 import { Navbar as BSNavbar, Container, Form, Nav, NavDropdown } from 'react-bootstrap'
 import { useConfigKeyValue } from '@/contexts'
 import { ConfigKeys, NavList } from '@/object-types'
@@ -26,6 +26,7 @@ function Navbar(): JSX.Element {
 
     const { data: session, status } = useSession()
     const [show, setShow] = useState(false)
+    const [globalSearchText, setGlobalSearchText] = useState('')
     const selectedLayoutSegment = useSelectedLayoutSegment()
     const pathname = selectedLayoutSegment !== null ? `/${selectedLayoutSegment}` : '/'
     const isPackageFeatureEnabled = useConfigKeyValue(ConfigKeys.IS_PACKAGE_PORTLET_ENABLED) === 'true'
@@ -39,6 +40,21 @@ function Navbar(): JSX.Element {
     const getLocalizedPath = (path: string) => {
         if (path === '#' || path === '/') return path
         return `/${locale}${path}`
+    }
+
+    const handleGlobalSearch = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        const trimmedSearchText = globalSearchText.trim()
+
+        if (trimmedSearchText === '') {
+            router.push(`/${locale}/search`)
+            return
+        }
+
+        const params = new URLSearchParams({
+            searchText: trimmedSearchText,
+        })
+        router.push(`/${locale}/search?${params.toString()}`)
     }
     // NavItems receives an array of links with possible entries:
     // href: the link (mandatory)
@@ -133,11 +149,16 @@ function Navbar(): JSX.Element {
                             </Nav>
                         )}
                         {pathname != '/' && (
-                            <Form className='d-flex gap-3'>
+                            <Form
+                                className='d-flex gap-3'
+                                onSubmit={handleGlobalSearch}
+                            >
                                 <Form.Control
                                     type='text'
                                     placeholder='Search'
                                     className='me-2'
+                                    value={globalSearchText}
+                                    onChange={(event) => setGlobalSearchText(event.target.value)}
                                 />
                                 <ProfileDropdown />
                                 <LocaleSwitcher />


### PR DESCRIPTION
This PR fixes the following:

1. Fixed global search submit flow to pass search text in URL query params.
2. Synced search page input with URL searchText so results load correctly from Navbar search.
3. Resolved issue where global search showed unfiltered results.

Issue Link

Issue: : #1935 

Suggest Reviewer
@GMishx @deo002 

How To Test?

1: Login sw360
2: open any page and put the value in global search textbox.
3: will get the filtered result in search tab.