### PR TITLE
fix: Display warnings from backend in Obligations tabs

### DIFF
--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
@@ -15,7 +15,7 @@ import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, PageSizeSelector, SW360Table, TableFooter } from 'next-sw360'
 import { JSX, useEffect, useMemo, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { Alert, Spinner } from 'react-bootstrap'
 import {
     Embedded,
     ErrorDetails,
@@ -48,6 +48,7 @@ interface ProjectObligationData extends ObligationData {
 
 export default function LicenseObligation({ projectId }: { projectId: string }): JSX.Element {
     const t = useTranslations('default')
+    const [warnings, setWarnings] = useState<string[]>([])
 
     const columns = useMemo<
         ColumnDef<
@@ -250,6 +251,7 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
 
                 const data = (await response.json()) as ObligationResponse
                 setPaginationMeta(data.page)
+                setWarnings(data.warnings ?? [])
                 setObligationData(data.obligations)
             } catch (error) {
                 ApiUtils.reportError(error)
@@ -451,6 +453,20 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
 
     return (
         <div className='mb-3'>
+            {warnings.length > 0 && (
+                <div className='mb-3'>
+                    {warnings.map((warning, index) => (
+                        <Alert
+                            key={index}
+                            variant='warning'
+                            dismissible
+                            onClose={() => setWarnings((prev) => prev.filter((_, i) => i !== index))}
+                        >
+                            {warning}
+                        </Alert>
+                    ))}
+                </div>
+            )}
             {pageableQueryParam && paginationMeta && table ? (
                 <>
                     <PageSizeSelector

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -14,7 +14,7 @@ import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { Alert, Spinner } from 'react-bootstrap'
 import { PaddedCell, PageSizeSelector, SW360Table, TableFooter, UpdateCommentModal } from '@/components/sw360'
 import {
     ActionType,
@@ -50,6 +50,7 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
     const [showLicenseDbObligationsModal, setShowLicenseDbObligationsModal] = useState(false)
     const [showCompareObligationsModal, setShowCompareObligationsModal] = useState(false)
     const [refresh, setRefresh] = useState(false)
+    const [warnings, setWarnings] = useState<string[]>([])
 
     const detailColumns = useMemo<
         ColumnDef<
@@ -457,6 +458,7 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
 
                 const data = (await response.json()) as ObligationResponse
                 setPaginationMeta(data.page)
+                setWarnings(data.warnings ?? [])
                 setObligationData(
                     Object.entries(data.obligations).map(
                         (o) =>
@@ -665,6 +667,20 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                 setShow={setShowCompareObligationsModal}
                 setSelectedProjectId={setSelectedProjectId}
             />
+            {warnings.length > 0 && (
+                <div className='mb-3'>
+                    {warnings.map((warning, index) => (
+                        <Alert
+                            key={index}
+                            variant='warning'
+                            dismissible
+                            onClose={() => setWarnings((prev) => prev.filter((_, i) => i !== index))}
+                        >
+                            {warning}
+                        </Alert>
+                    ))}
+                </div>
+            )}
             <div className='d-flex justify-content-end'>
                 {actionType === ActionType.EDIT && (
                     <>

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
@@ -13,7 +13,7 @@ import { ColumnDef, getCoreRowModel, getExpandedRowModel, useReactTable } from '
 import { StatusCodes } from 'http-status-codes'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useState } from 'react'
-import { Spinner } from 'react-bootstrap'
+import { Alert, Spinner } from 'react-bootstrap'
 import { PaddedCell, PageSizeSelector, SW360Table, TableFooter, UpdateCommentModal } from '@/components/sw360'
 import {
     ActionType,
@@ -51,6 +51,7 @@ export default function ObligationTab({
 }: Props): JSX.Element {
     const t = useTranslations('default')
     const [updateCommentModalData, setUpdateCommentModalData] = useState<UpdateCommentModalMetadata | null>(null)
+    const [warnings, setWarnings] = useState<string[]>([])
 
     const detailColumns = useMemo<
         ColumnDef<
@@ -324,6 +325,7 @@ export default function ObligationTab({
 
                 const data = (await response.json()) as ObligationResponse
                 setPaginationMeta(data.page)
+                setWarnings(data.warnings ?? [])
                 setObligationData(
                     Object.entries(data.obligations).map(
                         (o) =>
@@ -489,6 +491,20 @@ export default function ObligationTab({
                     }
                 }}
             />
+            {warnings.length > 0 && (
+                <div className='mb-3'>
+                    {warnings.map((warning, index) => (
+                        <Alert
+                            key={index}
+                            variant='warning'
+                            dismissible
+                            onClose={() => setWarnings((prev) => prev.filter((_, i) => i !== index))}
+                        >
+                            {warning}
+                        </Alert>
+                    ))}
+                </div>
+            )}
             <div className='mb-3'>
                 {pageableQueryParam && paginationMeta && detailTable && editTable ? (
                     <>

--- a/src/object-types/Obligation.ts
+++ b/src/object-types/Obligation.ts
@@ -59,6 +59,7 @@ export interface ObligationEntry {
 export interface ObligationResponse {
     obligations: ObligationEntry
     page?: PaginationMeta
+    warnings?: string[]
 }
 
 type TYPE = string


### PR DESCRIPTION
#1953 
This PR displays backend-provided warnings in the Project Obligations so users can see when obligation data may be incomplete.

How to reproduce:

- Open a project where at least one linked release has multiple CLI attachments.
- Go to Project Detail -> Obligations tab -> license obligations
- Before this fix: no warning is shown .
- After this fix: warning banner(s) appear above the obligations table .
