### PR TITLE
fix(Project): Update multiple obligation

### DIFF
--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -570,42 +570,86 @@ function EditProject({
                 ),
             ]
             if (Object.keys(obligations).length !== 0) {
+                const licenseObligations: Record<string, object> = {}
+                const componentObligations: Record<string, object> = {}
+                const projectObligations: Record<string, object> = {}
+                const organisationObligations: Record<string, object> = {}
+
                 for (const key in obligations) {
-                    if (obligations[key]?.obligationType === ObligationType.LICENSE_OBLIGATION) {
-                        if (Object.hasOwn(obligations[key], 'obligationType')) {
-                            delete obligations[key].obligationType
+                    const obligation = {
+                        ...obligations[key],
+                    }
+                    const obligationType = obligation.obligationType
+                    delete obligation.obligationType
+
+                    if (obligationType === ObligationType.LICENSE_OBLIGATION) {
+                        licenseObligations[key] = {
+                            ...obligation,
+                            obligationLevel: ObligationType.LICENSE_OBLIGATION,
                         }
+                    } else if (obligationType === ObligationType.COMPONENT_OBLIGATION) {
+                        componentObligations[key] = {
+                            ...obligation,
+                            obligationLevel: ObligationType.COMPONENT_OBLIGATION,
+                        }
+                    } else if (obligationType === ObligationType.PROJECT_OBLIGATION) {
+                        projectObligations[key] = {
+                            ...obligation,
+                            obligationLevel: ObligationType.PROJECT_OBLIGATION,
+                        }
+                    } else if (obligationType === ObligationType.ORGANISATION_OBLIGATION) {
+                        organisationObligations[key] = {
+                            ...obligation,
+                            obligationLevel: ObligationType.ORGANISATION_OBLIGATION,
+                        }
+                    }
+                }
+
+                const nonEmptyBuckets = [
+                    licenseObligations,
+                    componentObligations,
+                    projectObligations,
+                    organisationObligations,
+                ].filter((b) => Object.keys(b).length > 0)
+
+                if (nonEmptyBuckets.length > 1) {
+                    const allObligations = {
+                        ...licenseObligations,
+                        ...componentObligations,
+                        ...projectObligations,
+                        ...organisationObligations,
+                    }
+                    requests.push(
+                        ApiUtils.PATCH(`projects/${projectId}/updateObligation?obligationLevel=all`, allObligations),
+                    )
+                } else {
+                    if (Object.keys(licenseObligations).length > 0) {
                         requests.push(
-                            ApiUtils.PATCH(`projects/${projectId}/updateLicenseObligation`, {
-                                [key]: obligations[key],
-                            }),
+                            ApiUtils.PATCH(`projects/${projectId}/updateLicenseObligation`, licenseObligations),
                         )
-                    } else if (obligations[key]?.obligationType === ObligationType.COMPONENT_OBLIGATION) {
-                        if (Object.hasOwn(obligations[key], 'obligationType')) {
-                            delete obligations[key].obligationType
-                        }
+                    }
+                    if (Object.keys(componentObligations).length > 0) {
                         requests.push(
-                            ApiUtils.PATCH(`projects/${projectId}/updateObligation?obligationLevel=component`, {
-                                [key]: obligations[key],
-                            }),
+                            ApiUtils.PATCH(
+                                `projects/${projectId}/updateObligation?obligationLevel=component`,
+                                componentObligations,
+                            ),
                         )
-                    } else if (obligations[key]?.obligationType === ObligationType.PROJECT_OBLIGATION) {
-                        if (Object.hasOwn(obligations[key], 'obligationType')) {
-                            delete obligations[key].obligationType
-                        }
+                    }
+                    if (Object.keys(projectObligations).length > 0) {
                         requests.push(
-                            ApiUtils.PATCH(`projects/${projectId}/updateObligation?obligationLevel=project`, {
-                                [key]: obligations[key],
-                            }),
+                            ApiUtils.PATCH(
+                                `projects/${projectId}/updateObligation?obligationLevel=project`,
+                                projectObligations,
+                            ),
                         )
-                    } else if (obligations[key]?.obligationType === ObligationType.ORGANISATION_OBLIGATION) {
-                        if (Object.hasOwn(obligations[key], 'obligationType')) {
-                            delete obligations[key].obligationType
-                        }
+                    }
+                    if (Object.keys(organisationObligations).length > 0) {
                         requests.push(
-                            ApiUtils.PATCH(`projects/${projectId}/updateObligation?obligationLevel=organization`, {
-                                [key]: obligations[key],
-                            }),
+                            ApiUtils.PATCH(
+                                `projects/${projectId}/updateObligation?obligationLevel=organization`,
+                                organisationObligations,
+                            ),
                         )
                     }
                 }


### PR DESCRIPTION
[//]: # (This program and the accompanying materials are made)
[//]: # (available under the terms of the Eclipse Public License 2.0)
[//]: # (which is available at https://www.eclipse.org/legal/epl-2.0/)
[//]: # (SPDX-License-Identifier: EPL-2.0)

### Summary

Previously, when saving a project, each obligation type (license, component, project, organisation) was updated via separate PATCH requests regardless of how many types were present. This caused only the last request to persist when multiple obligation types were modified together.

This fix buckets obligations by their `obligationType` before dispatching updates:
- If obligations of **multiple types** are present, all are sent in a single `PATCH projects/{id}/updateObligation?obligationLevel=all` request.
- If obligations of only **one type** are present, the existing type-specific endpoint is used (`updateLicenseObligation`, `updateObligation?obligationLevel=component/project/organization`).

This ensures that saving a project with mixed obligation types correctly persists all changes.

Issue: https://github.com/eclipse-sw360/sw360-frontend/issues/1955

### Suggest Reviewer
> @amritkv @GMishx 

### How To Test?

1. Open an existing project that has obligations of **more than one type** (e.g. both License and Component obligations).
2. Change the status/comment on obligations from different types.
3. Save the project.
4. Re-open the project and verify that all obligation changes across all types are persisted correctly.

Previously only one obligation type would be saved; after this fix all types should reflect the changes.

### Checklist

Must:
- [ ] All related issues are referenced in commit messages and in PR
