### PR TITLE
fix(UI): Show Used By Projects loader during API fetch

### DIFF
--- a/src/components/ResourcesUsing/ProjectsUsing.tsx
+++ b/src/components/ResourcesUsing/ProjectsUsing.tsx
@@ -9,6 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'

--- a/src/components/ResourcesUsing/ResourcesUsing.tsx
+++ b/src/components/ResourcesUsing/ResourcesUsing.tsx
@@ -30,10 +30,15 @@ const ResourcesUsing = ({ documentId, documentType, documentName }: Props): JSX.
 
     const [showProcessing, setShowProcessing] = useState(false)
 
+    const projectUsings = resourcesUsing?._embedded['sw360:projects'] ?? []
+    const componentsUsing = resourcesUsing?._embedded['sw360:components'] ?? []
+    const restrictedResource = resourcesUsing?._embedded['sw360:restrictedResources']?.[0]
+    const shouldRenderProjectsUsing = showProcessing || !CommonUtils.isNullEmptyOrUndefinedArray(projectUsings)
+    const shouldRenderComponentsUsing = !CommonUtils.isNullEmptyOrUndefinedArray(componentsUsing)
+
     useEffect(() => {
         const controller = new AbortController()
         const signal = controller.signal
-
         void (async () => {
             try {
                 setShowProcessing(true)
@@ -65,29 +70,20 @@ const ResourcesUsing = ({ documentId, documentType, documentName }: Props): JSX.
 
     return (
         <>
-            {' '}
-            {resourcesUsing !== undefined && (
-                <>
-                    {!CommonUtils.isNullEmptyOrUndefinedArray(resourcesUsing._embedded['sw360:projects']) && (
-                        <ProjectsUsing
-                            projectUsings={resourcesUsing._embedded['sw360:projects']}
-                            documentName={documentName}
-                            restrictedResource={
-                                !CommonUtils.isNullOrUndefined(resourcesUsing._embedded['sw360:restrictedResources'])
-                                    ? resourcesUsing._embedded['sw360:restrictedResources'][0]
-                                    : undefined
-                            }
-                            showProcessing={showProcessing}
-                        />
-                    )}
-                    {!CommonUtils.isNullEmptyOrUndefinedArray(resourcesUsing._embedded['sw360:components']) && (
-                        <ComponentsUsing
-                            componentsUsing={resourcesUsing._embedded['sw360:components']}
-                            documentName={documentName}
-                            showProcessing={showProcessing}
-                        />
-                    )}
-                </>
+            {shouldRenderProjectsUsing && (
+                <ProjectsUsing
+                    projectUsings={projectUsings}
+                    documentName={documentName}
+                    restrictedResource={restrictedResource}
+                    showProcessing={showProcessing}
+                />
+            )}
+            {shouldRenderComponentsUsing && (
+                <ComponentsUsing
+                    componentsUsing={componentsUsing}
+                    documentName={documentName}
+                    showProcessing={showProcessing}
+                />
             )}
         </>
     )


### PR DESCRIPTION
## Summary
- Fixed "Used By" loader visibility issue in Projects section.
- Kept optimization minimal and safe.
- Added optional backend flag to skip restricted project count when not needed.

## Root Cause
- Projects section was not rendering during loading state, so loader was not visible.

## What Changed
- Frontend: render Projects section while loading so spinner can appear.

Issue:

Suggest Reviewer
@GMishx @amritkv .

How To Test?
How should these changes be tested by the reviewer?
Have you implemented any additional tests?

1. Open a release detail page that has linked projects.
2. Reload the page.
3. Verify loading feedback appears immediately in Used By Projects.
4. After response:
- if linked projects exist, table is shown
- if no linked projects exist, table remains hidden (existing behavior)
5. Verify Components usage section behavior remains unchanged.
6. Test on throttled network and confirm loader remains visible until response completes.

