### PR TITLE
fix(release): Adding the clearing report column in release overview

### DIFF
--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -20,11 +20,20 @@ import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter, TableSearch } from 'next-sw360'
 import { KeyboardEvent, ReactNode, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, OverlayTrigger, Tooltip } from 'react-bootstrap'
-import { BsClipboard, BsFillTrashFill, BsGit, BsLink45Deg, BsPencil } from 'react-icons/bs'
+import { BsClipboard, BsDownload, BsFillTrashFill, BsGit, BsLink45Deg, BsPencil } from 'react-icons/bs'
 import fossologyIcon from '@/assets/images/fossology.svg'
 import LinkReleaseToProjectModal from '@/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal'
 import FossologyClearing from '@/components/sw360/FossologyClearing/FossologyClearing'
-import { Embedded, ErrorDetails, PageableQueryParam, PaginationMeta, ReleaseLink, UserGroupType } from '@/object-types'
+import {
+    Attachment,
+    Embedded,
+    ErrorDetails,
+    PageableQueryParam,
+    PaginationMeta,
+    ReleaseLink,
+    UserGroupType,
+} from '@/object-types'
+import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
@@ -100,6 +109,69 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
         setLinkingReleaseId(releaseId)
     }
 
+    const handleClearingReportDownload = async (releaseId: string, attachment: Attachment) => {
+        if (!attachment.attachmentContentId) return
+
+        await DownloadService.download(
+            `releases/${releaseId}/attachments/${attachment.attachmentContentId}`,
+            attachment.filename,
+        )
+    }
+
+    const buildClearingReportTooltip = (attachment: Attachment): string => {
+        const status = attachment.checkStatus
+            ? `${attachment.checkStatus}${attachment.checkedBy ? ` by ${attachment.checkedBy}` : ''}${attachment.checkedOn ? ` on ${attachment.checkedOn}` : ''}`
+            : ''
+        const created = `${attachment.createdBy ?? ''}${attachment.createdOn ? ` on ${attachment.createdOn}` : ''}`
+
+        return [
+            `Filename: ${attachment.filename}`,
+            `Status: ${status}`,
+            `Comment: ${attachment.checkedComment ?? ''}`,
+            `Created: ${created}`,
+        ].join('\n')
+    }
+
+    const renderClearingReportCell = (release: ReleaseLink) => {
+        const reports = release.clearingReport?.attachments ?? []
+
+        if (reports.length === 0) {
+            const clearingReportStatus = release.clearingReport?.clearingReportStatus
+            return <>{clearingReportStatus ? t(clearingReportStatus as never) : t('NO_REPORT')}</>
+        }
+
+        return (
+            <span className='d-flex flex-wrap gap-1'>
+                {reports.map((attachment) => (
+                    <OverlayTrigger
+                        key={attachment.attachmentContentId ?? attachment.filename}
+                        placement='left'
+                        overlay={
+                            <Tooltip>
+                                <span
+                                    className='text-start d-inline-block'
+                                    style={{
+                                        whiteSpace: 'pre-line',
+                                    }}
+                                >
+                                    {buildClearingReportTooltip(attachment)}
+                                </span>
+                            </Tooltip>
+                        }
+                    >
+                        <span
+                            className='btn-icon text-warning'
+                            role='button'
+                            onClick={() => void handleClearingReportDownload(release.id, attachment)}
+                        >
+                            <BsDownload size={18} />
+                        </span>
+                    </OverlayTrigger>
+                ))}
+            </span>
+        )
+    }
+
     const searchFunction = (event: KeyboardEvent<HTMLInputElement>) => {
         if (event.currentTarget.value === '') {
             setSearch({
@@ -122,7 +194,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 enableSorting: true,
                 cell: (info) => info.getValue(),
                 meta: {
-                    width: '20%',
+                    width: '18%',
                 },
             },
             {
@@ -142,7 +214,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                     )
                 },
                 meta: {
-                    width: '20%',
+                    width: '18%',
                 },
             },
             {
@@ -153,7 +225,16 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 cell: ({ row }) => <>{Capitalize(row.original.clearingState ?? '')}</>,
 
                 meta: {
-                    width: '20%',
+                    width: '16%',
+                },
+            },
+            {
+                id: 'clearingReport',
+                header: t('CLEARING_REPORT'),
+                enableSorting: false,
+                cell: ({ row }) => renderClearingReportCell(row.original),
+                meta: {
+                    width: '16%',
                 },
             },
             {
@@ -163,7 +244,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 enableSorting: true,
                 cell: ({ row }) => <>{Capitalize(row.original.mainlineState ?? '')}</>,
                 meta: {
-                    width: '20%',
+                    width: '16%',
                 },
             },
             {
@@ -228,7 +309,7 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                     )
                 },
                 meta: {
-                    width: '20%',
+                    width: '16%',
                 },
             },
         ],
@@ -304,6 +385,9 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 setPaginationMeta(data.page)
                 setReleaseData(data['_embedded']?.['sw360:releaseLinks'] ?? [])
             } catch (error) {
+                if (error instanceof DOMException && error.name === 'AbortError') {
+                    return
+                }
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)

--- a/src/object-types/ReleaseLink.ts
+++ b/src/object-types/ReleaseLink.ts
@@ -9,6 +9,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+import Attachment from './Attachment'
+
 interface ReleaseLink {
     id: string
     name: string
@@ -17,6 +19,7 @@ interface ReleaseLink {
     clearingReport?:
         | {
               clearingReportStatus: string
+              attachments?: Attachment[]
           }
         | undefined
     clearingState?: string


### PR DESCRIPTION
Adding the Clearing Report column in release overview table in Components page.

<img width="1807" height="362" alt="image" src="https://github.com/user-attachments/assets/83a05f6e-17cf-4a9d-899f-627832a7e588" />
