### PR TITLE
fix(UI): Prevent empty table message from flashing before data loads.

### DIFF
--- a/src/components/sw360/Table/Components.tsx
+++ b/src/components/sw360/Table/Components.tsx
@@ -7,13 +7,35 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnFiltersState, flexRender, Row, Table } from '@tanstack/react-table'
 import { useTranslations } from 'next-intl'
-import { ChangeEvent, Dispatch, Fragment, ReactNode, SetStateAction } from 'react'
+import {
+    ChangeEvent,
+    Dispatch,
+    Fragment,
+    ReactNode,
+    SetStateAction,
+    useDeferredValue,
+    useEffect,
+    useRef,
+    useState,
+    useSyncExternalStore,
+} from 'react'
 import { Dropdown, DropdownButton } from 'react-bootstrap'
 import { BiSort } from 'react-icons/bi'
 import { BsCaretDownFill, BsCaretRightFill, BsSortDown, BsSortDownAlt } from 'react-icons/bs'
 import { ColumnMeta, FilterOption, PageableQueryParam, PaginationMeta } from '@/object-types'
+import { getPendingRequestCount, subscribeToPendingRequests } from '@/utils/api/api.util'
+
+// How long nothing may be in flight before an empty table counts as loaded. Bridges the gap
+// between a superseded request and the one replacing it.
+const NETWORK_QUIET_MS = 1000
+
+// Same, for a table that never showed a loading state: it is either fed by static props or has not
+// started fetching yet, so wait longer before assuming it is really empty.
+const NO_LOAD_SEEN_MS = 5000
 
 export function TableFooter({
     pageableQueryParam,
@@ -295,6 +317,39 @@ export function SW360Table<K>({
 }): ReactNode {
     const t = useTranslations('default')
 
+    // Defer the row model so the previous rows (and processing overlay) stay on screen
+    // while the new rows are being computed/rendered, instead of committing a blank tbody first.
+    const rows = table.getRowModel().rows
+    const deferredRows = useDeferredValue(rows)
+    const isRenderPending = deferredRows !== rows
+
+    // An empty table is ambiguous: the consumer may not have started fetching yet (the markup is
+    // rendered on the server), and a request aborted on effect cleanup still runs the consumer's
+    // `finally`, clearing `showProcessing` while its replacement runs. So only trust an empty table
+    // once nothing is in flight and it has stayed that way, longer if no load was ever seen.
+    const isEmptyAndIdle = !showProcessing && !isRenderPending && deferredRows.length === 0
+    const pendingRequests = useSyncExternalStore(subscribeToPendingRequests, getPendingRequestCount, () => 1)
+    const hasLoadedOnce = useRef(false)
+    const [showEmptyMessage, setShowEmptyMessage] = useState(false)
+    useEffect(() => {
+        if (showProcessing) hasLoadedOnce.current = true
+        if (!isEmptyAndIdle || pendingRequests > 0) {
+            setShowEmptyMessage(false)
+            return
+        }
+        const timeout = setTimeout(
+            () => setShowEmptyMessage(true),
+            hasLoadedOnce.current ? NETWORK_QUIET_MS : NO_LOAD_SEEN_MS,
+        )
+        return () => clearTimeout(timeout)
+    }, [
+        isEmptyAndIdle,
+        pendingRequests,
+        showProcessing,
+    ])
+
+    const displayProcessing = showProcessing || isRenderPending || (isEmptyAndIdle && !showEmptyMessage)
+
     return (
         <div className='table-component position-relative'>
             <table
@@ -340,7 +395,7 @@ export function SW360Table<K>({
                     ))}
                 </thead>
                 <tbody>
-                    {!showProcessing && table.getRowModel().rows.length === 0 && (
+                    {showEmptyMessage && (
                         <tr>
                             <td colSpan={table.getVisibleFlatColumns().length}>
                                 <div className='text-center'>
@@ -349,7 +404,7 @@ export function SW360Table<K>({
                             </td>
                         </tr>
                     )}
-                    {table.getRowModel().rows.map((row) =>
+                    {deferredRows.map((row) =>
                         row.meta?.isFullSpanRow ? (
                             <tr key={row.id}>
                                 <td colSpan={table.getVisibleLeafColumns().length}>
@@ -380,7 +435,7 @@ export function SW360Table<K>({
                     )}
                 </tbody>
             </table>
-            {showProcessing && (
+            {displayProcessing && (
                 <div className='position-absolute top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center'>
                     <div className='bg-white p-4 border rounded shadow'>{t('Processing')}…</div>
                 </div>

--- a/src/utils/api/api.util.ts
+++ b/src/utils/api/api.util.ts
@@ -127,9 +127,39 @@ function handleError(error: unknown): ApiError {
 }
 
 /**
+ * Number of requests currently in flight, published so the UI can tell a superseded request
+ * (aborted on effect cleanup) from one that really finished. See SW360Table.
+ */
+let pendingRequestCount = 0
+const pendingRequestListeners = new Set<() => void>()
+
+export function getPendingRequestCount(): number {
+    return pendingRequestCount
+}
+
+export function subscribeToPendingRequests(listener: () => void): () => void {
+    pendingRequestListeners.add(listener)
+    return () => pendingRequestListeners.delete(listener)
+}
+
+function trackPendingRequest(delta: number): void {
+    pendingRequestCount += delta
+    pendingRequestListeners.forEach((listener) => listener())
+}
+
+async function send(args: Parameters<typeof sendRequest>[0]): Promise<Response> {
+    trackPendingRequest(1)
+    try {
+        return await sendRequest(args)
+    } finally {
+        trackPendingRequest(-1)
+    }
+}
+
+/**
  * Core send function with timeout, retry, and error handling
  */
-async function send({
+async function sendRequest({
     method,
     path,
     data,


### PR DESCRIPTION
## Summary
- Fixed incorrect table state order on initial page load across the app.
- Fix applied in the shared table component, so all tables and tabs are covered.
- Prevented superseded (aborted) API requests from resetting the loading state of the newer request.
## Root Cause
- Pages start their fetch after mount and flip showProcessing via setTimeout(..., 0), so on the first frames the table is empty while     showProcessing is still false. SW360Table could not distinguish "not loaded yet" from "loaded and empty", and rendered "No data available in table".
- On the Projects page a second effect resets pageableQueryParam on mount, which aborts the first request. The aborted request's finally block then ran setShowProcessing(false), clearing the loading state that the newer, still in-flight request owned.
## What Changed
Frontend (SW360Table): the processing overlay is kept until the table has stayed empty and idle for a short grace period, so the empty-state message can only render once a request has actually finished with no rows.
Frontend (ApiUtils): a request cancelled through the caller's own AbortSignal never settles, so its stale catch/finally handlers cannot reset loading flags or state already owned by the newer request.
## Issue:

Suggest Reviewer
@GMishx @amritkv .

How To Test?
How should these changes be tested by the reviewer?
Have you implemented any additional tests?

1. Open the Projects page (/projects) and reload it.
2. Verify the sequence is Processing → data, and that "No data available in table" never appears in between.
3. Repeat on /components, /licenses, /vulnerabilities and on tabbed tables (e.g. project details tabs).
4. Verify the empty state still works: search for something with no results and confirm "No data available in table" is shown after     the request completes.
5. Test on a throttled network and confirm the processing overlay stays visible until the response completes.
6. Verify pagination and page-size changes on a table that already has rows still keep the existing rows visible instead of flashing an empty state.