### PR TITLE
fix(Attachment): Display attachment types as short forms

### DIFF
--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseConfirmation.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseConfirmation.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from 'next-intl'
 import { ReactNode } from 'react'
 import { BsCheck2Circle, BsXCircle } from 'react-icons/bs'
 import { Release, ReleaseDetail } from '@/object-types'
+import { getAttachmentTypeShortForm } from '@/utils/attachments.utils'
 
 export default function MergeReleaseConfirmation({
     targetRelease,
@@ -570,7 +571,7 @@ export default function MergeReleaseConfirmation({
                                         key={index}
                                         className='mb-2'
                                     >
-                                        {attachment.filename} ({attachment.attachmentType})
+                                        {attachment.filename} ({getAttachmentTypeShortForm(attachment.attachmentType)})
                                     </div>
                                 ))}
                             </div>

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -41,6 +41,7 @@ import {
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAttachmentTypeShortForm } from '@/utils/attachments.utils'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -607,7 +608,11 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                         header: t('Type'),
                         cell: ({ row }) => {
                             if (row.original.node.type === 'attachment') {
-                                return <div className='text-center'>{row.original.node.entity.attachmentType}</div>
+                                return (
+                                    <div className='text-center'>
+                                        {getAttachmentTypeShortForm(row.original.node.entity.attachmentType)}
+                                    </div>
+                                )
                             }
                         },
                         meta: {

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
@@ -18,6 +18,7 @@ import { Spinner } from 'react-bootstrap'
 import { Attachment, ErrorDetails, ModerationRequestDetails, RequestDocumentTypes } from '@/object-types'
 import { ApiError } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAttachmentTypeShortForm } from '@/utils/attachments.utils'
 import TableHeader from './TableHeader'
 
 type RowValue =
@@ -169,7 +170,7 @@ export default function ProposedChanges({
                     if (row.depth > 0) return
                     const { attachmentType } = row.original
 
-                    return <span className='text-center'>{attachmentType}</span>
+                    return <span className='text-center'>{getAttachmentTypeShortForm(attachmentType)}</span>
                 },
                 meta: {
                     width: '7%',

--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -25,6 +25,7 @@ import { Attachment, Embedded, ErrorDetails, NestedRows, UserGroupType } from '@
 import DownloadService from '@/services/download.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAttachmentTypeShortForm } from '@/utils/attachments.utils'
 import ImportSummary from '../../object-types/cyclonedx/ImportSummary'
 import ReleaseCheckStates from '../../object-types/enums/ReleaseCheckStates'
 
@@ -134,7 +135,7 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
                 header: t('Type'),
                 cell: ({ row }) => {
                     if (row.depth > 0) return
-                    return <p className='text-center'>{row.original.node.attachmentType ?? ''}</p>
+                    return <p className='text-center'>{getAttachmentTypeShortForm(row.original.node.attachmentType)}</p>
                 },
             },
             {

--- a/src/utils/attachments.utils.ts
+++ b/src/utils/attachments.utils.ts
@@ -1,0 +1,40 @@
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
+
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+
+// SPDX-License-Identifier: EPL-2.0
+// License-Filename: LICENSE
+
+const ATTACHMENT_TYPE_SHORT_FORMS: Record<string, string> = {
+    DOCUMENT: 'DOC',
+    SOURCE: 'SRC',
+    DESIGN: 'DES',
+    REQUIREMENT: 'REQ',
+    CLEARING_REPORT: 'CRT',
+    COMPONENT_LICENSE_INFO_XML: 'CLX',
+    COMPONENT_LICENSE_INFO_COMBINED: 'CLI',
+    SCAN_RESULT_REPORT: 'SRR',
+    SCAN_RESULT_REPORT_XML: 'SRX',
+    SOURCE_SELF: 'SCS',
+    BINARY: 'BIN',
+    BINARY_SELF: 'BIS',
+    DECISION_REPORT: 'DER',
+    LEGAL_EVALUATION: 'LEG',
+    LICENSE_AGREEMENT: 'LAG',
+    SCREENSHOT: 'SCR',
+    OTHER: 'OTH',
+    README_OSS: 'ROS',
+    SECURITY_ASSESSMENT: 'SEA',
+    INITIAL_SCAN_REPORT: 'ISR',
+    SBOM: 'SBM',
+    INTERNAL_USE_SCAN: 'IUS',
+}
+
+export const getAttachmentTypeShortForm = (attachmentType?: string): string => {
+    if (!attachmentType) return ''
+    return ATTACHMENT_TYPE_SHORT_FORMS[attachmentType] ?? attachmentType
+}
+
+export default getAttachmentTypeShortForm


### PR DESCRIPTION
---

**Description: Display attachment types as short forms**

Currently, attachment type fields in several places across the UI display raw enum values (e.g., `CLEARING_REPORT`, `COMPONENT_LICENSE_INFO_XML`), which are verbose and not user-friendly.

**Changes:**
- Added attachments.utils.ts — utility that maps full attachment type enums to their short forms (e.g., `CLEARING_REPORT` → `CRT`, `COMPONENT_LICENSE_INFO_XML` → `CLX`)
- Updated Type column in **Attachments** table (release/component detail page)
- Updated Attachment Type column in **Proposed Changes** (moderation request detail)
- Updated Type column in **Attachment Usages** (project detail)
- Updated attachment list in **Merge Release Confirmation**

**Why the utility is needed:**
The backend returns mixed formats depending on the endpoint — sometimes full enum values, sometimes already short forms. The utility normalises both to always display short forms consistently across the UI.

**Short form examples:**

| Full Enum | Short Form |
|-----------|-----------|
| CLEARING_REPORT | CRT |
| COMPONENT_LICENSE_INFO_XML | CLX |
| SOURCE | SRC |
| INITIAL_SCAN_REPORT | ISR |
| BINARY | BIN |