### PR TITLE
chore(ip): Add SPDX TV report for the repo

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -11,6 +11,10 @@ name: Build
 
 on:
   pull_request:
+    paths-ignore:
+      - Dockerfile
+      - docker-compose*.yml
+      - .github/workflows/docker_deploy.yml
   workflow_dispatch:
 
 permissions:
@@ -18,7 +22,8 @@ permissions:
   pull-requests: read
 
 jobs:
-  build:
+  build-and-test:
+    name: Frontend Build and Test
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -95,3 +100,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             dist/sw360-frontend-*.tgz
+
+  build:
+    name: build
+    needs: [build-and-test]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check build result
+        run: |
+          result="${{ needs.build-and-test.result }}"
+          if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+            echo "✅ Required check passed (build result: $result)"
+            exit 0
+          else
+            echo "❌ Required check failed (build result: $result)"
+            exit 1
+          fi

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -40,6 +40,7 @@ header:
     - 'cypress/fixtures/**'
     - 'LICENSE'
     - 'NOTICE'
+    - 'NOTICES.spdx'
     - 'pnpm-lock.yaml'
     - 'pnpm-workspace.yaml'
     - 'docs/templates/**'

--- a/NOTICES.spdx
+++ b/NOTICES.spdx
@@ -1,0 +1,28898 @@
+type: NamespaceMap
+namespace: http://fossology.localhost/repo/SPDX3TV_sw360-frontend-1.0.0.zip.spdx
+prefix: URI
+
+##-------------------------
+## Creation Information
+##-------------------------
+
+type: CreationInfo
+spdxId: creationInfo:creationInfo1
+specVersion: 3.0.0
+created: 2026-08-18T11:12:43Z
+createdBy: Person:SPDXRef-Actor-mishra.gaurav@siemens.com-mishra.gaurav@siemens.com
+createdUsing: Tool:SPDXRef-Actor-fossology-4.6.0.113
+comment: <text>This document was created using license information and a generator from Fossology.</text>
+
+##-------------------------
+## Document Information
+##-------------------------
+
+type: SpdxDocument
+spdxId: SPDXRef-DOCUMENT
+creationInfo: creationInfo1
+name: /srv/repository/report
+profileConformance: core, software, simpleLicensing, expandedLicensing
+element: SPDXRef-Actor-fossology-4.6.0.113, SPDXRef-Actor-mishra.gaurav@siemens.com-mishra.gaurav@siemens.com
+element: SPDXRef-upload89931
+rootElement: 
+rootElement: SPDXRef-upload89931dataLicense.type: simplelicensing_AnyLicenseInfo
+dataLicense.creationInfo: creationInfo1
+dataLicense.description: CC0-1.0
+##-------------------------
+## Tool Information
+##-------------------------
+
+type: Tool
+spdxId: SPDXRef-Actor-fossology-4.6.0.113
+creationInfo: creationInfo1
+name: fossology-4.6.0.113
+##-------------------------
+## Person Information
+##-------------------------
+
+type: Person
+spdxId: SPDXRef-Actor-mishra.gaurav@siemens.com-mishra.gaurav@siemens.com
+creationInfo: creationInfo1
+name: mishra.gaurav@siemens.com
+externalIdentifier.type: ExternalIdentifier
+externalIdentifier.externalIdentifierType: email
+externalIdentifier.identifier: mishra.gaurav@siemens.com
+
+##-------------------------
+## License Information
+##-------------------------
+
+
+##--------------------------
+## Package Information
+##--------------------------
+
+type: software_Package
+spdxId: SPDXRef-upload89931
+creationInfo: creationInfo:creationInfo1
+name: sw360-frontend-1.0.0.zip
+filename: sw360-frontend-1.0.0.zip
+comment: <text> licenseInfoInFile determined by Scanners: - nomos ('4.6.0.113'.2fb0c0) - monk ('4.6.0.113'.2fb0c0) - ojo ('4.6.0.113'.2fb0c0) </text>
+software_downloadLocation: NOASSERTION
+software_packageVersion: 1.0.0
+releaseTime: 2026-07-29T00:00:00Z
+externalRef.type: ExternalRef
+externalRef.comment: Package-Manager
+externalRef.externalRefType: purl
+externalRef.locator: pkg:npm/sw360-frontend@1.0.0
+software_copyrightText: NOASSERTION
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d52fa383998d7ca8ff2fcb88c1cc0f78bc7a5682
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: da1252255776b0f85d63c638d48c20d7f643057c15acd56edf6392bf5c6024b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 12d9c14e18f37e75cefad49c025af016
+
+type: PackageVerificationCode
+algorithm: sha1
+hashValue: 706974ea3cd8eeaa5a4d8c58f328808dc0dd7517
+
+type: simplelicensing_AnyLicenseInfo
+creationInfo: creationInfo:creationInfo1
+spdxId: SPDXRef-upload89931#EPL-2.0
+
+type: Annotation
+spdxId: SPDXRef-upload89931#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item
+statement: SPDX 2.X LicenseInfoFromFiles
+##-------------------------------------------
+## Document-Package Relationship Information
+##-------------------------------------------
+
+type: Relationship
+spdxId: SPDXRef-Relationship-0
+from: SPDXRef-DOCUMENT
+to: SPDXRef-upload89931
+relationshipType: describes
+creationInfo: creationInfo:creationInfo1
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102717
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d729a94a70cca601440af2c573775252f888ebcc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 19b3766767423788b7bb03585f00dfa122c09f1f58bf5894be46837dbf360c6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f620d3cda50ed7f1df2250ba80869ee3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102717#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102717#Apache
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102717
+statement: SPDX 2.X LicenseInfoInFiles
+
+type: Annotation
+spdxId: SPDXRef-item361102717#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102717
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102686
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseWorkflows.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fe59a28c00e01ef75247e5ecbb5fc4949073d9ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 69c07ae8ff697ca974c1bcc8265e246a92d0593a54c1e0270069a8f6349a4268
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 957545c990a061ad7a9f34d257038a61
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102686#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102686#MIT-style
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102686
+statement: SPDX 2.X LicenseInfoInFiles
+
+type: Annotation
+spdxId: SPDXRef-item361102686#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102686
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102905
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/images/fossology.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cc502dc648fd2a59076c009353561f9d869f1132
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 72a280997c565324bb08617d2283172f199664030685b2fcec77559159bcd5d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e9877679601a9c1c57244f8e099e341f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102905#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102905#CC-BY
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102905
+statement: SPDX 2.X LicenseInfoInFiles
+
+type: Annotation
+spdxId: SPDXRef-item361102905#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102905
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102655
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/zh-TW.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 457c964cededc74831a5a68cd897dfa70678616c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c03cb0052cfdb058242308c3198ef5d8d65bfd909b7643b48e6196fea799a149
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6c5b3d8ace9361ec2eb4aef57344ed95
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102655#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102655#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102655
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102658
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/zh-CN.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 57ffeadbaa429cddae86c94a0dd6fdc8bb19fa08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bca21d56796448499ede40002bc02543e768b3d02bb1c925b732db4ce65ae2e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 71ddc828e558063c8e3b1b56fc120d21
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102658#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102658#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102658
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102657
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/vi.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 955391334c5c512a4ef33afb3954820fe35d36a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8467d7a21718ff1924537b04d7399678f7a5cd23c5c4c851ff0beaab82ac466d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1e6c78384e7b514013c0e39787e6a5a7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102657#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102657#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102657
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102653
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/pt-BR.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a12da4e832c4f802462d46fafb23283795d8c877
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ff3f1c5536d6e8cba2ba02bce78eb9825e02f4f884d580ec98dad268adaa9b0b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 19460118dd5c799ec7f9243942a6b06c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102653#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102653#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102653
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102654
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/ko.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 246480665015e576cfd6a2b458d67748fb5393ec
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: de16e5ec0da27043032204f01818e34ca53812b9117d64172ae08a281eff6528
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f1e79e0630df0d192ad07c5193d83762
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102654#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102654#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102654
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102660
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/ja.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 610020a20a9e589f0380af85a455e9640cbf0615
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 90b624d4a65b1b635711c49051fd12abde29f17c968c2509ef99894bf8a852e4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a9cfd5b5dc6333abfd088369a5dc0b63
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102660#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102660#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102660
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102656
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/fr.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 461ae5089085633d477149d217f38483651444a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4a957779cee67f130770dd11c6d2f233f75b29f7d10a8a2945ed49e8289ec195
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b8edc409fc658f3a229d21f89942e27b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102656#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102656#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102656
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102659
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/es.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bd96235796f8111bac98fdf5d89c90cb8007468b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 12a122075e129f2b5b793d8647d0c5cdf0bed2276094683d7fdf17d124b3352e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 61b466291723c70131d1b07f2d03cb24
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102659#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102659#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102659
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102661
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/en.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 04bc8b729f112ee0456a97079ef1759366c82fc2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8ad186d1cb5f593da733aedb88f3ae6862e731b50c76e6e1655f0de221247745
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 771d70f323a86c8b7bff70e20c6050ec
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102661#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102661#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102661
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102662
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/messages/de.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8da86145e13d706266b5f33add8f38fd5b1415d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ad7e07b1724c0d6780c8a6f50ec510d4b8f831e1bcbe1ff7855fea2c219a0dc0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2e50c9b1a76d00e62f44d091300b2fb2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102662#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102662#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102662
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103745
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/CHANGELOG.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c7383ca8ffd4f4e8fa45838f5c0a9eda6b36b52c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 07a2d6c4d99029c80a887003b8f8ec53daec3eee37de65ec06880a9a8c2a3b23
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 48801fda9e95aff8c44599117cc7b1c5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103745#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103745#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103745
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103743
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.devcontainer/scripts/nodejs.sh
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 488db2268ab04befb0968bec27dd064ecc115136
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9c16a2657fd5aed836b183cc07323405c57ca45cae71b2ca62f79e2324576b6a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ca09c3f30b81e962a3d69ed830c6594d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103743#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103743#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103743
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103740
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.devcontainer/devcontainer.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 36c2c58392c2336f8537437798476e308b39c5b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 73806013a624999adbfd8b81d4be00eca0e937dd7192d71da928c78d8b459c41
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 78fd0d1a2b65feebae268ba2b72b8ddf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103740#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103740#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103740
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103737
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/provider.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 244c0d662d33bced0fbc9abb9be6635b9cbaad89
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 17a329119394c6bdf2049e23dcb79831c25095d63abfcb261d04237ad83ce1bd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 09f80d305bdc73ceb11ac77aa1bf485a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103737#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103737#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103737
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103735
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/session/route.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 375bbc25ab229cabb9708c1f3014c51c85bf42d0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f38dec302a2848bbcb658bb34847e1c094e529c3dca9a55a79aa197c07b883a7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 117cc317524009bfa23ce89a20e05ffc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103735#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103735#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103735
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103731
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/keycloakAuthOption.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 71e1f2672c9c5fac2175f31bf12ef656bfb7921e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ac79c52bee37dc40116d0a8c48f140adbe348d73e6554a3b7d9951146529c7a5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 937d03432a53d51ffef867cdbf87df71
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103731#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103731#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103731
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103729
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/basicAuthOption.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9d530de963410d53e5ea29168b020196fbde3b15
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 66265fcd554ef72a97675314a172649dcb16f35a5268cb15679eab74bc24c976
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0237b98d257f3292134f5e75bc7f20cf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103729#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103729#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103729
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103728
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/authOptions.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c3a1ed188e9fbe18bfcd85d06d586fd88b00feac
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: efc1c81d1ac3bf8486277e7cef754d48673c8b0a50eb0171ad22387f362d5b0c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 01192441037713be27f2e03c16e251aa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103728#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103728#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103728
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103722
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/ecc/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 95f93b3efde494729707830cb882d7a27a7f3dcb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ce38253c7e1cbf7efb6fe605d77096d1ec88b29d78827fccc40232b3e76625b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7ba5a1abc96e12af68a28bf0a551491d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103722#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103722#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103722
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103719
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/detail/[id]/components/Changelog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a1449b5437d68d20ac3b012430e073d964ed40b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f6927c6e6902770f185fd7e72545564503a5a457b773dfc9d9637019a393e8bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ffa92283c55670e23c445aeb93db0cf0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103719#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103719#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103719
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103716
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a3f7283dd52ad1024e60bc22fc2fa754b94d1174
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4a10ffe4af9230d7b4763d85bfe58de115542f24331e260b4a11e61bf91560ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6c9935f1fe6aa63cef6e3ae7236d7380
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103716#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103716#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103716
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103711
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fae1a094b9c544435adeadbe9ee31cf870dfc57a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b50c8523a95f6e0e36062ac7c2e8f6eab7a651db2451e81ada6771c877ad2c7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c27852faf26ccb6e06c11b46721918c4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103711#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103711#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103711
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103707
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/components/PackageManagers.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 03d137b02cf113b0cb996018fc8e39067398cfd1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 72696dfb8a1f3560fda11b11878ff17c702525aae5e65233c11d7f01a66c252a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 169d4ab76d49b68270ae8887b92834b0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103707#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103707#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103707
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103705
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/components/DeletePackageModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5d03503fe72f22dcc945117b044a02f5ac0a178c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8a69e5fc10bb41594055697bf69e197f07bd8cb5bce9fd605fd1f2abdb54a73e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9f01eccfc9ed5f83bd771babea4d962d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103705#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103705#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103705
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103702
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/layout.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 238a5aab23c2c238c627fde4e1bbfbc6277ace03
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 92e228ce6e34aea9f2d151a6540088fe9647c6d74ef1f5945d8d30df0bf9ba42
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0b1839966bc6fa8025b17b4bb071b31f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103702#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103702#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103702
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103700
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/add/components/CreatePackage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0e35a8648ccfc386e62044f9cfdf6fd4affd97d3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9e6042de08d5172630bfe1cf1daeb3ea75a2256d878781f1de8fdbbd429dd7e9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ef38e19bbaa12a7e7e444f0b5574fccb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103700#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103700#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103700
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103695
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/ComponentGeneral.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 15207e45f83b41e433d0f9b5b4e60d50c8a46d74
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c6f9b17e0d5ca79e1e715dccce7a367ed0000ffa3302526ec351bce7ecce6823
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 77212a272a364cb4d989c3877b3868d5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103695#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103695#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103695
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103692
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 42d1ebd4a2bf23ce6efa94f279c606e6fbdb67fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b46d2fb764a98baf7a5d88fe09d4d25b128f947d00dfcef81dfbdab9ab92374c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 035d2d078a0a10b8ab9b20f173a898e5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103692#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103692#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103692
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103750
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/docker-compose.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 51b15a5d29725f2746af4df44184ff83e4be9657
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 517fe7d99214daa19137fe5cd838b1a48c8217b1e7cd9aa910b0d2f3cac77fa4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e1c33ce65c19cd38b0e4557aeae969fa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103750#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103750#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103750
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103744
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.devcontainer/scripts/postCreateCommand.sh
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 220349446e229aa72c7748fcb64037bd9b472dda
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 947fa5224746be52e57e8edeed06ee306c0663b82d7603861957840246918d84
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 08b0f554d221892d8a10f213936a028c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103744#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103744#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103744
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103741
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.devcontainer/Dockerfile
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 14f5148ed883e27d7b2391757c8f1ab105c79a62
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c1fca74565afc1af4d3f6bcf49a7fc2628d43739be67b582da17acdbea2a87cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 89f9c38987e92850d294b349b1e2185b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103741#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103741#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103741
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103738
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/SessionStatusHandler.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d7aad853a1583093bbe60190a334786540048a1c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 372c85e3fc31a97592a8a1175aacaf3027b17c0012cf5e56cad1d9a8f0ba389e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 458e62940cdfc2beecc03df439a49351
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103738#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103738#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103738
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103736
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/uiConfigProvider.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6a3a652775a7cc395732a0f2711a5950f9f97b86
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a7760501f321d5a5d0be71709df701e47c789014184bfebc6219ebf43a85417e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c4d1eb4b0ec668dcdb625633dc4f5b6b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103736#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103736#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103736
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103733
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/sw360OauthPwdGrantTypeOption.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a2bd5e2d8b0310d4a4abc39a91a4a6ed154603f7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b76652ff0184bb543c32e816cd6b185e84a9c6320a5481646b35fc3213619aca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a8f98b4933c3f0a8e616d8c12a9d5277
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103733#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103733#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103733
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103732
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/route.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fc6bde3a7fcb2603155cdc8d98f8f950ed4cd88b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: add74d6614e886a33f88e4d51d77efbac0513b51404e541f559e52413ffbb952
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 42d19de170946087a928cf78b43b75c6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103732#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103732#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103732
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103730
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/api/auth/[...nextauth]/sw360OauthOption.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fe9f8dd753e50c258c4ecd88c2f020a949b6c1b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4864096f103fa9c682bef6121afffb26ee031b601f0ec2c17d38fff320b1b0bf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 87196d0a28db2cbce36c6b88fa9f7fa2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103730#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103730#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103730
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103724
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/ecc/components/ECC.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fa62ea8f00e558fbbea5555557a527cc1408a37c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5899bc778d62211108de9a57b6c4359cef654e716002eaa0bd39100fd40e4503
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 342e79d0f8bc1bbf7e19b76ed29ed5e4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103724#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103724#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103724
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103720
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/detail/[id]/components/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 97be4bb957dbe22f448f565a1f2c7012bdc0118f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 731082989f72ca614395415749e25c2fefae864c5ec0f93c76c1d0fa91fe27b4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: dc6d8674b2c300bfea73b635b875aea8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103720#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103720#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103720
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103718
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/detail/[id]/components/PackageDetailTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 04256fb914dca08638a6fba1095090ba3ed0bbe7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 547bcd8f17e4b32fabc2ca330c02006ac7e011a134117a348ff5468d981f5e38
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 64fc168f0948c1107c3df3ab9b5a0b33
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103718#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103718#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103718
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103713
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/edit/[id]/components/EditPackage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8837c70e0e960d620c25883be5c65d61330b2550
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8fdb861ccef5a9118ede324ec1c79818870a4a36df198e22da0eb56b4aaa8005
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 71f232db59772033349347263b2b8222
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103713#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103713#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103713
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103708
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/components/Packages.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9b4dbdf70f9641d239efdbd90d9abf96d0c83a2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a8ca713ce87184f1bac72b1aa0eb3ba0f98837fedece644ad83be1f6c9fff139
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a3fc328a5a2d7b66f53d04229b8d5eb4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103708#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103708#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103708
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103706
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/components/purlUtils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 26e4ff83ade7646aa7e44af697aea0db4b4b066b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e32b8237728e481c1d14f5bd339fd6d81c783f2103272d5cb37a629d5466eb76
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 83a717897eeb9cc65066c9d8ec6b643c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103706#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103706#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103706
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103704
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/components/CreateOrEditPackage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6b0a2632e6a6d096eb44b435464318ba704be094
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f96a871824f23d2e72d798f8ea9e4950d7a767f6051b44539670d2ad7bfb4be7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 506f53c5c884a4a0b49d502e7bf65382
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103704#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103704#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103704
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103701
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5452f01342821397e80195a35588712e10d311ce
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 10deb859f00556ea6e6a7bde3006e03c3ce257acfde388151a2fdf8bfa721460
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9ada6fb9d83065183ed1050ef8827ec3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103701#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103701#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103701
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103698
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/packages/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d68bf0b8ef650656a1de366b4995831dbba50f6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 70c63f12c664826ae0daf94021feabef82693c1707fe8034dcfc63b6a8448205
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0317e1b1b87bfdcd79e7768585ab2453
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103698#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103698#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103698
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103694
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0d8aaaa4082b5abff4b7dd20238775c8fd1dfda9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 920c7a9de6247ccada21291fe7b9c6f027413dcd234dfd0e6378814cdd7bc8a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 31fc438f11aa42ae904e0cf5e23c21d5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103694#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103694#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103694
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103693
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/ReleaseAggregate.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8c7d59049d11aa5ee149a9ef0039fe845a9dcc68
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1a2869b7e7718d0ee0eb9578793c8c3272b94ce64a916464539939b01e8d76e9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 921f4cde7d0c0a7ca71b76184b184b8c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103693#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103693#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103693
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103690
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/SummaryRole.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 866d9f7c8bbaa783133a9e15c50c3f46fedfa111
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: eb0fba8e7e087ee01970e965b425e5987f76a8023a780eb7d7956a3bcfae2d01
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 049e13395565698504dec4bf4bada456
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103690#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103690#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103690
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103691
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/DeleteReleaseModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 89c7fd586796605ba0c0f2b1633338435f222c23
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b844d99ef2bb67a4c1f627bdfa67b3b416ac672991d7b202482acdb88c75966b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2cd925d612acf0b5f86b395448fc855b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103691#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103691#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103691
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103689
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5d2221bd78bf71fe219cb41b7bc218885d3be378
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 07d55216d9752317f2e0c843dc085cd0b235af1a62304922ccb8001a23aa7c00
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 40c48f31f1b81130457d8557d43eecad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103689#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103689#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103689
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103686
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8527c67090bf10e8d9ce55e853925873b894ce54
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 131c62ee94938319c5c0d86278e7bf85873cfe8bb5745db9a6f60c3f3f3bfdfc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 58423d205e5745ad081f1e954bc6d945
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103686#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103686#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103686
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103684
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/split/components/SplitOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 144d0c4bfb80ba6293c035916065832bcf4196c9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 079fa7dcf2b0e0b74bc0fe8f293a0d951af180d37cbac751debcc65c9dfadb5d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 945db5b0707a109c0f494d51b82f1286
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103684#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103684#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103684
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103679
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/components/MergeConfirmation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4398bccfc96db7988c33a268841d449537d620b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 72bc1543d5db7cf3a06592de8cdbe1d717a007eb6d9a9e80dad3169b470973ee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9e48fdbd689694186c6844f2851b5e01
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103679#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103679#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103679
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103678
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/components/MergeOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a6ca6ab5a3da1b35c8af36f6b7d5e673a45d88dd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c720b867dc82b3ad3edef7633fcad22d50b4fb5fdd24caada8e0987882cda4ff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d3670a453a42d2de0881fc1a50520159
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103678#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103678#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103678
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103675
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/components/MergeComponent.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 05c8eaa5d1845c483b23538059fb91451b0ad11a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f8105bdfb0096950e27cab132640f0c19c4cdebbee342f3cb77984ae0d3c9ec3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 606f5c76291847b0422804b0d1177492
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103675#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103675#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103675
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103669
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/EditECCDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4a0b48d826df218f1190f56959fc7c15a47a67a4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 85e166507f21ebcd16f8f0d00e2638d61c1502f896c24c7f41e06bb56f8e01f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ef69d41faec450a873e43ded3b0da80e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103669#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103669#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103669
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103667
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/EditRelease.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6bc778e8f7b9c2230cf52b8c0ef07e11ca5969a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7af3161b0a579d8484329e8b3a91637177f64108ad6d3c65dfade45ec10b57e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 45ae16fb195880075167aff834dd7aff
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103667#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103667#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103667
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103665
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/ClearingDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 914b0fa9ea4f1ae22780c0bbf4059db9b4c77621
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3390d6d1981c65ad5433797c3436e3ccbf9c15093969e6fc3cbcbad432564c17
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 32f196961102549d14eb8758cfa4d3ad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103665#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103665#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103665
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103663
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/EditClearingDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b9d2831b7bf2195f5abf2d5097a4b6cf79ddff4c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b2e9be0f1b717edb3887592abb5804b30fb3702035f277b53bf32395610c5528
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 80ffa6a8f1dc72bd94734c4afc38c2ab
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103663#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103663#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103663
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103661
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/AnnotationInformation/Annotator.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1e9d7d49fd97cc5b5f0d544a8b14c766e013c08a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 39c6e0821a5cf1ff17d166ae4c31aa97a9cd705af54222ce89553437acca932a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 46fe60f5431b7238e6142f3271c83a6a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103661#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103661#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103661
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103658
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditDocumentCreationInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c9bcd55d86fa3926d9cdda2c0c857049b46baaa8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 23afecee54243e88d05c72ee5166fa8e5944990651822bb21c8c26c60d3baee1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7373e4c7daa465c0ca6d2d90f53c307b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103658#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103658#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103658
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103656
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditAnnotationInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 19753e0806cd1c5a767ee77593110e116d197c72
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4397938a663907234f41f466dc2e18f63bb1dca20ba4911c5428d64302575313
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 580672df28a0a410658cc97278d4b724
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103656#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103656#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103656
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103652
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditPackageInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9b88e044c53d6738d9dde29b3b2e4672e7d9aff4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3e514d78c99cdb13348c84898f88ebb8637733ab0ad2439c5c1303223e00626a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ef763b375db158a4e8d81b162ef2f4d2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103652#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103652#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103652
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103650
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditRelationshipbetweenSPDXElementsInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6a4f1d68275ff5cb86691247dff701da514ea208
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ebd8de820d24cbdb05720a30435f2ad1602a8f1514c9a4d469db5e6301b1b50c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 32ff663573ea010523648bee5c8009ca
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103650#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103650#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103650
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103648
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/SnippetInformation/SnippetLicenseInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 73c22e5bac110c62ff8f656e5ce2a44fb34e915a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 31a36ab6ade92dbe3b8195797a8aa372ee6a7c7b79f89bb1d30b3a8f2f0ec9d9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: abf104a31c551cbc3b4311e1ed012be0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103648#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103648#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103648
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103646
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/SnippetInformation/SnippetCopyrightText.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dfa9b94f4627cb0225c336e7c9f825f03756dff7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c5233430bb0e2b15a1c6a0b86c6afc8b8f6b88eeddd64f3247652063247f1a98
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b8642f01fe61142a19dd3baea6b45be2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103646#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103646#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103646
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103643
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageOriginator.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0d88607e06e0b164dfcead9e6ba74008a8cc9532
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 56104f4f8317bd8298da88beac7ca85a593f2be9da2a22aeab83a32476b66531
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fa678439cc1e4403732c7548ed17ccd1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103643#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103643#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103643
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103641
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageHomePage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 508e95fc04fa4c49a73c4755a5029c7efcaf9fba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 294d875f01f9f0a8801ebd96ee2c5c39df89da271d92e3daf3238557c8a85e10
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 84a8fe0ffc1c485a5a5dc20211449a9e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103641#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103641#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103641
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103639
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/CheckSums.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 61ba81fc5c18be807e4db83d4dc4f6701e9d70d1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 936161eae6c3fe602cf5f0432608f47937a377358d6014faefc5772474ff9164
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 15e2d84c264e6f711e3d453391ff0336
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103639#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103639#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103639
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103637
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/BuiltDate.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5c41eac4888e1e10fb5c7dbd3605c8f5d7909637
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f5e2970f7bedcb6b541bfee7d93a8d046e1b5bed94e572649a09ce4fda38aea3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ba792402992be85c62e934f80c458c8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103637#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103637#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103637
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103635
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageDownloadLocation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 906b3acdc297607c17839f644a73b2dfc137072a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5fc98cd3bf8ecc2e8aa57dbaec31525b8c21e826896a621ff2b8e4317a262b6a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: baf228285445980ef5fb5d280f900637
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103635#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103635#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103635
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103633
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/ValidUntilDate.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f90f5d0e213c33e48a1ce66dff07ab40b24df5f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ea1faa4d30adc037908d6b037fcef6bed8770af7133391c6fd4554d309eaf959
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3d5311b29129a30973cfb2b47a9bc7b4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103633#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103633#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103633
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103630
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditOtherLicensingInformationDetected.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7fdb44e701094fd43848c0c008b0e1b588b6bfa2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2672c5c848a0a763a5758757756069805d798b222576efda1f3c8703bb73959f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ce205100c9ebe336f314da2d04361430
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103630#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103630#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103630
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103626
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3c43032a53594cf1496f8b0c9a7e9d06b5a3c43e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5f592be3f51992c0c2c54b11658f86e048d8f41a694069ad54d3c73e64dbb796
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 20ebad289221ca972c48a792af13f1d5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103626#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103626#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103626
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103622
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/components/EditComponent.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0c9a5142cf70007257974bb1a52f27f999fead2e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5d11fd26f474e5d1f519f2747e3cbddaaa0653201a5d09c97b020cbe5b0039c9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b00fdbb4b6a71d606ca6ee9234bc4d29
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103622#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103622#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103622
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103619
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9b9deca5aed2cd5422a08e73f1dea5c695c27ba9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8f4b41800898ab0a7b6b4a5ace26273a0a526fac255e05829b0907f091b67abf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e24f63b7320ae51ad60ead9af95fde17
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103619#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103619#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103619
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103617
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/release/add/components/AddRelease.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6a2356b91424746dccf0f4b0864ebe87fb873bc0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ef4dc6f638f0be1d376dd54e042defdea3cb9cf4e6ba17b8b68efafca5a78797
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d4d25395ef4c1da755cb9eff04a899e6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103617#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103617#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103617
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103610
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/components/DeleteComponentDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d59e3bea1744eca0bb1720e07b6a0a4995100e02
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e07b911002cf753555e14c91e287b3d71ec5add61df5ed88ee47701f0b423518
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9024b94860b99be37011b327bdfbb5d0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103610#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103610#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103610
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103608
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/components/ImportSBOMModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5493fdcc97ff23d107cf7dff350ae1497d01ee8c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b798b685da4ac7548dc9b2d50f0f3451579cd0d375a1b253e4f585c6946e8fbd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a64f301ed9f7274a5bf1f225bfcd7fb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103608#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103608#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103608
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103605
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 742e86b1ad1f4e42a74d7f6afae3b20dae2a84d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6450e68f622f2e7c0e348a975d5e18385e03cc35108afb82fc4e4b7c72465097
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ba1e5247366ddfeb1a1fcb4591079d9b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103605#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103605#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103605
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103603
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 847b21409741882dd141728903dee3c6906acb8b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 34d019668d9b4217f22b24729ac5c56fe3c3b3613a9be548f02ae1ab015d4ba0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1ec77b3b73b1b7d451b8f09e64fd28e6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103603#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103603#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103603
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103601
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/RequestInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 10f52f4385eecae145dac08c9c85508762919e6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cb8ed89f354a71c477117875867a6c6901aabfeddc65f8fefeabde2840f23c74
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a7a251fea5322761ab11c3524e5e7fa6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103601#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103601#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103601
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103599
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/AssessmentSummaryInfo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 45fcb0d752e38d2010a1c6d947b49f266ab68650
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8fc91fd8819c478d85a0ba690396f52613da9570bd2dbca40ec425badba5659d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d4bdd637fe1522b51456219585500e0d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103599#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103599#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103599
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103597
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/SupplementalInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 79ab750bf02ab862196efc5b7e03b7cd4720ae3f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3bbc914d7b86436fb66e46b87bd5a07e8ece5eaca53c17c845ed6053cc37f43d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 385d0ab87e4a77f68b278d26db6b114d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103597#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103597#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103597
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103595
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fa6ffaeddaa64639bb48073988ca23bdb99a55b2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9be1685a40250b060a5aadeb6eaff8adea667ee5c1f502ded08cfe498b664997
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1c6e9b61bac5a9824ef3281d419f2b92
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103595#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103595#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103595
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103593
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/ECCDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e9b73606728c977909a533527b901a960d5fc5b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 13ea793692c69c83b7ecff2e2aaa8c36cb08671c1c5a002a1e6407638efe0415
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 39e0f3b1e635f7d41ee16e4da6d79a48
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103593#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103593#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103593
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103591
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/SnippetInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0749f2b2f8d385637c05a211a7d53bac6973ccfb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 63abeb8f914f47f6322872a06c807adc0ef6ceb162b154e2208e9c83ced9bc9f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 33c8b0f583e7864478403602bdae38c0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103591#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103591#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103591
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103589
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/RelationshipbetweenSPDXElementsInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 54e3cd5bea97181a61e620806bfb247d3359e08b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2331706e3199b6181f44353753a15c56bccdbb1766865747092397021e2e33ec
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9044b243eefb8c7f8b4ba7cb4e89c25b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103589#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103589#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103589
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103587
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/DocumentCreationInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2285e79f7345b55e3b0b1042dffe3efeddd9b229
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 31c275415f25d618d008d04d2251f6cbae5776218ceb0cc12f34dd82031cba91
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0bfcbc236870ddf9f7331fd289810d30
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103587#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103587#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103587
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103585
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/PackageInformationDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6c64a2d862b7de2fce36649fa09fc79a2b1d0112
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a93412d0bd7152da8235fe33331afb2df7eeb744b305be574ca73c2a41831ce1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d585fba37fcf53dccce961e1458b3270
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103585#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103585#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103585
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103583
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/ClearingInformationStatus.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3dc3973d9ceaec21b8e4ebc4a14a9fc614df7f18
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d01f3bbbd104c8281a8f2314ea8ec69aff8a431c7fefb9e62b6d6ebc61c7d6cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aee4d22a054a4aeca16dde5d7471607f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103583#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103583#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103583
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103581
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/SPDXLicenseView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2cfb623e16833228878a60adbae788bc4e913dce
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 44d4e3516aa0f62884a5caaf065c2f2bca65052384a526c5c6ee2e4a2bb12472
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: be4b796c1a3cb281ad25cc7d5554664e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103581#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103581#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103581
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103578
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d6139bcc4d0a480bbc23f1141275a692f1cb7ff9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7d2e4c4f05e9e7a6fa04b1ba01be580ebdbc311a7265734d33573570d473e95a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4799bf7968a3d917f7fae39c5ecac4df
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103578#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103578#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103578
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103576
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/AdditionalDataSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f88e973f351f2e325514996d477cdbd996e908a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d556aa15961e02ffda81e78c3b0cd9156687ac2f832427d433d5a04c8601eb07
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9303cc6c09e0c3a7d8c427062c321dce
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103576#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103576#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103576
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103574
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/Attachments.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f51b0703a7875b9e7664cfaeadf6cf3791b2c8bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 914daca1ff78289311351d6b7edbcb110cd32389879eb0ec5a97319b3cf29cc4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 54bc09a3d6ecaabb5842a4db9d02e158
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103574#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103574#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103574
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103572
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/CommercialDetailAdmin.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c0c31a082ab9adb9f109f78f5cc3ee4971d707ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: be8dcdf8c539706424451e4b591bb10a8eab83eb64490e86eb5f430be8f71c3b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ecd8719feacb13fa3307ec5ebcadcf12
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103572#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103572#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103572
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103569
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/GeneralSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2e6702cc30c3e88b1c3ed2df1dfbc91aa29a8d37
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 28c24d825897d79dccfaa5b54f750d30389ebb515b067db2f83dd9a4931f9573
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 68cea6d962912d0ece95c51b815b4b08
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103569#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103569#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103569
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103567
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseDataCheck.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8e0b54df8def28d767e02f798bc8d1ee3ea5cfbf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 090ef94f11ea6d9b7afbbe9f9ee96558db9b9daf5efa6552d60dd819a1995309
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8c296a3bd65f509d54073a5b0d95a958
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103567#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103567#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103567
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103565
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseConfirmation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: be61afa501551bd769560eb536f4746942612cea
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 093834a4ee92fcfa6785b4d81ddcede87fde9d67d1109280bba32540aa8fdddf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7c2aca76d2e98353a934859413088884
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103565#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103565#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103565
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103563
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/LinkedReleasesSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 30aecd8910fd1dd3f616b27737155a5ef98d628e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dc254e98fa820ab58462d06f67d0524074752be1199663bb950f8adb7e79379f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d1dcb4ac730b02d419620151bb610e7d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103563#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103563#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103563
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103556
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/add/components/AddComponent.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a2c83946848d5e9280751d042e37ccc570ca2b71
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a712126ba4d8dbba9de7b167b75b31a21d246cb49d7716b7b5afeac5cacaa650
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 09f244bc3126868429081fe346326e4c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103556#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103556#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103556
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103551
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/error.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9ace36cb3980a92a11484013684c65ab9f2d5939
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 68da2fa7f13fd9f48849d28973e45fc3343ded96961de954cde765ae540828a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fefd0e913b07fa9c3ff761071d4b9cfa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103551#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103551#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103551
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103549
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/components/MetaData.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: db90d70f53b0043747efacf8e9ffae8155f39c0e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6f644f7b861e618ffed3c01e2dbcc241211036c37d1efe1ec77ed06bda18d4ce
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 72dead226987334e3de9ae29ec587a9c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103549#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103549#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103549
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103547
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/components/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0db9d665718dbb46a2a9963f40f1e581d10d2d57
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: af2e2fde26d553b668d44770f4345be35abd268d373f6c16e843738e9792b311
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c53f382a58059a834c95ec320865b077
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103547#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103547#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103547
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103545
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/components/VulnerabilityDetailsTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3cf63b950ff072a626555b278182e299044434ae
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 084442e9e7a91649de7b00601ca987cf69f088ca8d39f155de42db496eb88676
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 52651a0796c212172cc666276d356367
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103545#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103545#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103545
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103543
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c62a03a3f5f417b588ce32005d7de9efe63f56f1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7aad5e35f154e7566155ab6bd9ed6182be4f0c1a2bb35815ec8cd4bcc1d56f4d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2ff2262758cf8db831a014b29e93ed4b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103543#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103543#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103543
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103538
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a462f146571bad694f82fd7d937c88cda8655ec7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 01bc3a51d29370aa72ca0f4a9c5c79a49f88c6cca4f1f09740a62ec2eca9a8df
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 14b01e8d054c650756e98f2e9158a0bf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103538#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103538#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103538
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103534
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/VulnerabilityAccess.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 02e75d6f667bf42f4d15803edf8d6b96a3ba6d25
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fad09ec7c3dcf2b0f7265b4024ddd4e37eb19df6e06e5e018f5e816fda0b9102
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 14bdb5c4bf34ff4967e8a3308c94b72b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103534#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103534#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103534
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103532
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5f4851f303279b298a8412b7d8a1661527a5bde6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ac98250c8d8d3f4564bfda7ac112ae6afd5eee8547207141875cbc2857f8d3e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 39e6d811d3f2a2a8efa27d59562c3061
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103532#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103532#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103532
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103530
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/VulnerabilityImpact.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4dcdcf00eed7cf3e2b05bf92a05a22d58ba37ef0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1658c67f7e486f61d0ffe63aabd4f8c8bcf54cc4e43bdc779f0953db82e877c4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2e59349eaa0776992fb52f3fd86d515e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103530#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103530#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103530
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103528
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/DeleteVulnerabilityModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6d41d2a868833929d43feeee728fdd6263c9a465
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e38b424ffbddc2a52522eda9d3bfd16c46455bd609555021e02f51352e1627ef
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0f6ce8b6835980cdb58496aa4bdfca2b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103528#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103528#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103528
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103525
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/add/components/AddVulnerability.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0b2860e10dcb57ab7621c40d04933ed93dee3a87
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f61cf5b04100941a305aa37424e5ad4e46f7d0cd28d78740dd006964e4f9802f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 99a97454228993d2d993be5a53122a06
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103525#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103525#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103525
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103520
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 32704d7811a315647a652bc23a434c1ce4291dc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cd4f303a4ce570d855410241fb2a432289d5e74f93f81220ba75416a9f9781eb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8925536b10ffffd72bffe6e272cc93ab
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103520#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103520#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103520
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103518
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/search/components/SearchPage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cc0841cc370da6feedd6f2bdb5c20c3f57b42b00
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5da9bb94d32d0a7dacf6512a0e0d0b9d5151fd150fa1e96a903b9b7ebe1b9e8c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a2482aa0ba5aa090199a8dccd53c7477
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103518#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103518#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103518
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103514
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/details/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b26d29d3ea2721486d146f632c956c34b35e782b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c3e55563a94250f353752d05b21250f7aa67bcb7c1ac2d4f786b13f65d5b7cc4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f60fe5cd877dccb5ee1e9e4e15fb2ba1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103514#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103514#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103514
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103510
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/edit/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 85292e34e24a81b17e6df5a2b94ab92602b814ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bf9dc5dbd42cc56ec00efa80aed1b012e77a9c7bda7ca7a11e4d56ba6ba3b66e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1e89fd49b9536c9382ebb875b480600a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103510#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103510#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103510
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103507
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/components/BulkUserUpload.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 13cd96988b9a8a23b47ab2550e803d348ec059fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 26540ec093ca33b0edcf94d3ef33168ceb4ba24f363d173d9495eb0c3b1579ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: af9bf83dfcfca96bd1a1044b65777a66
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103507#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103507#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103507
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103504
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2529173ebf694b32ded1b09274bde22d5030546b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e8e7fff8c3a7eb52973e04cd2d64d4ca34d7fb7fed20ed987fd3ea852054252d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4f4a576e106418e9ed916232d33974cd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103504#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103504#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103504
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103500
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/edit/[id]/components/EditObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a56df0a0fd10a69fea48ca284cf77cb962fe27f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2408053c989db1daa7664802cfdf46f5ff52023c851692da5d1a861e9dabba8d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5d3b074795b162fd649966103cfcf40f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103500#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103500#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103500
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103495
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/DeleteObligationDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 639e1fcb3f974fc960a2c5cd7e1fa452f00ae7a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1143ea24af8283721cc8231429be98ba63bf0eabff1af87b981206b47bd4b644
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4705fcff8c403e1fa5bf728c05061626
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103495#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103495#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103495
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103493
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/ImportElementDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 89a2ced77b951d6f4f927f0df7e505b4f5ad80bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9eb698dc1891f5ce7ccfe6b064c23180e1907f4a6b416ac82640d1e50f9b8336
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f6c741a8be5d0547557c9aa75b1f345a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103493#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103493#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103493
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103491
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/Obligations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 83cfd9e5dcc582cede9d585cff8208b0c89d8740
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8ee4f51954434e5df03b651d39da6564c5ca5dc3ba7da50f9492ed4a54a8abc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3feb02c59787dffbcce456dc1363bd95
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103491#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103491#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103491
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103488
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/hook/useObligationTree.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d494b57671e97a1fe217873c5bc6c5449732502c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 131cd0a1ad35c1f5d527d4fdaad3c6b0d81810819b113c6e6ef0b99d1fb81668
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 89af04f75129bffab083118fa8b5b6e8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103488#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103488#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103488
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103486
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b4ae18e314f2f52725f1a5ff442428fb6230dd21
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e62c2b59092e2b5f42b91b364294000e59c80bb15df9b786cec2dc797d2b1002
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e469e4710b99ac7f1572ab99ce16c4a3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103486#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103486#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103486
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103483
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/changelog/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a82614727a5d14324b1a6a791ad1c411d74ec5e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 60641ccc34281b2c515c9d3210e65e4a02651cd491f2f3e4a3a6904d22ce1e55
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 75949f09faa7582e5b208db3314b963e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103483#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103483#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103483
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103478
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/duplicate/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bd7b2e07ea9348321d37a66ab22be7f21b1a7e09
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7719b370f035fb724454ebfb56cda8feeefc48ff0f024a2eff8acacd820091c9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0242158067f4bab728c9e092c4f5b4c0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103478#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103478#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103478
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103473
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c4c77a53bdd6f9307c6cf7c9ea26d66a4c7551d2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 72426a782ad957829d724cec99147d708552216bcad4ec91bbba852c122bd199
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a23b5a61c66624162f972bd0fcebdb53
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103473#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103473#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103473
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103468
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/importexport/components/ImportExport.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4bb95afa69b736e5204a2c0a4b3a5d6c9db3ea9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9053f9ef847d0b4978484a8b440ca485f2b5ac2e73adb959a5bcf9626866e57a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7342bbbe78918350f9e44379a82235a9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103468#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103468#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103468
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103464
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0b0cce7ab287e51d82ba7bd0134522fb083fa600
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bf9c715e922e1ed3861549ce6fb8b012abd36c05f2b3e63e137f5877eff6b4c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 722286eff86c97bfa5141cd252bb97ad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103464#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103464#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103464
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103462
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/schedule/components/ScheduleList.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 454805fe8a02e56b5ca0fb0335864ffd366c0223
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9138fad2267a0c6dad813f03cc80190fc27559675d6650bcb07e9ad2457b2a4e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ac35fcfcfb4bda861f2a55a31ee7020
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103462#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103462#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103462
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthineers, 2025.Copyright (C) Siemens AG, 2025,2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103458
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenseTypes/components/DeleteLicenseTypesModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dda716cea56889e8f28e4910cc539b526d297f0b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 06f9e9ef07192f9213bd439e91fbe508a2ed5a3948f5833f6c2e1dba3e1094f5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b2d98bba4f9e0b3b21d3d7dd7d1998ae
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103458#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103458#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103458
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103455
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenseTypes/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9e766ce0db666fa1a41d6ada5c1f05874e43b33c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 29a702c4faf397d3c3b00661885e9a5ff65380f3013db38ef0f3de1aa372c9f9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d04b579df6d94770699ff615155ba2a6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103455#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103455#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103455
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103452
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenseTypes/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0dd99499f1eea7593906a65672f09dd15b5b0951
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 00d9d31d2877d9a0fb0ddd568225a290ff06181ad61bbacf23aaf324f8c0d30f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 72011b36642686d3e165edf010913897
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103452#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103452#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103452
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103449
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/oauthclient/components/OAuthClientsList.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cda922e34cf0d7b1d62b887eeb2916fcc0433c68
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 57fe87bce274bc00f4ed06205fc167bea5908ecd2f3fc78f7a411a79f268ca27
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4048177911ae86a37bce1740f99fb800
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103449#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103449#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103449
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103447
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/oauthclient/components/DeleteClientDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ae8c6156ab7e8b5f54e9eaf2f8f09af1877f8fc8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fb705a017315583a3570ae759a6c6c93624101d0a76a4c0e5b88fc26174d63ff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1a062f5c981dc869b518aabb7d946919
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103447#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103447#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103447
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103444
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/oauthclient/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2920c0dea137c357c858bac7ec284662b755f6bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2acee927491dd02b9e3922a1eb69fe9283caffd4d972cdc0a45ad69d58b5f1e2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d038bd89eeefca953aa6a2b0f348558b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103444#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103444#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103444
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103440
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/fossology/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6001548f3895c8ae2102436b67110eed5a142b02
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ce44180480312ea3a664737de4ed7751127bc3a2274db0191ed06da4459aa370
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 51c817408bba38ac3b81c6584062dc2d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103440#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103440#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103440
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103436
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/bulkreleaseedit/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3439dd7258dd24015f61a3560dbf75086f09f90f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 06d653cfe7e5361c6af34d43fd85e06d254e03e706f9292163abcef0932b0fa6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 641a9e1ce10b161ad8c9f5df6b914987
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103436#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103436#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103436
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103433
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/SelectUserGroup.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e548ec38be41877a5cf5b6e68ad357e85800e44f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 394ee367a204816037bf8ec325ec7e8d76c08f98368f30ade294b61f59225d1d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e514025b6c65b9f7055acf65deaba7c7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103433#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103433#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103433
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103431
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/AttachmentStorageConfigurations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 54ef0de5ba88a4aac733dbc1ab34413a3848603f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b09d6f61df119eac7a36ec857dcdb54a71f3d789eac02b528edb0f4a9e7d43a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ab51eaf9b5e3ce7b9ad42e9b3be94c8c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103431#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103431#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103431
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103429
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/FrontEndConfigs.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 265de451b7f09cd4df6feb6dbc83f6ed76ced3d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d48df3f0a7596c44fc5aee364c8ebe32ee2700ed8775a466ecbe041055083edd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1a601def2e94962b74fdfac61703fccb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103429#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103429#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103429
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103427
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/OnOffSwitch.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 363807318fa5b7afa601628bde8715a4e348a3aa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 75117076a93074c72a77eae55b08afa7607f50c6c04cd6d4f20941f0bc4297e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 77df7e52f6f1acd64ef9cd2733b774c5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103427#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103427#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103427
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103422
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/databaseSanitation/components/DatabaseSanitation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 426f6472e45dbab06501117a09c037442780e67c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 16602d151b46669c95f5859856d2f82eed270f355cb8f2a7fb3281d3bf44932c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7aeeeb406046fe78c5fdbc5422534f6f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103422#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103422#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103422
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103418
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/edit/[id]/components/EditVendor.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 057a8589f2da3b08e93cd663c768bc3339e7f195
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bd98d2495943df1bca831afd54e436e3fff0369da71115d9dc5693893bcfaf3c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9ffaa447dec0138b0b200968928d9fde
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103418#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103418#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103418
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103413
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/components/VendorsList.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 77e11c687c8e21272e70e97b410f4599e16bf3a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 24e2c769c0ca256201e51a96ac469a576b4bff184530d12600b221df773fd497
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 27d15b7e3d0016a70bac167b9f114401
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103413#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103413#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103413
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103688
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fa79e9a4101438c7486f61496ebf9bd82695a91e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5a39e8bcd10c1666b50f31384e337a4a3d4216dd523041b26b685a29883193b7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b296b653aec1cf48cc9cefc351ad5556
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103688#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103688#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103688
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103685
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/split/components/ConfirmSplit.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2989c6e2849636dddbd1431e6a1e84488b215bde
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 29380acba30a46e705945efd3da526c9044f1e303776ed5f7ee5470f99b6af7e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0c8df29d50194e08d61c79c97417421c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103685#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103685#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103685
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103683
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/split/components/SplitData.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4a9be7c01de5ef7d2e0047e6300e68bd118b9fca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d06e28649a024fd50132329c7feb1002833255d9bd7878592e1239aec0adebfe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 000f2ee9be6b551e5eda71544958059b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103683#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103683#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103683
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103681
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/split/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d8164858e55e27b3e69b1b53fff02c87cda3f9a2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 60d94cdd9c3b9a9594112e5300b76bed426e9bb9b75d965483fc4345684030ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 595dfd0bddef725e06fbeb2ad285b96c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103681#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103681#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103681
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103677
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/components/GeneralSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 63813501c0e2a10f04d6d6e00566c55affded876
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 88f89ffe58db05fd75a373fc7c84b61593d39328d1b5e626965d07ed104f5c3f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fba21def9d5db337ac59c25ac21d1c5b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103677#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103677#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103677
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103676
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/components/RolesSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: de2976c29dd2df9dc628ae1e44c86d37c75077fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f326d5afe6f678c53bd52eeeea923713653937c38f3b7cbdfa681dcfdc64087c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fe6de7cf247920f99845cdb0839a891d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103676#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103676#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103676
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103673
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/detail/[id]/merge/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d72a2266b37aed382aaf6914fcec94fa784c6c4f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 77234addc169f52305712f39dfd3bab902824c7da426ac5fd7971b2dc7c73dcd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0c00cd4b814a94d61a07c8f8c1bc1bf5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103673#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103673#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103673
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103668
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/RequestInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4f834ef4bd2361534140de40f0edb2e55c5bd191
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3b84e62cf1e8bc519a6393aef1ff84eda564c30df840e986b2c8aa2aaf93fa94
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 883b14adde168c9eeee908d57d2ca467
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103668#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103668#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103668
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103666
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/SupplementalInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ed25e8dcdf15127eef5b835eba306b4d87639239
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 192dace4e0d1ce6f80f6390d3df734f401f7cdca58ba8768ad91541a87451a31
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9964d761671338e92643e7cce333b961
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103666#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103666#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103666
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103664
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/EditLinkedPackage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fa459081f9da31d09c74836cf99f6f9db9c4237c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c9e17409c441fda4fb7bb1440dbd56d4cf9cf35024b9ec8ba789f99fdd4cbb82
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 96156a8e0b6be03e3775f08d931d7321
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103664#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103664#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103664
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthinners, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103662
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/EditSPDXDocument.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e0d1d2d4c0bc4ee266690f702abe1685e4c28440
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1573332dfce584cc25f29fdc7db0f1abe98043fc56e840764086e70adc295c6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d54b532c8626c3a33250a33905bd937a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103662#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103662#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103662
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103660
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/AnnotationInformation/AnnotationDate.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4859afe7eabb62d154bc7c5fad2803fca7ad38e6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 295c373fcd9398fbd6e8198e505f736d9f7ff46a7d52cda8907bad60d38ff0b4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8a2053af4cafc0da7094a4148edf903a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103660#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103660#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103660
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103657
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/EditSnippetInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bc8576bfe1322fcac25fd2cadbb31ac9c2966aee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 78e7cca10c37897905ee716386c154d96e8af5ac06db2679d54819467ed904e1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3228a266bf74be135dd6879c2cc335e1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103657#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103657#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103657
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103655
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/DocumentCreationInfo/Created.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 87bcd7e511cfc1aded3c29c699f516bcfbfc91c2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bf7814fca2af2bb0d95ea0dd7999acb5a5477eadffa9207edf89ebdffaa26207
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 85038586988dc13337cf9e27bf914978
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103655#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103655#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103655
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103654
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/DocumentCreationInfo/Creators.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: de41afa1d0691d2584da802b6059495fa0792219
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 82079853334fd431d44f9b2c7c7600ef8743e58b7ef9b94fad4810e1982400df
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0d4c6ef8c36ced26e9ad76ecfaf8966f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103654#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103654#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103654
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103651
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/OtherLicenseName.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: eb46b086a84f96f42882f0bce90709c09a6973be
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ca44311e57393aa4a56abd61d3a805750ef747c1563997b809e034f86e9eef8a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aff31122cafc4075c581ea6e341d905a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103651#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103651#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103651
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103649
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/SnippetInformation/SnippetConcludedLicense.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 33f97b65b2989a6664bf15a849ef7c21a883ce6e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5217f9578c9b1b042e37437c35d284255257bea54da824031cf4fcf5dc0ca453
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9e38c4312ef3fe844b2615de4324c70b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103649#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103649#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103649
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103647
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/SnippetInformation/SnippetFileSPDXIdentifier.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2586aaae3b7aacb0d9f1ee71affb3969db26256f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9110d43610b61cf3325b7bf05155f5a2c6cae13ebf2b9b2160e2b17e42024e40
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 020142b68c4f1e40b4a1739d5871742e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103647#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103647#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103647
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103645
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/SnippetInformation/SnippetRanges.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 63da1bfc7d1518c66a4b8e38d1000742bbecd988
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f4fd1c3deca91527525e20fdbe0ac1c39eecbd89b75fe6ae65491c7116d90cb0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ebbc4a53260388a4af807288f5245b4f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103645#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103645#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103645
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103642
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageAllLicensesInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2df7b4ed90fb0b6ba9facd86395158b2441caaf1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: eb915aa8dd50c76f896a49f4368091c2225967a61796984f5c864d344103719f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 911700031d3a1f12887659e3ed4338ad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103642#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103642#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103642
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103640
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageConcludedLicense.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a36a0314c02f7660312049b7b668fbbcdcab4e96
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8a3b6715e25eec19c8ba1cd3c820c8c1363281a221fe882f48af3a1efc2eb307
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8801dbd182c0c4d7db81149b9fd35b15
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103640#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103640#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103640
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103638
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/ReleaseDate.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6b4629a0898dc0c5a49e76aefafca7c32bc6ae96
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 38e0a2d657494a93d1213741459b347a06c8a298bc18e3c8cbe6a2e19c76182d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fe855a3c3ad982c067f7cf1880eac4fe
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103638#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103638#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103638
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103636
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageDeclaredLicense.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cc79670f8b994e90556a4a85f83bae2606b63dab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2dc8d9c45674ff1c5ba6ac6c25908ea59cf9798900ffd5417454be76be4ff1b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d74231d063897e54eee1eb8acee51d7a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103636#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103636#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103636
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103634
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageSupplier.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e728f090149f78e252d671640ee21e12da361a08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 55ff2195e8841156c642f173df9cbf50b995f2bd694e01b36127045af0a4abd7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 632094902bef096594328b42a7c31774
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103634#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103634#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103634
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103632
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/spdx/PackageInformation/PackageCopyrightText.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b830af128deed9ef751b6b5461f5370f6a0c7292
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c7ddec88c07e21839939f54c3ad8909188701a05b8dfe42ba3f9ab9e76a8acef
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d84c16d891abbf4c0dfaabe5903a4f9f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103632#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103632#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103632
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103628
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/editRelease/[id]/components/ReleaseEditSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 74234dce9306b2198712e2baa88a5f020dd21b24
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: edf3e8c7d8226d8500513f17439eff216104df3ab6089bf1e62cbf95b8870949
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 13c65c607b961aabaffb2fba24bae9bf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103628#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103628#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103628
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103623
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/components/ComponentEditSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 749768d1d18841be2f6c5933b80ac0044a27b5a1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cb12bf3f1ecf548511b055ce42ad2b9683376c97b576abc188a7021ef00ce980
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 62b210b1db7431581b32ef8dc706dcaf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103623#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103623#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103623
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103621
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/components/Releases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2e274b2342124929fdd9ecf8f73b83e32dbd8063
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a2d1af18bb79e853b258e57e53289c76ae80d1c42c5867f267f6dd6fa2996e4c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 97dbf2c358a91b96417a0affcc354949
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103621#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103621#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103621
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103618
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/release/add/components/ReleaseAddSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7cd4fedb8d0247544fcae36b5d2f0d6ccbaee565
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b7b61150c5bff77975a4291d126d794577033a06be36e86be372dcae48c4df19
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: abe15d299cea5533537dc32db3fb7982
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103618#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103618#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103618
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103615
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/edit/[id]/release/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 08a2773c6905cde96e22980aa2c39929c5e26ab5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d675c532af59e0a169122bc98831923667f6c943089ad418abbb33f9d8dcbe5d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 962757d304b1ed45e97d96bba9b0baf7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103615#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103615#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103615
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103609
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/components/ComponentsTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 87e56f2f36bb75e2d9079bb2bb4e1f3bb78102cc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fb40dcb40b871f1ce6b2ec783015f03b2c8950c5c718102a830b6623da2bb75f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 869164eaa4590b2f88d0de60af9c8f09
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103609#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103609#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103609
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103607
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/components/ComponentIndex.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 86f0d3b35dc2f66d93e9384dcf0e45d4c4b24da3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 86913facfe54b234225c4fe2c97a4b148a05dadc5b53db4e5162cc3afffba279
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a659be3caa7cfb20875f99d0923036d6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103607#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103607#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103607
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103604
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 38fc5dfad150e30169d87fc58f5e7cf26457fd07
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3ee3617812fa59547aeae86fa55befe17e9e9a18b8f2e19e12126770db62b83f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cb33714a92fffbcfd2a4b2986138df62
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103604#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103604#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103604
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103602
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e8478d6651a011b5ffcd85dc95360383f9d00c7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8253be900dd518a50420642ccdc68ef39f80063e6788b5fb6f0719508056ab23
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb6c6bb3266e2099fd1ba2edd49de2c9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103602#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103602#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103602
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103600
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/ReleaseVendor.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ee326ec8d392837b813cf9ddf7f72e3a70769a88
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d6f0a3f043077937b8edcbcccc818b4024f61b6e53cce7020feeda0497f8001b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 833b7df8aa46bc6eca23c481c8208c70
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103600#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103600#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103600
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103598
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/ReleaseGeneral.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8ca2927de7fdc344c6dce92596800469f928d01e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fec2c817004039c1690ea1662331b34af6ed730f01130bf111dd062017634721
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e269ed93eb0c9cf626b4b747ec0b5a1c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103598#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103598#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103598
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103596
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/ClearingDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e466571997ec2eec6ddb748900eff66170e6a0d2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f28ede2d90465145ed248e346fa6ea25dde746549543c052b90d520d118c7e21
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b430587d6a75d4eaf9227266747ed770
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103596#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103596#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103596
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103594
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/CommercialDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 37d672a1e32861971dd77b227401c912bc2a4a8a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f963882a8d49a37b5d8b5998e17687da87c6034bcbdbd1eee6e36b8955728999
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 08b6c06718f18529406e0fab91f9c7ce
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103594#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103594#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103594
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103592
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/CotsOssInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 18077ae4d1c9716ae67fdaea30fd7b4833b1a5c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 457efe6fe6b136dc70b1facd7753bf803185fef0dbd88539619461f16f45bf40
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb79e9bf9be84587c8b007a60da41753
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103592#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103592#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103592
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103590
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/AnnotationInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 374bfdccfe87d6b9b929f599a28009655bd0e758
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 971525cba94c81e30beaeb41d90082162be5f36a7c67af764359f19f93b94d0f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d5dd4aa4c829efd8073c826f3e0ccaf6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103590#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103590#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103590
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103588
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/OtherLicensingInformationDetectedDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ed539c76376c153298ec111caa47b8e6e23a9ec6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6a4fb8cdd14358863f7297215c8b4349c905df951ac39aa507d7650522fce7c2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e391ba24947d0e3813e70433d5174788
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103588#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103588#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103588
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103586
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/spdx/SPDXDocumentTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 41ad8afd88bd86c06f6b8a676a0646a3490abce6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e2f9c5e308a2d50ef83f4f5dcb626d6ffe09c200b2f021b6f7d4726208d7694b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2eb2cbb781c15bcbcccf30991a7cde80
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103586#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103586#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103586
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103582
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0b7403cafa5fcee873c860e692c8449b4b4aefc3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 53513de7fb9ce44808eada74f0cc61bf000f65670f09861856a27655575a3658
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ec8e9fc74d2b18bad25c02f8f1318b7a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103582#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103582#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103582
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103580
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/components/CommercialDetailsAdministration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 450319bdc277d431940c555d9f059c5331bc8417
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7d005e1a0e8ec846124ef7e7c5a2ee3454aeb335c6f61bcf6855ee2bf5ace6a5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 28cf93f2ea7d2e555f8d528ce2a0b95e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103580#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103580#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103580
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103577
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/RequestInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 768679dfcbabb2369e598494d657fbac33ee20e4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bf29e6cb3b1fa68fb9de480dcd00d3ff2601674cfe47f80a6af9f04f536f60ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: efa1e3bf34916a43b0ff71e2db594f0c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103577#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103577#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103577
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103575
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9aff2f4b1672660a190931778b7dd149203dbb13
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a958a88716b110009f9a473b8e9f556f16193197c020dbaaffd08d33a4b6ff20
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a17b317b7efd0bf18866753d27b7643f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103575#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103575#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103575
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103573
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/SupplementalInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c999895d4bf2e70772a519840ce3a78e8aeea3eb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 181905cbeca57a44f8e0b5e6f63e344dcd8dcd90a418200a3cc26c3c995dd2fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: efc1ccbd036ea63dbba53f6bcd28e2a0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103573#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103573#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103573
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103571
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/ExternalIdsSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8d07a6ba76342c16cad822dcc67dea85f912d822
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8410db1d347e8307fd9cb6661d0af81190579a008f2c8ef65cbaa31deecfae29
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a96f1242fef8ab144a43a23b28ca0c5b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103571#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103571#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103571
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103570
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/ClearingDetailsSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 123ab12083d35c20510e7b097c11c1b360f30291
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9370a68c163759cd4fa0f319457aa56326ae269c93417627efdc48432c6fd843
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c7f53749a545908352b3e66633362d0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103570#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103570#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103570
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103568
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/CotsOssInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 33fb345dedb374ecfee8f045f561205a0ee69e48
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f7b3703d9870c1c027ce15d7fa807ff47649d20676512add54f534e382bfdb8b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 03161f227426cbe21de62685d98b3d96
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103568#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103568#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103568
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103566
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/ECCInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e9dc2850ebec28e5d6a54ca60053c8479841cc4b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a4532daf17afa384f8b172c0de8e293b84e2db42ec8d376622ce6b574e541784
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fd25025a265bde95cf22f8dea803c5eb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103566#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103566#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103566
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103564
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 168a68e42d8b7be04bdd0950299f53abc22ef2e5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 13ae05f63ba88560089cc411cfa24e1828fb4b65662a9e14f80f0878f4792208
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8dfc3d13144d80d42b52dfabf6e08e97
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103564#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103564#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103564
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103561
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/releases/detail/[id]/merge/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6a9fc5a3b4081d3ff154da22c617ddb01fd9c5ca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e0fc3b17627093a674a0599a85a0baea15aa8363b94f377936dbcd3a0b8a540b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8c1359b97a4b224508904d7a484fb5aa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103561#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103561#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103561
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103554
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/components/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 65d2d51bb486e0ac9a4e2cc1dd2d6520162b4e13
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 76396e3a87dfea391c2fbc8ac97225972e6eccd8498a715f60f45cfd6aa74439
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4675f8e8e0430ed932f8e43cb9ba7349
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103554#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103554#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103554
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103550
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/layout.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 70c82312a648b739bd76410050cf2e1783e73343
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 31b20fdc50164142fe0d58eb55fa18f4000041e429708fd09a74ceaa01bd7d5d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 299d0ba05b331f7c073379b87811ae4d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103550#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103550#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103550
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103548
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/components/UsingReleasesTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2979f73c1890c627ec2e09938063d2adbba1ac42
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 00e66f04d1f2e80cff993e6cadb4afd5f8630dacb11fec559cb9fd87d7809b1e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 07c5a2a2cdd589f6c3170095f18b1337
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103548#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103548#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103548
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103546
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/detail/[id]/components/References.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 10cb73a18cfd20b02096b4f5eb273ff226ade276
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c622756dc4aa812b9ea21a648bd66fe9c79765e4c08962864854950e7e6c8f19
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8002ce7525cd07287566f7ab1e5b321a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103546#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103546#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103546
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103540
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/edit/[id]/components/EditVulnerability.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d94a44bf974134ef74289c1aabb85bb17bf28c87
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 00d4e6ebe349ab854a2356bf0b9098d3f39f289d3399146bc778c36cb95fbe5c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 838240e8102c33762fb164239cf6b8fc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103540#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103540#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103540
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103535
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/CVEReferences.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 82e79532b49277fb409cb11612069764d74571b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c0d6135b865e6bf349796517089c7a82fba310474507620abcc779406eab8f95
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 21871b42bef62da04721d6bf43cd5397
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103535#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103535#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103535
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103533
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/VendorAdvisories.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 39305379c54639504a4b1d89e89b20058fcf78ab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bf75c17638bc3f47d8cade050404994458b076cc28410827ba2ad32d5ff8e3ed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1509940cda16fc7a34f84cb666fe9137
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103533#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103533#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103533
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103531
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/AddValues.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 06b0d7fb4d8f740c1638b365114bd568b0299c06
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4fc356626ff47d2fc73e7fca7ce01813f61618dad970a82ad65f89219d4068d8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4c776fa7f2f92dda26679ca3c6acd7ee
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103531#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103531#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103531
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103529
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/components/VulnerabilityDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ea502143c3b13777028e6770679ccd44602df175
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a8a2971ec1ee123338973d7779313e0f9380feb4868b34800770c26d86c2aca3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2067021c69f3b92630515af5cc507460
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103529#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103529#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103529
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103526
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2a91eb35905e2429934258b571bbc2c27122ef3e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b2279d38338b918ecc2e7a68cb2af2cce2e6e88ab2995dc517c7eda49bfb6832
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 782d2eae376183796056aa92b4b147c3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103526#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103526#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103526
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103523
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/vulnerabilities/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5f235c69e1202a070a841a7b00f80382a475d137
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ec978ea51dde5bc6ea451d97b25b6d6ebadcc2bc5a0fe6d5db6175b14867ba68
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4897a84aeb95f16071bc4fd49a83f70f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103523#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103523#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103523
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103519
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/search/components/KeywordSearch.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9bf108c3fbeaadbb354a6eb0a8e15458fc582e14
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 73cff9e4211ecd1b452946b206b844822ae544f44ee5e9d34706e90503d966f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6bccd202a955a652f6d893dcf31bcfb8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103519#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103519#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103519
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103516
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/search/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 505cff5751256d76fe67cc380f52d400ed5a4a60
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3c0e914a04c473880002596be43d20ef1fd0c2fd1be5a5d874c43efb0b894277
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3a4ac5d0b127cbc7509e5aaefa2d9458
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103516#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103516#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103516
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103512
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/edit/components/ToggleUserActiveModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c5bea55078b7c86cb87dcf38615f1f10e6c95ee4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5ee98f764c78ba63bb229bacfe8efcc4a87c3bd8d302b8d1b9d7dab9beb9d221
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4fa4f98d518ce0570fd39bdf65143904
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103512#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103512#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103512
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103508
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/components/UserAdministration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d0867a167b118ebbeff447373b89b0c5c783091d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 619671b7cbfcafb5a53edddc5616970a10187040515cfdabc9d53be9287804f5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6046f27a396f07e7d0cfecd1d26a58bb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103508#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103508#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103508
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103506
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/components/EditSecondaryDepartmentsAndRolesModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0866ae60d8d3efd4098320c5cae589a18b0c9dd2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ed9b8f8b6c069696cd3dea106e83e07a26ba5a15a735129523a73a6d6524c233
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f37f43ff8e902c358398716ec0553f31
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103506#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103506#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103506
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103503
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/users/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b0c7a72b85905dfd9be0736264ffa87fc8302eff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0ca43db3b7953470e1bab9e4033737d3243f3c6ea9379d5b523e6e7f09a8fa84
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb093e86659c912bc904277abde33d1f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103503#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103503#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103503
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103498
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 35e40437167da1cd92ecd0a132fc4ec3b725b60a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6b56512e9722c58c845d1265a8d3f55f499a9179ac847bbc6547d77fe893058a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ca6b877c3be5b1c8a81000a440858e5f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103498#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103498#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103498
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103494
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/ObligationTree.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c909b1d55be341434cf7522098e9d966a650ae7c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3229d0aebd61becef7775b63c8d24adee7f8d3ce5db6a562772740d42f9368b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f280e87e5c84fb468c5c8185abfad41f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103494#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103494#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103494
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103492
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/ObligationHeader.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 16df86cfdfbb7cdf369c77008308472d0dc0a8d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8ea6753efc1c8e89d49399c6c20a8b7be53cc14d6b4331d287326f95a50db701
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9fd5971063f62013a068ddec5e37ea93
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103492#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103492#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103492
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103490
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/components/AddOrEditObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 77dabd326c5d40b10d2dd25465df98f40dabb4ca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a70d52fe84d712a8602ef4318d2440d2b4376e99f1fb03f57e6b3061a4d0429b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4b37ef4c0564a288e9c27f4241b8bc79
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103490#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103490#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103490
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103485
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b89fe5a7c609433b757d2a977f0e1327ac750db1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2b6acb7a80858aa748764d714bfefda87a5a395189f9daddba6399405aa780b5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d8f011d3c2b94248533b41520af600f3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103485#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103485#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103485
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103480
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/duplicate/[id]/components/DuplicateObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c48549efdade55c5eac8b0720bbaef79baa8449c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f61299673b0be89a162e52171c606e0bd344f20b182ea14af0e48156c500205c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ff246b56d2fcdce0d899a522d185870b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103480#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103480#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103480
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103475
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/obligations/add/components/AddObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f0c2351353145f48904206cb0f36a22a5bcf96d9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: aaa5f533024e5a18b81fc54d16cc140b646fbaad9c29f87eff76a822b25c6381
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c34b1f424dd2441bc63b01b7d9f55f63
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103475#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103475#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103475
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103470
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/components/Admin.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0e7c4ea2c5fe9c7c5442de2f9388fd2be52ebdd0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fad0779e3ebe6f2a22744a9d85d8aaae449bdd118e4ed1176d8f7525b5fede55
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0674b603b2a88a352ae863ead6196730
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103470#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103470#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103470
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103466
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/importexport/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2995b9d7688883dfc1a93e4de7ebe01d19997fc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a4fd84641d66224dec7422a90da23d05eb66c9ec3f665ec782530e7e03bb79b5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c8d82ee3109957d288d5834fa02fb26
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103466#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103466#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103466
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103463
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/schedule/components/ScheduleItem.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5bd29bcc3c823b29d546dcbf643d605d2c40d46e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b824c14314f30f84e5a157f1ab6b8b345a44e60d931a3038b31316629126f0e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9b5d2aa40ad2fef46171439a2db1deef
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103463#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103463#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103463
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthineers, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103460
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/schedule/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5268319200a4a8171d4418795f53121558ad76ed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5c8e5eb67970de4c6738c08a2972a2ba0c78dfe8fd720faefae725363d3b02f9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 28884371842aec681d70b402539b6abb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103460#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103460#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103460
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103457
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c95ba711fae6a2715dfc4ca80088ec11bc1a0fd5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 08d1b53016fe8ed27cfd2add43d0ca95bca04dfecb1d4478710a43c6e238b11a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0a22adb48d54ea4be1874f5104c112eb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103457#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103457#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103457
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103454
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenseTypes/add/components/AddLicenseTypes.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9426956a4f3bf0ae7b943e9f14de2f94b7cab386
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2af40c11e284b6b9c24b4cda612ede890a270997e1c15844e4fbe024fd65c487
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 001c8231a9c89a784db13d0837a39f83
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103454#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103454#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103454
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103448
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/oauthclient/components/AddClientDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 940f424796b19892319fa05fbe925982c497eb48
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8fc28ec917b64f2667a83b6655d915b2f69f1b7c06087821b38d97a1077f1456
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c0f5fcba64c50656e78586d2dfd00df6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103448#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103448#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103448
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103446
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/oauthclient/components/OAuthClientTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8ed1bd6927c6a9c6786badef72fa0fe014cd7c4b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cfda09a9ed9f719cee73cb6bea786d9c013e969f01d82817e38cf80e4d9e8f6f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 22e26ccb120e15b1834d6b6e0ddd3591
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103446#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103446#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103446
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103442
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/fossology/components/FossologyOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0771d431e018f1ef9f3a5fc041176eca032e8142
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e5dab535683edfc970f2ba7825fca233dc63b93e00091bb3d081c60e161f590a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c9b95c0aeeb47c5e742420fa5a8e99ef
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103442#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103442#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103442
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103438
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e14c7c6f80efc4ca4ea749737c81d44ae2cadacb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f481791b47c0f697169612c5c4369fdb010dd5ba0e4375352c397adce7d10669
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0f0e80ee1092824799800c7e486538ca
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103438#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103438#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103438
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103434
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/MailConfigurations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a89740ea6c0ed63b9abb00a3c4952f80e4815045
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d17b8b158932daf86caa59757366c449ad5de643c80eabcf1165df280a458a7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8d68a0b8ca00154e10faf0ace902b175
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103434#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103434#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103434
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103432
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/PackageManagementConfigurations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5e7700cc79786301f31cbc37635ac51fbd9ed976
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0381da21335edfa71ac3a07e90c397207e016e54ef2e03a8d3be9afa7eee366a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b181ef00df923efa3cd364fa6eca805d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103432#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103432#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103432
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103430
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/RestConfigurations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 16f50816449b8cc2e38bc2d3a603906ab81a161f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4a51e59b5316d339c71355e4801a57f0624fb90252474bddb3c5a952e5ae0599
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8a8b34697791287d095fed27fe74025f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103430#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103430#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103430
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103428
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/FeatureConfigurations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9e19e595a16a301f092984fa9af5dda0ba06deba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 092bb7abf6d70c9f5f6f6cda90b9a16e1033dedeb386510da3009021c1d68bf5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c299cf50871956f59d23b2cafeec5dab
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103428#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103428#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103428
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103426
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/components/ConfigurationsTabs.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d357957de7724686d98544f673f6deef3850eb45
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: aa12c7f59cf8eb549a79c8f5f243c467de14b8315ba03d4e0edbe88ac91af413
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2f3499b16be23bae177c1d6257b0ee95
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103426#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103426#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103426
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103424
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/configurations/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a0ef46f64f55a06328625eaaf57e039f70ce49c3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5ad6ea2ff787829f00c2a1f5c7eaf6f7c6323e39f5c97e446c85ede045477d47
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9d7fc11365c0d0e5af2568c5b338c791
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103424#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103424#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103424
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103420
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/databaseSanitation/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8659cff384602cf9a23db7ea5048a8b9c8ab2e28
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9645b58ea905aeba9b94e1ecdddf1e0e6e8006232d4045c532ffbf727f214067
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d2d470d974ecdda9db6d83dbc64a379b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103420#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103420#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103420
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103416
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2d46944319d1680d54bc97b0bd57f957b1269722
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 42ccf152a5f6ba3390b268b10d77793e8a5229221d72f57e458523df3ff696ff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6b4eeffca758e2329b56ad7846b3cf79
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103416#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103416#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103416
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103412
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/components/AddVendor.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3852cbfad486490e070afecf99ea67183a8c80e1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f3153b36a41115aa572cde3b41b16ef74e8064d826bb7b53f1772d7d44991211
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d7888737a55a7e809e34f8370b8a495b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103412#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103412#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103412
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103409
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 250d0d2bbf98cec941af9139ee301d1a267101d2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3dd236e7b20786a03bfd585c93df8bcb58e6c46edcac33e924534b9f045186d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0af31c548ebb3953a7140aaf00d54e06
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103409#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103409#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103409
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103411
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/components/VendorDetailForm.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ba5b48d10923b1828f4dfa38546fd220566c72f1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d3675b046c776b13246b4ba344608f4e3e7bf35acbd7d8430c3654e6e2a28a5c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 13a9d8d3282018215615d49c199e43a1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103411#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103411#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103411
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103408
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/merge/[id]/components/MergeOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6e574bb7ef37e833a2045245b562105da48ee35d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b877ff56487303da09c02e6db0c20160815e06d174e3372c56450f9d0fcc165
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e523a4c75615782809b0f6ef45a3d044
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103408#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103408#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103408
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103406
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/merge/[id]/components/MergeData.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bdff5c8c79af50b52ccd48bab508e339de54fddb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a1364aa0a131a6c13f9291d875aa8cfd9de104013c889242385e131664e4d23b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8731b594dabc027974ad4874dc167578
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103406#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103406#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103406
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103401
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: df8711acd3d8beaa3942f3e1bc6141d6e3423bb6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b612aa06268996a0f0f34541e87d9dec37192631a5c243b56f12a71b6b072397
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7ac9393a1b14e00892fb789278231b57
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103401#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103401#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103401
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103397
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenses/components/LicenseAdministration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 265e011654b883d6871303c1dc9c61afd83954cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 350bce8d00e3427e6379dcd542804e8b86e5ccaf20790f39674402d054eddc59
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c3415dbf3b887424a4cdb73acb8d590c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103397#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103397#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103397
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103393
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/edit/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b3c02a4bfa555631919f88501c4b7b447509b726
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a4593e85824d680ec8ea1b86f858fada61125db9856975777f5c9aa2ccc2139c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: dd910bc47bb8aa9fab945953c0f1eb0e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103393#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103393#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103393
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103390
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0c256b81d0503dfed3064049059691e524138629
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2465f9f5078aedeb5a72efeca97de9b3fc23f7e9843465262991b2b1a6f2d98d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 566953fb193734209c63809fd0fcd2d0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103390#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103390#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103390
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103388
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/components/ViewLogsModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dc4b079df840a76cc15d807a441f3760c207f744
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 691bd1f2901ce9f5c8acb249053598b6bbe33687a91cf84850b4f584551a62ee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 948e88b2d448fc20e11fc95ce22e5582
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103388#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103388#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103388
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103383
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ProjectVulnerabilities.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 29c0ce90c73ad1e27e40e449ae1f0d0df1bc9cea
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 31f48010fb9ae292ab3133e6ea0ed9e061287458fa6e259cda054bc915913e18
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9fc1e1fa26ba907428dd681d279c0729
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103383#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103383#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103383
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103381
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 38a4f21f61125133aa589eede10d4e9bee69918d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 25217dea80f4f18c4fd96e8b2750ee575ea685f823d4288f254948d57bce8a7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 567cd47d320c591d5f7f1030dc7c73bd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103381#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103381#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103381
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103379
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ClearingStateBadge.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 888e0e7655d323e58c23d0808dbe72e805ae1ff7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 68b67583dc0c1167e7064244f871a5f7c45899b4f5c8cf645210c1a0703b2c89
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cd958c20b17e7e688687c98127989f44
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103379#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103379#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103379
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103377
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 78a927d74103b2dee0306fc728d799a54b3baaa4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 591ffbc5a932328e2dc0d87088ba834d5f70df12501c0bf36804d5171e3f9de1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c6d66e3a71f1b6c22c27569dce403bd7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103377#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103377#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103377
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103375
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5d81c1bd46a0777ffca945c1a5de1821a25138ca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cb278f3b181b12eba2d7fa8486942d3074d23512c99656c29243749f5812d7d8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 57e3ae6592a530b0becb1f81642cc228
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103375#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103375#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103375
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103373
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b1d6abd571d765a0ba947b9defe0ee3f099d21e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 87be613e31e5c58bfaf37ee1e9d2ba924625492c25e6db6cc6ac7b8db2b5a46b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1b498dca4b215dd23cff2eddc8014748
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103373#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103373#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103373
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103372
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/Changelog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5288b46cd123b79330e52245cfd11e024fb2978c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 078b807cd0d3cc146b7592027e658d36179db3541fb7ea5dbc441d4908672571
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e436c617032616e7de93b11818fd8032
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103372#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103372#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103372
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103370
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ExportProjectSbomModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dc4755616a00e983dd9e36b9c328bd27a2946613
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 795f93d8918bd88a9c0b71a91c081812366bf2a2edf07f9a91669ea1ee258f71
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5d7fc0d2d65c7c8ed8d431838c36b1cb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103370#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103370#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103370
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103368
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 327fd37998e655c42e61f7e95e74b17351ad9796
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 25287f8cb393ccdb2401e2d633829cd703cc12d38a075c1a99b00fef96fd6899
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 592f3eca4ad20f575a69388e1424c14e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103368#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103368#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103368
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103366
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ece9494c32c1035bc2e57928267db15856ff3d0a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3ffc6a446d6176a4580bf72038eabf4d95b1661c3a1655b1b3e51a78ab49a15f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e1959e3b5c286a899a49c5c612d42263
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103366#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103366#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103366
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103364
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cace7087f1d76ec3bbcbcca4c9fe616b9585cba6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b7191ec711c82687c828bd92ec551135daa68eb4d1a0f234e99da82ad0d69290
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c1312a0a07c043fd681a4e4dab8fdef5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103364#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103364#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103364
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103362
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/AddLicenseInfoToReleaseModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 377d4c8bc95b5e4a65d98792ad551ee46dca6dcc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 233ce690ccc412a4c2c4573692d4087c61e0c35f26662b3ddfbcf40248c88012
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f88e73e1eb0b4f3d98f36467160f8a31
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103362#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103362#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103362
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103360
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d0ba97ea3883a02e6b2ec3816ccba76b56a90c1e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ccb2dd158280e52e0103186d67b37c26b9e77b9f3f787dc9bbbbce9e35d46b45
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 27f0189c336dc320cb378b5f6218a3b5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103360#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103360#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103360
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103355
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6fbfc7fc753121d81f60bb9764d90f9353994a7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5b85ea8a2cc5f21adb39b95728f53cf2040402d6a40d82826e47b2c6f62f7acf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f4845202e210258ecb7cbd9392e2cbae
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103355#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103355#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103355
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103353
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateLicenseInfo/[id]/components/LicenseInfoDownloadConfirmation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 76a3df4d15cbf845f80c5145753c7bcc09e9350a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 782ce18de255bbb2972fe0318422f91f592bdfa8d9ca45a9a2d1e0fbff4f7262
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0947e4ba16f001dcc9370418750f40ef
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103353#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103353#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103353
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103351
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateLicenseInfo/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 898d7a44fb8776b28265d1d42e12c00cd9577f40
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 75b1d46f342648af8aaaf03f1dd469336b85cd7013da526f3f2879f57ca1961b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 165a53a2dc8bc6865afafc8955fa552f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103351#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103351#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103351
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103346
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9fda836fae7d84c17f15a141c873e5c6b3c948aa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6bc0ae10e52e9083d39996c3bfc98cc87cc63d4d77378bb5704eee1e67f91452
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 66f66ccd17c5276902b6e9039442ec21
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103346#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103346#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103346
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103342
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3c7de918180b97d3bffb81b1abd24a6ee70f0d93
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1e15deb8590113553b822efb84f53d347a21b06ba4a6c35dd888adf3ac401408
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1f72523f058c8ffcc653f15ae058c019
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103342#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103342#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103342
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103340
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1d1b2374934fd515a1d5eca43922882a475ee36c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6998aa3b2c722ba0a29c03ad4a40729c6f1ec47fe7ec73a42b5fe978c3c4cf3c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: df77b172a63657e388bc1ecafafd3483
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103340#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103340#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103340
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103338
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/ExpandableComponents.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 70d448698f46ce11bc299b3addac712f43526fb8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6e936707f8b5af1bd910c87f1b8fbebe8c90d27befe1cc05ed71a60458f12e4b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a4a14856ba691a38b4a02495e77b6e0c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103338#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103338#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103338
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103335
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0afa0632323c581e54b8df27c721474860862fe3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bda41f8a8265b684467f2b9fcca3997b7a994abe7c680343be771913751fe6b4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e961f8519196daed976d2428d6892be7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103335#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103335#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103335
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103332
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Projects.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c15380b718fd1ca9ce6cee1daf4e3065bcb591a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c3153f9c779f4d8015f8f08781f9fbd8d46296cf2948b1de9b786ddd57d6c02e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9eb14eea33e9dc6d29508c65a0c0684d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103332#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103332#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103332
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103330
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/DeleteProjectDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c68ce9fe38350f782bbafa1d3f1037f5f6364f27
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: acb2ebd40e89d25b64eaba6e9f06e1b0f51f12991fcbd84fa306b715077f24da
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: efc9d347d3e8ed9fc5ef193668a3c1fd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103330#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103330#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103330
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103327
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 05e2f0c8eebb14968665dc51092dc49b9b9b457b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c512320ccc716c68dba0e1ea9669cff975f84bb1a0ab49ab54f0fe752a094606
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 479dd588f6279ecbe7174a479c1b5a4d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103327#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103327#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103327
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103322
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/duplicate/[id]/components/DuplicateProject.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b12d406c78110f257e058e384b99830ebc95d093
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4073a561a3ba1c18603da9023e868884fb5e5dd07cbd783e40a1787f83ef3989
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a6c369fea79fd574bc0f6538c5cb42c0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103322#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103322#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103322
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103317
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3e21e7dbbd4af2d0911584c39b26bb0fa6fe57fc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d2d0a8f60454f38f8e8fa7607c4ba585499aff8134c9ba05f6204bf04d55a946
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 685241a83ac3201aa7dcbc296ec9d7ba
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103317#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103317#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103317
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103313
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/NotificationSettings.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bdbfbb61435328c800e19af15ac3553f49fe1c4a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c8c576244c04ecaaece473988c27209c8e0992568e8214825d2965b85c31632d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a06c36f35a94d26bc0b93835bca0901c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103313#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103313#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103313
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103312
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/NotificationSettingForm.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1a04458517342634f0c2a479f606d665b8b40421
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6d1d2dec3d8db49752b5c33f7bbeb87ece27a1ab1db0fb300d637c139deba3a4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f0c6ef3589e31b741cd899028b010756
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103312#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103312#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103312
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103310
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/UserInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 27782f6774980bbabfa688136f86907c4ec2d1cf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8f782c3eae89c4d5308d2bf3520b63a9d65f2caab2bde97980dd21bb902cbba2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9c63defa0b7f3f6948dabbf3100e9999
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103310#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103310#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103310
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103307
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 852787e778a6a3813d4e6dffe68ac1410a6d31dc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8211ab444aba9ae07135694be840c4eccccdd7e2279ae871182d6e8840b32821
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b697b5cb8f8c21f8586c8ef96d47a83d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103307#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103307#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103307
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103304
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/OpenModerationRequest.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8fbd226e816d29c97d6d4dec7d353450baa9d582
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 999aa6f021e3f9053bde25b1c30703ff269c05e658dbf44d9670e051a6c5bc48
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 21976cac69e29b43369604921b5f02a0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103304#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103304#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103304
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103302
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/ClearingRequest.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9aea1a7cfbab2109ff53931b2282f658977a68fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bef1d4536409c8da9ee8f4e385238aedf747aa9b34b077a549a9c0e31d8f84d0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 72ce4ffadea93ed94b31055fa08311ab
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103302#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103302#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103302
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103300
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/ClosedModerationRequest.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f8fc677864b96c68783f60b5e4aecc66680fd834
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: edeec6ebcd69b2cc25ebc8a88fd131fabef9e62d92c988c6ccf975edfa60e150
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6b7ca15679037b5031271c40af70da2c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103300#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103300#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103300
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103296
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/ModerationRequestDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 14705dcf464c6f0487110dae329d24883af63c4c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 029bda29a5ed405e823fa2d6932f87d5afbd67aa51743c60b074688fb2d443fc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d4532f4fb4cead4a248a9ad285373750
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103296#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103296#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103296
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103294
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/currentProject/CurrentProjectDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b9b4e129d81393fdf98efaf532a90787627ac310
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 636ee98235b20123bcfe0f9688c195c8fd7926ce80ab6c69130bca1d98875d96
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bf2e8455fae9940177f951a72a0dd6aa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103294#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103294#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103294
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103290
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: af48f288ec89f18b0ca7400eafcfe74b843871d6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fa210f81fde00c2014510abaacb295881655769ee9e8a39a91903a89633f5710
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f73ed4198c8f3776bf51d87948f8c89e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103290#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103290#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103290
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103287
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/ProposedChanges.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2687e25a42bedee0e553810a73d43d007d67a0d3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5fb51dc9658a6eb0924932442738a1c5541a16ed2b2f9006671071a7fdbb297a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ffff0f953df7e9cb6897931d76abe31e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103287#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103287#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103287
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103285
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fca75ef9a381a5bef6b37dae72ea54d5ab06f8a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4448767ba9c12489656dc78248134dd33ac44a6bdcefacb71b65d0a938eaa4aa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b13d111636a2b06f20e83b0ca5a150b3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103285#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103285#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103285
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103281
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingDecision.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5973014cb68d4366023203ac6667ad1c69e5f5b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 55ffc27b0ea6109ea44632e4c4a8f80935515d1fe6898050c220b8fea38f65f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: afac58787ab8b76efd0e31d6eadc8b2b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103281#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103281#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103281
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103279
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingComments.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 68ecca8c7db8533c7e6e775b68cdcf48d154ab87
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 831ddccd014e4c5ef75e3c92f107747a952449fea3a48b3359f377808b60c28d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d773318fd1350455c91cf444ace0176f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103279#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103279#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103279
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103273
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingDecision.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0ed5946227501863178736e0e1a06afaf2e71820
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 60f16449892b42d203a38cbc919673da7d2351a49317af5c215c0ce64d0069a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c2a33f5b1cae19a293f22aabb47e1ef6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103273#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103273#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103273
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103271
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/edit/[id]/components/ReopenClosedClearingRequestModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 55799d0578971761676b109e5cc56b4401737271
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e094573a56b85cdabf3475473c97b98c33a19bd19aa98c8c7e0f4a7296daedfb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b2f82e67841c2a248e62525adbc77a47
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103271#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103271#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103271
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103269
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/edit/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 82acd11df7ae7bf0a6f0b32e7f6ddbed2978e77c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 693b23d208dee542d6296f6fd4485db9ea404ca461cb965ba94fe48fc5ba678f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 55fd0ebdd95b8e2436318715f6d89c23
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103269#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103269#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103269
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103261
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/detail/components/Detail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d6d4a8c514483a49508c4727249ac410ede5bce7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 94dbe008b785f95e1e5f97ba4785dc4b6c309e7830286593bca0e2ab58fd1a8d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d899fab3d5037fa893b1fd999b45ef61
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103261#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103261#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103261
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103258
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/detail/components/Obligations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e98ffa2057bc1e0a2f2fa5c369349c837cdc637a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d63ee50a9bd26916e1d94a0089c829e697db1e90e575e226ece8a6008c011d52
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fb016a98f34ef4207d0c34e6000a17cc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103258#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103258#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103258
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103254
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/edit/components/EditLicenseDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fd996378d2a9977ec79dbc4e75d1a4da26ba254c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d39908abf4dae607bb15d2110b9c6254288e18e06477802e53b09dd0789dfb71
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a81b7494656e14fbab8f404a3ca3b95c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103254#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103254#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103254
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103252
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/edit/components/EditLicenseText.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9b31408dba700d85b998484afb084d55716b8110
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e4f2b6acfdabe3d3ca4208d1900e859bf7db6603f876c2e8de028dc26500ebc5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ccce853761c50b1ffc7312613ac9bdc4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103252#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103252#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103252
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103249
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/edit/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d6c4253cdeece9faad6957fa568a21f89090ce08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 72ef1ea2b76f97afacf3a72455d0f0e1bf3641814de14453e9e028f33a5354e5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 35577920a8f9cfb32b373d32db38a5bb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103249#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103249#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103249
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103246
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/components/DeleteLicenseDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 507999837c4c614c593c4ac4403698d75c23db13
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 564c5bb32d1f03453c6efcf16670ef3fa31cea17b2971329a14838768ce1d2c3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0b3b4a2d45681905e1b23808310eaa44
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103246#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103246#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103246
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103243
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/add/components/AddLicenseSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 80595e6306a90a299298aec9a0fcd5e279868932
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5eb3980c109e9c5dd681198042b88402995f7dde1bdd4e1e1472a2a1ff899a3d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 86601e88fe0263751f5b0a2524e6b6e4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103243#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103243#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103243
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103241
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/add/components/AddLicense.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b697bf149ed4cb1d78479376ff84a3921e35daae
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bb68d0276930f6c8319dd98bee6e482febc04e6493121ea1616333c1fbdebebe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ff0c8f820f4fe05b1607d4aa8907f267
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103241#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103241#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103241
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103238
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/add/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cb71f1adf34996e3f1c957d408de59317c24d5a7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2e1c1a36cf2f97a9ad9e5c6ea0716285eb4727914f46c3c25290b7cd75e3438e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 709cefb275974ebd0a92abea8bb6f1a3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103238#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103238#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103238
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103234
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/MyComponentsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d811eec1d5ef634e85fab699d339e1c15302167f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c30698be8cec5ba02b318d04e93f64cc30d60261e29b8372527ddded57be6cbd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 725d7d32ce6291e28a6c449c73b0b368
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103234#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103234#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103234
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103232
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/RecentComponentsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 974435abef6bdc8ae794fa523684560317e691f5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1a604402a31d8e61c1c476e4a124ed28dfb57532fc47836e48978a5f2b522840
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 914a5abad648b5ccacdf691194a46803
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103232#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103232#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103232
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103230
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/MyTaskAssignmentsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b244043193b10bc828036b3a0f5b4a82de56491f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: efb55a6410a5d2a3ceb04c988b91bea00f0b0d0938c61b60021747100becb1e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 78321627a5e509bf8895eb159ed83bcc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103230#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103230#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103230
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103228
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/MyTaskSubmissionsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6ce55086c3684d620aa1a2066860661f37d27957
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4d6c125667ec8f2fb3bd33ec6f63552a3f9182cd980c6a8ab27211e18f8997e1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2e3caa3f845648597f0356c307caa012
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103228#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103228#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103228
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103225
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/error.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 12b78fb676f6452af8695b6424cf2010ba597c60
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8d822d73256673321497cbb632ea9c1d75444f6c880302947cabf82a405c3782
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 58644070b8a2951c72ac22915bc086bb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103225#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103225#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103225
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) VAIBHAVSING, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103224
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1e47309cdeceffb5c5b29a51898b443abe107073
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: af2d2614b12ba946a736741824b4634d1e2e9491e8dc6dda602eabfa42b49925
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 98d6f63b66b5beb74b1123ea770bab21
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103224#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103224#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103224
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103219
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ClearingRequest.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9d212771491c2df22acf1bc433b4faedd4b4ef59
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1224e60518a4ee266bcaeca76f7f09cda05ca6431438b64a41b0ebb1eb50e4e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 74199b07d221546b35e374f1d7b43358
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103219#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103219#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103219
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103217
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedReleaseData.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 12e68bd21d749ff62cc8bd64f6e6c36a723dd241
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a7eccdc6733b88719f4cd015bae0026e82c2c6eff2624daa0934d74e10eab0b2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: deedda2eaad6550e399cbf738903190c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103217#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103217#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103217
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103213
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/FileList.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 071a8915626a376b09ebe1350b3b72fda3c9ea5e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4f7082d0a67ef8aa2428a8db035ff3461bcb3e7d3516f29f8a7028098b2ba697
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6244496245c8ff281fbb3cb904f0176d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103213#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103213#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103213
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103211
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Pageable.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1aaf932384d6503a752ae9652d3d95f9ea3cadaf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 378cc7672c9182fbb5dfa0afe8326f58f36a669c60e3e68500858929f7c266db
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8173960a44f41df1b29b459b3a1e2764
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103211#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103211#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103211
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103209
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ReleaseLink.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f53aaf3fe5680e3479cd56bfe6418fcccafc214e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 16d49ac65347072e52500b708fe4b32131bd72b46c5f6889281de72a55628d20
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9fb96a97e3777f581b5732fd75b5fd8f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103209#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103209#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103209
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103207
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ModerationRequest.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9756a7bf5da5c2b2fb4c11ecbffdd8886ee807b5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 774d0b5b5f668a44c294c71eff31326ad053e25253b7e73a178e40d49284512b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a0c2267f1fb9c7fa2a2bc84b22281cf5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103207#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103207#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103207
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103205
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ProjectVulnerabilityTypes.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 48e085f3764a69921bb3d7725b01a0ee98b42676
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 35f5575118529f2f1f156ea1868b8b0680b765892c197b9664b6c294a48237b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a91ee530d2845759c11ca07db69b7575
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103205#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103205#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103205
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103203
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Constants.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d9819101c6c0987368b0d8917a5ed9cf1a4b0069
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: df500ae89936d57a1d014a1547b2b6e1a6485a9c79cf8662df4566de46354fab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9f40ba498874790dbfd9cdb71d0771b1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103203#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103203#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103203
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103201
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Project.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4a8ffde3c9de33567d4f1ccae257934f0ca7c40e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8224e53868e0bc122fda26201b5f470909d2334de5705b776ba9f5039d1f5350
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 710963903e9444af4d007cf3b2d5fadc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103201#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103201#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103201
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103199
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ReleaseDetail.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7770ed0394cdc9a4494f1d40ca9a48dd75b2b268
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 318b7be7312e86184cf06bd462bdba44880ec4d71a608c99223a11a53e3e459e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3884bf851446c6f56bdf4e669546cc60
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103199#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103199#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103199
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103197
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ClearingRequestDetails.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dabdccc0daa3dfe2e27f22d3649b801ef982da8b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cd37350e5ded16db1451792d2898206675a606ae765e13048ce71619ad1f9fb0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9afbd594d59052362b1d5b5c3369600f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103197#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103197#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103197
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103195
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LicenseClearing.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1b310ff3bed8812a452798af87a165cd22468c3e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 93f9faf53fa4b61733f76d3689e929cb54d8dceb4753573fcdeee8b284c4a9f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f4ec73b6504494c4382a563dfa3374f2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103195#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103195#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103195
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103193
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedPackage.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 08b1dd31c5e70929c11b9809e0c289673ca49eea
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9b4e8d754fc4d0ee5f70d15d66b4ff851e047d773826c95efaa1d0e1bbaa7662
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8b99b1221ab087c3a5271a7237b1b7be
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103193#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103193#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103193
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103191
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/SearchDuplicateResponse.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 86772c8bc55b571384545f7f528fbc1b1e849bc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cc5426506c96efc3df871d1437e41fc701850dc4cade9b8d706cf8024839f886
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f1b85c116ca531517c8102d86609d465
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103191#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103191#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103191
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103190
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/VersionInfo.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 726e1019bfbc78199c55fc524f70040188f499ea
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1673d6ad7429bcfead022cf7f639fe360b27a578f7334429165f98917117487d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 86d028528a9f4e56705fedc764e834cf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103190#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103190#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103190
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103188
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ClearingInformation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ea2e3ed403022a2bcf10d942792f041a7998e2c8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 77128957bf237e1549e77488ab41033750366e171d0c89bcc8efde163b3c9205
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f482fd513f6e0488b7ec10b57c1e718b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103188#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103188#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103188
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103186
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ClearingRequestStates.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1031990d4671c567e30050caf6d4d5fcce8d364d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f3c685106c0f6dbc71d5a6f9c7c69248681fbaa64ed6afe5e24e9cfb14c04747
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 69ecc363ca18b998c8b50107d2ecffc4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103186#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103186#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103186
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103185
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/UserGroupPriority.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 66902c584002763fc74b6813ee2b775c2dba5f0b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8c22ff59b0029919cb8511319ce27e97c422cca697467646dff1b825fc0d8cff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d6a03492fe51ef7d135a82d7bb0d85fe
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103185#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103185#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103185
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103183
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ReleaseClearingStateMapping.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5229e8499613a51c1b41b11a406ca8435392b534
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cbb4acd3f71109e3ff8e72ba3245f8892a3f7131bf3845886b09fb1e164c0897
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8195052ac5c92db8aa51e9e485b6faa4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103183#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103183#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103183
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103181
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/UserGroupType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 091e0ef4d5de58f1b004b57d31c1ccf1bd875408
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c32d9bf75528f2d3bef74b534b7cdd68fedd80f6174f50f220b081202e2178a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a6391c6bcddcf667362672bdc5bedf7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103181#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103181#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103181
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103178
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/DocumentTypes.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1ab556c5d7e83c5cccc282bed0ba6a5c028cffb6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e29f2fc0ca6d65e9c31b36aaa834537d8d3db1f438e74c7c70a7b673953f2a0e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c13515e20df4d43c8d31afca317d596f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103178#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103178#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103178
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103176
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/RequestDocumentTypes.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cca3a99f9fa031ca7a4d8bf8318962e492449360
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f895b69838884bed4efce3460a2b5a025499f0587da2913d00b193193cc15e88
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b48402a64ce1e46473cb0c677bc92f0d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103176#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103176#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103176
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103174
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ObligationType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e69b36acf9ff65ef25fa712c6bdc8bdacd6533f7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6f99a8d7bddc7ee96f947e7435d291bf811918d9ad45b9bbdbf5ca438557e5b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c312b930a04ad3c65d783b9a0f90c235
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103174#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103174#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103174
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103171
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/COTSDetails.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 56049c24bb8557c78884c9548dfdb9c5da64c1f0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 03ea77e8d9d967d24e4dc98d500cba79d9ad029c0c64a878bb08757390f3d683
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 968fe759f965f5aa7c9c09809d5a3e48
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103171#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103171#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103171
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103170
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/RolesType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7f45c8e42e1d7690b5c7add5a04a323f9f4e0475
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4cfabaff089d50d1f65a0a32b735b097ac128f50cbdd41fe9a13ecf13a54950c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: eb1589f99bc22d6f926eac55bf765fa9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103170#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103170#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103170
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103168
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/FossologyConfig.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2f202e443c793bc3de2e9584c5bfeabf5f31dd76
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7ca77b6e82d25c99791a5e9759db3bd4447d8852b6673a8b644342e384b1aa3c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0a7c07d545c866d61358787f9fe86801
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103168#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103168#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103168
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103166
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AttachmentType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 38eec8bc7cbeecc1294acaddf96d1264b468792a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d0a7e4b9d0d4000f26d691296002ea0563ff8afac2f18eff7acaf60d40954e93
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e1c2eb9ec136449dddd7c0fc81c6ae21
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103166#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103166#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103166
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103164
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Component.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b5bb22b2f8a0d501bc84af68831373a8de691aac
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 381d177a4e5bd259fbac522c5490e27b7ccf98ee7ec01a3a62f5c7c44b4950b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 30ca74f219f0f933160b6990426a77ec
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103164#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103164#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103164
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103162
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/CreateClearingRequestPayload.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a61cbfc814362c891e23c556c743864a734ced7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e8cecbfe7b206198537a8916f95ee75645cc509ce055644b0c4835abf97d79b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 06b56266ad00892cb8edca37cffb2449
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103162#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103162#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103162
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103160
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/SearchResult.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 458512db179670858eda8b4e3d2d7d23b9ddbb03
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3e1e7bdbb657ae90d7b0b955dd11b436ac29579e388991402fcb91236386b1f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 04d8c3c33cf0ed1fcf3f53eecdc6c175
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103160#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103160#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103160
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103158
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/cyclonedx/ImportSBOMMetadata.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9484c6212d99006fb89783a613738c1cb0a39d2a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b7638a3a1c5edbbc30bd769fcda9c87adf5127ff9f85287f83e8010a6c2aaec5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b27bb94f9592a64ca232b64b2be150f7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103158#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103158#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103158
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthineers, GmBH 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103407
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d4bea7dc8a39fcdeaf47414af06d0a66cce2c692
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ac95696ba30f7187d08dfb5b9a4ef5f7e793e82a77c0a640324e4081fc5d995c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6daf0b7310862cd637d5abf61d655183
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103407#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103407#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103407
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103404
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/vendors/merge/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a952986448010e64a7fb0a4bc35d7d14927ae3d7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ab1ebb0407865b2d805e0ede622d80fdb0f7e8c91c64a780a648f4e084ba0db7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 833c5c83680f7768363caf2f8bf098ee
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103404#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103404#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103404
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103398
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenses/components/DeleteAllLicenseInformationModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7d4ce58079702f3c06851ec6673bbdab0ff894f9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c19c84f8d4bec527d2cbdc53a8a8cbb2c6962128b3cf241aaf277b82a0b487fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ba75951dcdefb67cb0e32f03bed93a7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103398#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103398#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103398
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103395
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/licenses/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 662297b9615231d1b2c7b4a7d317a58f3c250a98
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c50a33927307a07e3546f1ad802d8dbdf846983d69e76026672a557ee88c2da1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 83e1e1a92a09fec599a4865cc6fe9de6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103395#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103395#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103395
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103391
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/components/ImportSecondaryDepartmentsSection.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 65c20243bcfbb225c4de03695edd106643d759d9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c8c233f4c30849d78c186dd4d079aae13f7b3ae304f0427c8a3bf65d158dd905
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 541646ed6ef68f47325f9bfbef523958
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103391#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103391#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103391
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103389
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/components/SecondaryDepartments.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4c8a8989193c81aa080384ff0f14d07479c037c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 95c3d1ab335390f4012290e73076f816bd938283de8b40f0f18168d2d706a7f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 34a992acb3876f79dbf5b0c649c4cd84
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103389#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103389#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103389
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103386
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/admin/departments/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cdb7cb8910aa626eebfbb902ff9aec56cc2f3c7c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e804d5c5d57075f9f104dd5f02cba501e0e3d649d37bd876e9fb20595f195b4a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 401e39c48ba4d0d0f302114ddcceb865
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103386#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103386#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103386
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103382
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/LicenseClearingFilters.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fc0b404f26333066ee683bf9bcd7d12dc7682bef
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cd16dd0035074623190b2e8a8a26be3c6140f5f828fe297288a9c2c0b03a2f66
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: db5a2f97929e2703f88eaab5ba5abc10
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103382#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103382#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103382
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103380
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 199a3f14a45c5bef6fa89e7ebf2e612b5d72cb7e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d995881342beb8dd115997c47fdc6f38c48ab458d8356f09172310e8dfac7d4c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0cee68e1e1c236bda1ab876092581a86
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103380#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103380#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103380
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103378
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/Administration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 608744805240cc473cf47571dc0c51f1abdb5b16
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 66fdc1515f478519fe85349bf7888053860806798a61559fb7addf00c8461394
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1f95aeb55b742579d863a55f9630327b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103378#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103378#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103378
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103376
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ViewClearingRequestModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: eb77eeae844fbea7549c5813ac0d9560405c1029
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b4dcfc65a19984740e51bf3bb00462c866bc25cedffc53ab4c5a58491d7860f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c45c92e413f317fac3c786e5b32efeb5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103376#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103376#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103376
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103374
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e62ef5382346922d8e0b84ef226a29d2cbaa29f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ff904aed89aeffdd540977b269902e204e1eb7c4b50fd6aebe515fe1021d8b39
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ceff829cc01e0d758ee5a352fb19ad7d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103374#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103374#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103374
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103371
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/TogglerLicenseList.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 61346805c153b9e3adc26840a5ead725228d7926
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f891b8f8e785a3acbf1f31a403cdac472b07c04982825fae42236ea8dfc18f2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ba5f69724de730321ec47023289f3920
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103371#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103371#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103371
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103369
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 79f42496047178e8eba9b2cde101f0772e11a6b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 76e9cea604896cbea1d508590eed4c23edcd97af2fe6dcdf2215fd1d80f15ebe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ffe05c30efb8614c589dbaf9a2f1092
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103369#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103369#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103369
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103367
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ChangeVulnerabilityModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f932d95085ea0b9585673b70e80fe47622e5d4af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bc5ecf325e900f03a3a855dfd74b3c70516297ef19d2eb37105f5a6f7d78f74a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0d0e863c52c6b5a79eb66855c81bacb9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103367#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103367#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103367
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103365
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/ViewFileListIcon.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7cc2922db96d00cee98b9279fb610d8418d1a804
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 596b31efcac5a897229a39751a9c6ff1e650d30b80ac8c2297612710305af065
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: dd888a2b778ef11c971aa9a75491dacd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103365#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103365#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103365
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103363
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/CreateClearingRequestModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2af2ccb659e7b21e38cc346f9c2759d34fcc2162
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5349133c4dd7f2be2006eb0ce039d93e569d8ee8a65a87fca3a120e850e362fc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8b0e746cb88e8e7f4d6a5084571dbcd2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103363#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103363#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103363
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103361
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 31f933496b3ff8517ca492b5b028e49011ac846e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b06db2bb9767cbd45f5291554b7609e7b65b942f21573d42763133f62cba6490
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 921c5001c9061365c6d1a3513961c071
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103361#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103361#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103361
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103358
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 71530007e300bc7d0add1390920bd0dc148055a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d956ae3a9013c1504279cb5e36eb3608470d006a5caf19462c63203db54d0964
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 166dd99897c92e76c551a580682525f9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103358#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103358#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103358
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103354
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 44e6389d157a271328ffddad922de370db6b2c64
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5265e0c155900f418f7e3933734b455c36cd27f0eadb905c0c600831efea89bc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cccc03662d2d76a105ae7beccdb7d9c1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103354#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103354#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103354
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103348
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b472769d63ff502f0aa932faef7630a662037c0b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ebadf28cab27d412e2fc49b38063678add52951a0332597b70c507a97157ec0e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 20d68f45b8ac721578e83551c2423b63
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103348#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103348#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103348
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103343
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationsView.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 59503f27525e0bd4846b4335b30881e3bfd5fb98
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2c34f1539714d26613f01fc1bac99239bf03c23c733cae6af5d66ccfc103b750
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bee078fd7953253ec8472f448d6510ce
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103343#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103343#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103343
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103341
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseDbObligationsModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4f07324355bec40e3ddcd245bf79d3fbd582690b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b19c7adc5868dbad6922830d6ec39d3dbc62d72ea5da7360f42f9ea6d6a7318a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0bbf18e4d142ad26635b0f2a84539f04
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103341#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103341#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103341
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103339
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b12b6c92e92a8ed0f9562ccce249adb588db0ea3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: df696a3b9110085cbe88a7cbfd32aad788b7204cb1223114d71bc3df1891e9e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 607ce445bfa6a3e48a1ca9aa7e5466b2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103339#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103339#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103339
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103336
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/CompareObligation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4783cfe9ee647b6a568cef1089b7cf39a9104b86
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4208162f985d9b34ca989d6ffc924dc11d315e88a85e0f731bef42d24773f678
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 659d4e2d180b32cfbc560a0ddcef96f4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103336#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103336#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103336
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103334
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/Obligations/Obligations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8247463976ff3171209f20313a22b59f15f49bda
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d6fbfc62907db9c83b5e4d1b8361230de35b76a378e48509e401832861a182c6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ad8d65b92bf8b81d8b3da046d28fa0de
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103334#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103334#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103334
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103331
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/components/ImportSBOMModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ca2ec3f47afbfa66b7a8c5f7b622d251674e1dfd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d2c3f55f36b892132ee61d5408d7035ee4630ffdd1235a2f390e98c1b4cc0430
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 16bad225543d9cce60a15a318522a621
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103331#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103331#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103331
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103328
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 466881a138a9c64e88bfdf96ff86cff65b74b73f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4dfa36596724fc564fde474e2679920201290b013c1f98c4d79e2d354b6da996
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c467496800d5184c0d109b5e8029f97
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103328#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103328#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103328
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103325
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/generateSourceCode/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a64377cf72edbcbaed137e8e263c54fdacd3ee3d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5cbfcf4bf99ddc85cb461b76172e807cc9ac7303532a3bf7dfbce321030c1336
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c0c00f6d408425c3bfbc5ed5e435c33
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103325#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103325#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103325
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103320
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/projects/duplicate/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ecd4e5948ddb308d3f0499d9688c91d909f97d33
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bb28abc3823feff1d4a100cc903e2d425f8b349814453c4b39c231de42f6bdf1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 78520075ea935381b2b3b71a35aa8509
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103320#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103320#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103320
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103314
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/UserAccessToken.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cabd6a3a381cef42f341105e619c91e322da7583
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0701c9e0b82a82cc79bfcceec6bd9cd90dfbbc6a3e834dd236f1a017afee1868
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 59c1269c6ff7d4bb960a8619456b3f2c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103314#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103314#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103314
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103311
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/TokensTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 893d51e5e5588b07e2e86a012f6bb50b78bdaf06
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c6b280293ac1dd71315230498bc932ccb36969c4d5b70834c0fb71b410c1b0d0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b565bbe5ab9fd4a03fb4365410e87a3a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103311#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103311#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103311
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103309
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/preferences/components/UserPreferences.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: efd225a8936e970a1ffa77336f44dc0122035307
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8bf9571ec90331132511755334f6bad55ca7229684ca02d702b08e3d4d11c1f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 56537b12eef9ad3ae5774ba04d13429b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103309#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103309#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103309
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103305
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/Requests.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bbbb8062450b00f392e0b6bf17ee364fe19bdc3f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 41b5002cc2398d096950a08bd4ae05e4c99f437a71cafeeb8b87ab086cddeed9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e4d682c437fa9c7026036496edc77824
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103305#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103305#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103305
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103303
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/ExpandingModeratorCell.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d302c8ae3acc82139abbb80451943fed06dc0d45
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: becd58824346fed5e7a83c0461a69fdb583ed73ae3f0ef1986e7cf96e8e659c3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c3244b91666c87ca1ef4b49a83b7d54d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103303#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103303#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103303
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103301
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/components/BulkDeclineModerationRequestModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 352f0b9cb0dff75f983ac9601c8278eca0c9cc43
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f130d74f3787c3855d7da1d6ba658173d42c63df8f5cc77587bdd249452143bd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b3fa98a104ad21e995ecd92fce42beb3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103301#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103301#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103301
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103298
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d8f6ec0e038d5479550932f534b85f6e1cf8d233
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 76636518df22227eafeeb80bbfc7616f89190146c6d72908ca0ec6b591a9f271
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1d22703b6693fd00f4d04819b66b7451
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103298#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103298#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103298
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103297
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/ModerationRequestInfo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a550bb68c66bd93cd2f2dc12e34d5a1fba916ac5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 87179e2941c75bad9ad8a1db578b70e3b7e06557c7b99d2c612f7f35a482322d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2efac2ebc62be912b26fc31b007c5268
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103297#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103297#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103297
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103295
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/ModerationDecision.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4e785f68cf48476e220cf7f5b33358a3d5ea099b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1742640d8565d739a8147dab7c7d023d4771162c3b2be4654846228d09905e9c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 90053d5eead13a518fa5ad390ae294d8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103295#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103295#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103295
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103292
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/currentComponent/CurrentComponentDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d0881273a819bbe5e57e3e2add8ac2642d72aff7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c4ea7e031755d775c7ad87b8f0df35429833578062d95bf80b2fcce0b595b9b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1b40ef9d10922a7c6803a9caaaf681b2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103292#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103292#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103292
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103288
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/moderationRequest/[id]/components/TableHeader.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: def2d66ebd386e8e1cbba9047dbd4cd7d39a8da0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 25de62f12ded9bb25b75c14d4531bc86faf2ba833caba737fd03f46a8c7b7220
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 87234bfb031a29b2d87f5b4f90c9ec54
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103288#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103288#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103288
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103282
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c5f7869fa13050815001859d97893cf9ec591a97
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 41c123bc3a435ee322a601dec064da5875c7a4ca69fd1742f4f4efb4f38c2b0a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1dee2f190ff7e7073fcd442debb8342a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103282#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103282#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103282
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103280
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/detail/[id]/components/ClearingRequestInfo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1a6cfa05d11c5080489971b3c1d20f619bc04fcd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 44e31f50848225142993507d5bd20dfe0cddc4a8ad7e8163ab8368ad182f6d74
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ed9c6e9308f367c7984a9189adbaa25
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103280#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103280#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103280
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103277
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/detail/[id]/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b8103365458211ff2e795ddb06d5790cc3a33539
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2626f91458ac69d6f0e7768dc8e05559d8d0aec096db9f2fcee439e4ad5c569c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 23c3293b5b0d88089a95bd5dbf7baeda
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103277#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103277#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103277
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103274
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequestInfo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9afd51bc71fb09739376c03ca3fd1b66000c1650
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c5a3e6859f8c717dcd379206962d21805f178def7cd0e41846ce4616b510b86b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 19da02b48c120d4cd14cbf09a2c23723
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103274#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103274#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103274
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103272
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/requests/clearingRequest/edit/[id]/components/EditClearingRequest.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f562a3d4a6ef4d58c86dea187a65760daea82c54
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fbced282303d6650f6bb80a3d75472c11e503c230b6cffc590b17d697ce8bdaf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 22bce485bd22dda5cda98cce60b04622
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103272#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103272#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103272
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103264
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/reports/download/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: aae681feef3908753c978da3ea069bdb5f4f2394
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9ead9de88800309774cae8c51c92ea7468cf6f5f3b473a38123a295e4b3324b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d89ea02c76f4dbb50251d2a192eaa19d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103264#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103264#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103264
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103260
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/detail/components/LicenseDetailOverview.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5ed3398e8e6800b330fa3ac383652577f8d2de90
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2d754b23e3a6c786737eedc272fb697197172fc4e42e32cf87b0f232077a6d40
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9ba2111d14e37561f84853bbdca16a08
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103260#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103260#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103260
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103259
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/detail/components/Text.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5765fd4d6d1615965bfb25123f39f9882404a2b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: aeea061b4ad4802db29d4c82f1d1a51f3d96a95918053e48266c03243145c56c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6d23f7fed17278d457fa6562f119e2c2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103259#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103259#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103259
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103256
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/detail/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 044dd2cb140999274fae7e49cc36e31ae1b4f425
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 583a13cc1a425c4f0f94bcc7b28e5e0c6882c4dd05ae8056617f00beecaf75e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a867ea268507cfbb0b97772699eddb4a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103256#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103256#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103256
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103253
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/edit/components/EditLicense.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 989894db698cfc7039a78cce8912309f4899be7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1a9d51b00f6f1d18b38e144263156d6a342c2e5ae2b012e3187140bafe9c0428
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a04212b82c828206ba979aa5fac35410
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103253#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103253#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103253
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103251
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/edit/components/EditLicenseSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e4337359c7d41e5146e3613b0c3080f6e776b636
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 41a1f6f868a48a7c6736b62cf73d43744fa36990d668293e4f70f6c4329bf2b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 16a22751886db09ad7fca09b355060dd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103251#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103251#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103251
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103247
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/components/LicensePage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 85277a55435e78497e8fb722cbae42f907a4ac66
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f405c142218d0a83d4c21b7ea0258b195a2fecbf2427611c838ffef4f0310687
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 097128599253ad6f925bb574a17aaba4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103247#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103247#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103247
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103244
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/page.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5109089eadea86061fb6d3a9c54d3fff3dbef90b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2c31ca317f71ceb54fb2638bd09ea28c33cea62a9464bfd8b8b2bb703d6e4421
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 51448c47dcf64d51ee6bbed638d73868
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103244#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103244#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103244
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103242
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/add/components/AddLicenseDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2dcfd378c9a27e39f9d2b3aa6e603130b68e36b7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c860429472f6ae1533d8ba4c4f9f634a8c487187d48c6e448f254189519c6cc4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 79f59297241a27fa9e9a1f5885d4090b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103242#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103242#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103242
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103240
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/licenses/add/components/AddLicenseText.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b8b53ac6f1b7789db5c4823c789524a5bfe8f3a2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 65e316fd2ad6a69ae9bf7fcfc5c6ed28b56e51c4ab2940fe2c6252adce2d37b2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3f057df603baab3030298108c2222d5e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103240#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103240#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103240
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103235
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/HomePage.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d33904899e7b1db4c91f36bb5d6a2db0a8ac1ace
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d1f4b8d3e54590fc9e84018ca9b821fc51402a058c90f85cc06ffa788c8b4dc5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9c5c34b94555fb0b9bf76bcde79eb5c9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103235#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103235#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103235
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103233
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/RecentReleasesWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d51a4634bc6b5ec80253719a18054f494440d539
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 154fb2c26297cd6ae6c7d5994010673f615b70b326e81f15cd5cf20ef160ee58
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 78ae4bc8e59434deb4e968d375f8b3d4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103233#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103233#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103233
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103231
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/HomeTableHeader.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4b9e694387af0373a4193d64df7a43977360e059
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c09622963c0b0cfb45b53067c45198d8c6b5b06ceb76934f56dc9904ed2196e2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 57dd16f5802292823dcb5f1145f30e66
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103231#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103231#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103231
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103229
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/MySubscriptionsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c7ac192381f322d51b571cc4d608091c8e2a4943
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 21990ca4f57e52016901dce9be9455b5835d54b36159dcf39458ff08c7c396bf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1add7c37ad465ae7990ba2371f23511d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103229#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103229#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103229
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103227
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/app/[locale]/home/components/MyProjectsWidget.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c154cf9b364b07076a9aa2d3ca33cb5b2ee076bf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 278af44dc879fbdb97e21ca2cff38335f0db8c24a48520de417cbc5381d4d782
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d6d84b4e1dbc4f8064bf5e535af49cae
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103227#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103227#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103227
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103220
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/proxy.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 803e77986662662aaba7c8e36523ce54ecb7973d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: de8165e441385e4bf587b2d8c8794fee8d426d4c675dd732e051d1c1b11c5481
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 45206b4f7229b856e39f508b89454cd0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103220#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103220#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103220
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103218
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Attachment.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0aec8321827067a53a96f39b0ba668dd57e37753
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e6b0e66458d116e50e6a85c6cbeac2a819807bde30dc12ea4decdd0cd4d1ccb8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ad33999787931f29bf33c52840d434e1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103218#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103218#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103218
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103216
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ListFieldProcessComponent.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6bc990c72b09298ac5888fe4ef740ff3215f4f16
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 161a1cacac51e0a1b7536823ea5635c3dbca83a0de58d5180385d997547c8b0d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 753a26ac9b6092f154ce44f97e9e3d1a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103216#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103216#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103216
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103215
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ECCInformation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 205ae29e71262bc62fa9239938660c0175693317
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d86388a6164530907b9fc513d72407a7affdceac0802f7b42269b42e39865875
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8066b9af40b0edd0919b79150f5742ca
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103215#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103215#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103215
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103214
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/InputKeyValue.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c3dbc05882364d5542844cb95dbe3e2087a5a72f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 58d7110dee0c26ec07ae2c5159514bb877d1eb2fea69b81a4b5660217b042673
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: afa3b3373b6d449a4355492aac7ed53b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103214#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103214#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103214
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103212
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedVulnerability.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 44cdc68002a1ed8a8054d42e632876db8fce83ed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b5a6a2e240cf779bb6c6b7f9e3ad6e57a37c592574838a48ae9780f8e0978667
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 560cd9f84844653f420d9af543cb46c7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103212#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103212#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103212
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103210
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/index.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5dff73eff2939493266486af68412e07f75ead5b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 97a5f9e956ce3b3a61e10fb5843283d540f9ba76cd6fcfb27cb74597a12121e7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 977cbbfe6f2ac01aaa854e7d52fa0af0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103210#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103210#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103210
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103208
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/SummaryDataType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 838117800548911e714b55407d027ee440f7e5ca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: be9a00008b7c29b2a52bea109455963a95de129b1bad1e4d4c98c7ac0f03df4e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fb7d9e7a4b718247a61ce4bed58836af
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103208#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103208#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103208
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103206
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Vendor.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 46354593b8d8d6a96ebbd8d41df8683fe608753e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 337155b3355b921a09e18f4e2419b077323ec3956363670b871f32ffb2430f46
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 544e2a52a1fad07a732f119d961c1056
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103206#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103206#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103206
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103204
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/RestrictedResource.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3b9daa2781dcefc8ab5747559fa954a973335d9e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2d66a321910ee4a101d3e1e88ff4cbaf3c801fe0932542be7eb24500b3965e01
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 00d9b7525928beb00c9e7ce4fa357e32
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103204#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103204#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103204
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103202
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ComponentPayLoad.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 80741674449bc163da982e62e22f603b98ec3c0e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f53fe7f3c7dc430fea07ca1e63ec667c8e1f163213d99f0aa1fcb1e1b0471975
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 93bd404905f6e61c6ed7887c393b4a48
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103202#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103202#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103202
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103200
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/VerificationStateInfo.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fd7c045cbaa32a8700b590dd6c34253509b52e9c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bc196827e768ce1c8b0b9899b451eb52933d59c41b02241b4c92e31ab7b53207
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1e4d96f855d8da350f0827c394c9a55c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103200#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103200#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103200
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103198
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ModerationRequestDetails.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0f503b3d3df147621049d721593d5f82028661a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0be7dff49322835a2d2d73f26d17ae8c80b6e6a47ddfe47e5bc67825e990facc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5e8ff15eaf30b0f5e7c61e7a309622ef
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103198#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103198#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103198
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103196
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LicenseType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2f38955ca17f62bd380054f6bb68e24dcd712666
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0d4e7c64f4128f06c6d2231ccb571b066782d012c8a800b88aaef37ef8461cc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3e60499d39fcc4e6544a780bc40bf817
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103196#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103196#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103196
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103194
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AuthToken.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 88bc450d5ca0e5cc3d4d24f05a4e92c4f3bc3b03
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f2b70aeeff405352358df01886d9ce6dbf7f7d693cb9d65691d0d934f7c05063
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 70c16be7b57b08c77c8434f9200831a5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103194#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103194#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103194
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103192
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AccessToken.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8e5fcd086fe6c8cefb84cd4add5fa85e0d7bb7fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d509cc0916c041267afc47afc26a46e0c50d328ea4a8e4cea836732dff88d3a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 82cac242028666cdcede9200c2dd6a89
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103192#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103192#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103192
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103189
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Message.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5d99c016e76f73e89c0e40d5776aefcab0179d8d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 864f8a425839fc5607b9acb967c9d644c087ad15c2a7a3a474f7cd9a95337d19
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 140db4df8db2a5cbf0fc9f2923502e8f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103189#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103189#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103189
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103187
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/UIConfigKeys.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a7a341c1ecad1b9a354e48c12b5ef5179fd84044
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e5d4624cdd4741995bdc2bbfc5fb25abfb2bfc7e9f21f3b481848623b2b6941b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a7dfae770bbe7cadf9461d656cc1d93f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103187#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103187#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103187
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103184
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ConfigKeys.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 357275558293880a15a77e1708bed0e21c0e2a7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8a6ab023d11178d92d6db6ddcada029590d68b91254b3c20af59b7e990eac772
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ef6d14a8199ae42c2d134e61255b29d9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103184#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103184#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103184
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103182
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ActionType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c25022f0ae6074e03898f75532cc8a28eaa3f070
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 48d6863f8dfa064f144cc4118b8892905a993944d34ed7882a6366bc10b037b7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 21b379db613dbb960386b82dd98119d1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103182#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103182#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103182
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103180
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/RequestType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9731eb6f2d8912a9220e1db7944b343dc282020f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 621384da9926ff215e5699d25c86214dd4d09b5b8469c1cf220bc90ab10be4ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9f2678124e311d8851756008179a0618
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103180#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103180#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103180
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103179
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/VulnerabilitiesVerificationState.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1478ff0e20301b930b0adadebb6aafa7e70fe313
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8245a6e8de7b059cac5bbe47aad6cd04e4c93a4fe9a2d0afab5dbe57a94e2b48
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 777c3a01c9862ec0c6d38c62f8fdd13b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103179#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103179#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103179
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103177
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ProjectVulnerabilityTabType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5332e06215fa7151f52f9732599a13c398167a92
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3d25ca4bd31230a8a7fcd100d885a8c3ae16082e020bbe5e29678d1297ef8252
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 618835a036fb5281c89ad2f769dc8577
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103177#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103177#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103177
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103175
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/ReleaseCheckStates.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1f0eb0a8f2d26ef959eb311ceb2aca179ad525c2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: eb8b513f95a8043f2c0c97093ba5bbf85c20173d7dc956e66e0832b1340cae25
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c0972984938efe59ddca45c5fc93d57e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103175#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103175#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103175
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103173
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/enums/MergeOrSplitActionType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 601110dbfbc2d19adda4d3b3484db512c2df1142
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d407374abffb1e892dc28ba497ae4eab187d78958d563af446a6020ac4c8a559
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9192af6c14ac14ab88842a3a4add010d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103173#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103173#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103173
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103169
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/UserCredentialInfo.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2f13c76cecb1c9f6e71bf6edccb127d4f2bb06da
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 198abaff596a45033346921113186d468e35badd1f78cef7f95d35b415ec1f71
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: da8f680355b5bca4e639724acf13c02e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103169#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103169#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103169
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103167
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/SW360DataType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 558b0cbe257955288590c076eb92b657831b897b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4b62c59a472eb2c481228d02a3c159ded1301d0731119f8ad1e35d8a53daec29
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f341a5374f52a0ea4cc9e697df36c348
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103167#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103167#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103167
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103165
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ECC.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: beef593f96ef0161159e49673a280209783c4ffd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: edf8385ebf3feab642ea45cf053186b0231c2c6aa7803c6430b53bb5715b3fd1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f8f7f936c7db822b56d8ec282c20fe40
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103165#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103165#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103165
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103163
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/FossologyProcessStatus.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6f2ce0826c4ecbd0b48002ab380f00efd78ffc51
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4a7e7a11bd6cb75d2f80dd0906d90986f3e4bc2caba40fa4cb1a52d6343499fb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9817746ca64bad1c6f60899e41ff65d1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103163#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103163#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103163
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103161
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AddtionalDataType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7244274fcdb9a2edd0d3f6a3906600bcd197d0a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 23df0da45445c7e727ac8556dc2ef6cf119a0400b19b2b661b399b36e2ef4451
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5dc16803db8827bfd69690def8298682
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103161#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103161#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103161
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103159
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/cyclonedx/ImportSummary.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f549da7b2035f439b0a6ef08c65ea96c51817b4d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 83fb8d2ab713fe4418f70910ffccbe09101063b461c7116975e577c818b279f3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e47d57cdd06de6582a8cfdd769fad949
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103159#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103159#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103159
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthineers GmBH, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103156
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Resources.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 92aed39b852c5ae027611966526b7ceaa1696e8c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4898e94c57e80831147c2bc9d4aa7e2fe58d65f892413af750dc67d29d51ead1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 92cec1802baaf50362151a79e120cb36
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103156#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103156#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103156
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103154
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/VendorAdvisory.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e2af2efc567e11180456a5b3338cc92e5cf3650b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 33ba40d29703517a04498964aa34cdeff5909ca5b6dce90c0517f2273af05458
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9cf3356154ab3daf0f434fae85fa1b00
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103154#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103154#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103154
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103152
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/OAuthClient.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bc200d9948e0b22e136aff13a36aa5f2255de297
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3a6dc0ec0442eb93a1618c850ae9a91d28d2acc67ad6710feaa863d09bc19ca3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fb2f4f1c7e0260792c3f3262c2cb0e92
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103152#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103152#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103152
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103150
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/ConfigurationContainers.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 79d765e86be5698a6810587d0b5660134b697c05
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c5c414caef2e6122b8074ce1ebe952f8b54ed05a84e6558bb2e8b60b67b9a5ee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4fb2ec42c95395dcca9e3c9a9fc5221b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103150#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103150#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103150
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103148
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/PaginationDefaults.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3b1e7684ba98345951095ca94aef5c62cd35f61a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 85f993420b13fbd2084c27db9f3db34bf00a4362cb03a24f0ed5fab50582327f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8f9c0c3b22b7ee764c42c9e92ed9e6b2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103148#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103148#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103148
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103155
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/UpdateClearingRequestPayload.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 256a818aee6385a2767e1bc353f3bdbd523e1712
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 16335e9d1038885b9b0426ff1cfd8f7ef56d9c799efe5800025fbd8b97cd784b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 31a08288ddcfd7fe5bd4cc753f54fea4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103155#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103155#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103155
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103153
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ToastData.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7bab38d1e4f1e90492e01f67eb45032ebd11bcfd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b4713b4e8e2eee488cda40a33e1cb34a9a2588807b354a8c35b9c39d45b1834b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bafaf572f4d1cb6cfda33b024fa09f1c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103153#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103153#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103153
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103151
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ProjectDetailTabCounts.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bcbeded40cc691977bd197bfa7813960e3b05f29
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a366d8dee591ce2f62a528d80e76f8d122a4100c2c1bf63587f11a79388552f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 10f2c0362067a2cca69b8c45ca05d058
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103151#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103151#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103151
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103149
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/LicenseTabIds.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9bd8d117caf40c09c7966545c02a493fc0459432
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a1caf964b3b32bbbb7b8f411392ed89ec3e6bf4d9c490e733e2cdf5deff672f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7cf4d0f1700c4d1a9a8727f7a17fa3af
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103149#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103149#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103149
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103147
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/AttachmentTypes.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a0ed8d16a7f2c20cf21dfb8d5c16b0a30db5feed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e26f4f02c4135dc6e1a88cc48d14e83784b9c4a138d2aee417c98d7229f6ad59
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2599844682e23da58c3aaebc44ac987a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103147#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103147#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103147
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103145
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/ReleaseTabIds.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f3829046f32499f94551cd6700ebb94736082ff5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 084e4019f2b110ce585fcf1ad3b050ab3e528024367bfabd86bc840073a407ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2e16ea45473769437c52760bd9f90c7e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103145#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103145#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103145
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103142
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Configuration.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fb9222c67f0f9bb38943d87c7c312a3ca79b5aa4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ba634d24c31f3a17cdfadc6b2eafd487076118db93432b776ba57dd558ae2db1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 04bc3bb617537459ea50603a2ffd0fb5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103142#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103142#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103142
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103139
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Release.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a9f373d17bff960100532c6791fc2d4c47c1da85
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 56658d5721c342552b5c20db2c8310c1f8a4cb188889fed10a0dfae3df7a2d1c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a24b968eb73a79c5f37c709c6d2b0384
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103139#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103139#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103139
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103137
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Links.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4814c32c60cb02f1f2b376b329e1f620813b42de
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7d4ef5f733a07428100ee5a94e667a10c05be4524fe72ea88f246d6262951076
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1be98b90a9557bfca051d738ddaacc31
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103137#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103137#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103137
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103135
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LicensePayload.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 23e99335e8fe525c2839c9965bede6b956946ce8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 20ce3e4eb7bef902701daf2b9a4f144679c131d01cf2920afe4b86db7101d471
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4274f653bb23aed4539c341796cbd3e0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103135#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103135#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103135
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103133
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedProjectData.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e9e43b15f9b2c853a9bc49d5499094effe0ea7d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1a52b9bdbcad32829721d66ed8ea606a2cebda35970079c41e72bfe663af3c11
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 77b61401aa26ad4c7aa061f248abcdb5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103133#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103133#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103133
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103131
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Session.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: caefd13dd937dba7afc0d23ef5905cd6ab852ba4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a8950df111eb486191075e315849d787f68be419d4d4f241d1b8f5387f402799
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4b027424ae7debef262607539e9793a2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103131#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103131#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103131
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103130
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/FossologyProcessInfo.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 069934f3cb8268ec59c1ff6d63e29cf6b6237897
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0a434c91606347818c6a2e8844254cdf88003050d709949a0ae6100f4fe800b8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f98d308f4ac4ac4e3e2d8102787f0cb8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103130#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103130#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103130
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103128
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Obligation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: eb59a1c687fdf2be69590a48140c95cfcf00c19b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a27452033a323eab076873846add209e476ae92ac732351c127127146ad0a9dd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 095f8a59d837dd0a493f840e70ce2df1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103128#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103128#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103128
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103125
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/NavList.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2a58f005f7eedc8015b6abfef4b480c9685285e1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 290332be0656ece2e870b72624974d758a479939f11659d7844fff348dd3a9bd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3b90e7d96bf1156a05fabdc9a2183c09
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103125#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103125#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103125
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103123
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Preferences.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 973af696e18dbe36bd21877d604471ca23ac81c0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: db1a5125943069da964f6bc4ac97cb170c1a52c2dec9c0a72a037bededb14d5a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 43654020916b3a7c49b5e2b31944019d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103123#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103123#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103123
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2024.Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103121
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/RequestContent.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 722248207d49c290ec99e1c8d060cef28562be68
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2c0fedba023ae6cf3f5571232baba143c5794e2e4f5c7884ef6b4214c0c65846
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c33ed81cbf5751ea90774d9fc163d7d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103121#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103121#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103121
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103119
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/VulnerabilityTrackingStatus.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 08a051bb003cf1654e9098864224f96565bbd7ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dec52c65ffe6390af1f7646363bd37c23b68f082e004c773d1e806625255a9da
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 739188a66d9c2d85ec5a02566b874116
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103119#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103119#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103119
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103117
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ProjectPayload.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a3c600e22b3c9044ec061ee5681b6032965e89a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a926207613439f9d31e94a2a7710b8a2cf2164f28f0fe115d1c080ab9964ce0f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3c06e7e1415665e2590f553c2d55bc4c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103117#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103117#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103117
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103115
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/Creator.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: aad50c69e75dcaa9fb89115e29e6b68a5cb840d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 257f8e2867d4598ccd692df51ab395632e6f507a53d91e56151f52ed46c9c291
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bc71699358c90e7bebb6c61f69a6865c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103115#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103115#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103115
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103113
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/ExternalDocumentReferences.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f2c5eb9e4b8f7741ee2860b6523158fcb2f497fc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d150ac3eab13e6fccb73505bf1bb9f62f72e7a0eee4c0039ce080ea18c2270ee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 38ee4f6c5fc93781e8e891518036b54a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103113#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103113#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103113
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103111
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/RelationshipsBetweenSPDXElements.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 089d485cac520677ff2857129fb691e3005c386e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 996470a0875cd339b34355b9a140c6ff8ffb3b323008f7a4d343db6a03d73b92
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ae2fd6dd91d94428033055dffca7436e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103111#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103111#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103111
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103109
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/SnippetInformation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d463160302798f883cd9d70f8d3bdf6153264580
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4e43f6a0f779fad1448d04b1f408b54cd2a25157e2b7cd8f8c3cdc3ea2450726
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 90a8960958228fb3c2bd1b5446831e78
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103109#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103109#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103109
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103106
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/OtherLicensingInformationDetected.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a77f42cf2ef4b3a091dac998b1300287255be484
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 50c102a29a5857bb84547fdf757674291b9204c5880300db5f406dd61bd4cd76
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bfeb229def73f72a1f56aaca7e3fd49c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103106#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103106#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103106
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103104
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/SPDXDocument.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 47cc8f527a8a35ae5d44c6e7639396f299c26f9e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 41a3ccbed9e717e2bf82e0a9e5941735703befb88021371c32f49ad3971f16c4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 309fcf36782fd4e75b5f2d1f5ca7f614
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103104#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103104#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103104
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103102
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/CheckSum.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2162b9bb94e9db4e9cea089994504ecc30335bd8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b7a75ee0b5508d2eb5f4ce0b41d481a60e26b4b0a0cc35c975855199af33dfe8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ed01b57ada9efe8ff358ef87d5570204
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103102#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103102#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103102
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103100
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/DocumentState.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 21240d7c9e62e8ede7fabfc913e59c7c84eae619
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c4c48441c202f0f8fe711b09b32588bd43794c140623a4f8da88ee5a479d001c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e407488379e891d121def7699c80421c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103100#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103100#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103100
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103097
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/NavItem.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7c8fdc62ad4278289a5c45d0c6563bbe580c54d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3420e36c1447f45102f6bd16c39e97b934d1d98a19e6e2795b515d75ed259b6e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 05e4879afc220e890003ca0a887ae716
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103097#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103097#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103097
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103095
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedPackageData.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: df89b7857036bf01d6f7c2dc49dbec18683f06bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ca4db5f715fdb1a876832ab0d0f49d06749295737182068c97d6b625a555efa5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 81a4bb549f8c14c73299f1909730f69c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103095#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103095#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103095
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103093
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Package.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 128b1351b1f8c3cde111e1d048a712b05229f460
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 12b3cc386349a00ece2876c37a0a97eb63433e68d89c0eaeeac6620a1a6f5b79
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9580c7ff4707349721bce76ff1d3110e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103093#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103093#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103093
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103091
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/NodeData.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e1d0ed3763cb100bf10ff007ba87db6850302779
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6d13b03fdb820d094eb69fe0defa0769f6a4bf41de0234399f574801df9f39c0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2fed6ab4c5fe10346a3d59960bc318c9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103091#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103091#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103091
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103089
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AttachmentUsages.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 21c2ca3656650ef892b41f8fdc0a4b0dfb6093a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1076068b26d4402c046125205aff8660230b96bf7d64ac8d2b39fca76ab9cd06
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f909706e2636e4711ac8e1c36d97f21c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103089#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103089#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103089
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103086
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkedReleases/LinkedReleases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: eecd3820cabe97f9a371e1907700b34d798123a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0093d3a3d5d701ead79f1925ff508114e21ba0d31ed02de2185551625cfc3c3d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3f2e9bf66d5283ad78f27c5891151f1f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103086#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103086#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103086
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103083
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkedReleases/TableLinkedReleases/TableLinkedReleases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2d5beb57e6f313e6bea38bb4ad84933c138278c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 52aa4a7cf4bfda101f01d498fc01777a0ecd9198342cc5459bafb04d3ad74990
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1d415f5211d910234ba4e2ee43f58833
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103083#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103083#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103083
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103078
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/CommercialDetails/COTSOSSInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cc29ab5458a29c14386318c98ffbd37facd20a82
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2a6107ba2fd3ef481428e7030c2083fbea7e36932a9877c2b5961a3d9a3823d6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8f769d5f6c3443cef3b4fe7b887f0b38
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103078#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103078#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103078
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103076
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/CommercialDetails/CommercialDetailsAdministration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f3c4f7b4cb9983aa5a379140efc2e2b17337f00d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: beefb3179e0df24714c88e4c3b5f6633ca780f685eae0150a693e515455d0871
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e2cfd3e461d73cddba1fbf413d63c557
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103076#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103076#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103076
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103073
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ResourcesUsing/ComponentsUsing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 73dc19c28b4a3f1e2aa9eaa962c6bec243853329
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ab1494e03776a52625f5b3e011e8de6874024049b7e16624a64cdb65b47f76c6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7b20d1764b5b8551c3a2a7e55c52bda0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103073#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103073#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103073
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103070
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/Roles/Roles.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cfe1cd16852c2d02ca420d9d37cf51ae1bd4c94d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a35e55a24a88a675225d3a00bb6c3d686e36bb0544a70e41f2ef73ee1a10a0e2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 86ed51fa17cbd40ef6f5d071e2e3a7e8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103070#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103070#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103070
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103067
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/Summary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 62b2566e0a14920fe1bf30d098dd02f50a298d47
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d67fd3fd1d0be43e3a69f930b36977cb1888079d5dee912f9e94978d0ba8d10b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 458f6e6afbb9ac38be0fdf67c0fa87fa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103067#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103067#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103067
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103065
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ff6c7bc40e88fb9813a25e82e19fee861d8217ed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6b0400800198af0ad3a11752da9ded0a665cf55919af8aa9cd5230c9096ae542
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 723e80e4a46de20dbb3e39a175448b17
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103065#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103065#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103065
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103062
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/Summary/GeneralInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1ba528eae1ba0f0f98f5a3cf82b599f57a4ad883
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0c88ca7be9a39a1cf78fce37061857317570e7ed8e0dff397965e58e3a10a9b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6219e1deda3042d9ba86284f6c84f625
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103062#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103062#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103062
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103059
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/Administration/LicenseInfoHeader.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 55f70ebc6b098ca394f967fc870dff817663b46c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: af51ca1e39bace18ae6188adaa64b27ea253283b4d493ed83fd2471499ffee6d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cbf6ab985527232a482eb24c07146459
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103059#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103059#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103059
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103055
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/LinkedReleasesAndProjects.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d5c33928f8a28948ffb8f85181a582e41cff4baa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7dc11df495171ef5c1bc74cb817d112cd6fd26c469c4b5500b01afcc0a1c6118
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 48eafca297c364419168bfaa3cc68427
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103055#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103055#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103055
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103052
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ChangeLog/ChangeLogList/ChangeLogList.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 559fdedd1fe98919609b7981efc9cb0f00b45abc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 030a221c85517cef550731c5089a3a341433866aa1f12c93fbadf5c68c8821e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 234a5e208e2dbbb7e43a29fc81855516
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103052#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103052#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103052
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103049
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ChangeLog/ChangeLogDetail/ChangeLogDetail.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4e653d562a2870e9328c1eada081ea28310ee818
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ab46cafb5b8ea1ccc9a3e076049cb3314ea3d720062e27fb8f85d2c540138c6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 03cf9a2567de0cf3560c00b489d8adb2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103049#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103049#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103049
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103045
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/DisplayMap/DisplayMap.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f3ae62104f92e8b46e6d1ca225051cc97452941d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8385c08892003538bcabd2b3a3a720a05e08896e2ac55d8fb8282e1890daeca9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 579685140d156569313f54c63ca49a23
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103045#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103045#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103045
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103041
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkReleaseToProjectModal/LinkReleaseToProjectModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 41e6be5e5ea9f633d72a857d0a285abd5a271906
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c15b84e8262f2f917b49b3e289fa48ba8d2165f5e1c4d4faf783695f0edfb1fb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 31f9b22db55af348d03f1e5f65f62e62
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103041#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103041#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103041
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103038
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/EditDepedencyNetwork/LinkedReleasesTable.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0095cac18bef76ae68c8969b169e8ef1ad0f9dad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: be10bbc57ab3c8a6df35262f5f5ba0a2ee3b0624012caae94476be4a83f4de72
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7cb3526874c49b4f071a339b66b919d0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103038#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103038#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103038
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103034
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkedObligations/LinkedObligations.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 731aeb38131955cedab6f5af4d1febd26e48e7c5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 90a00469e3e34443ab536510a5628af3ea7a0800479de91410adacb0b10ba7c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6caa7d61f1cf421b63fda676f0b8de70
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103034#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103034#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103034
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103030
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/GeneralInfoComponent/GeneralInfoComponent.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 982f3908f055820ea1ea9a7efbf9499e94fcd6cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c4dae73a12c0b0da10bd1b9f549f89e3145f2d304f887a306a5b1be67a93de6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d5d7c57c07ace4a84316ae3cad8464ea
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103030#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103030#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103030
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103027
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ReleaseRepository/ReleaseRepository.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: caed33032f9cefd1ca3bac986c8e9262208ec33a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 29b6515e18779b85cb3960ad484366a4906fed79bf9ddf213cddc60238e4633f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d7077c0acccec8f35ff7b8c374f7ed44
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103027#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103027#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103027
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103025
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ExternalIds/ExternalIds.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 157e41a14d3a350561691704143b35c1466ac24c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 17d182739e9c3806bbf8168eaa41a26bc308cc5d47abb828b1204af34d211768
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a99cd1ba3e0e7aaa5f220f2419b6e79d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103025#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103025#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103025
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103021
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/UserEditForm/SecondaryDepartmentsAndRoles.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1abb61ea62748597f902d6dae85f64f2d19e62a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 50273e39051ae70f3feadfce8d6380529242c3c024420362eaad457f51dfcd1d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2b8d300ef5b1823756bbeb534cc1ebbf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103021#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103021#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103021
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103017
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/RolesInformation/RolesInformation.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9d2e4ef6c15d21ac370439c15e2a1bf845ecacd9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e73fdac7ac061bcb7d14b82297ddd0969c4bece311b3d48d19f7b084dcff5fdd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e10e0ccb0562838c781d6603939ff030
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103017#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103017#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103017
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103014
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ComponentVulnerabilities/ComponentVulnerabilities.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6e183e89affe3751ede1b44b7fa737efe76e4945
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bd9401a3ed4e3d78fdc2ef18f3acf572e4d91d705bedbbd442763c891bf1853d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cb5fd2a213ec79e185624b11c65e51ed
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103014#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103014#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103014
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103011
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/LocaleSwitcher/LocaleSwitcher.stories.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c40ffbfe1969e56418a18c94b506604771b3bc05
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f89d23febfeb9a17685f68d83194e5b2972ba0c9193619a042802d96bd278c91
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 083d43830aacafd8503bd9a422511051
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103011#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103011#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103011
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103008
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Logo/Logo.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 92e2f0c0a80d65b5f8bae67df411a45023d334d5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 50224c1c39083065378872d7a14a0db39df5c7bc57f1f3bcc27f287bacc8f09e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b6e283a3b46190303e8418f283444a3b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103008#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103008#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103008
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103005
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/index.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4d466406ecff2425223059865c2620b95659796d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7f23a1c8b44c6c9d82597f95e673643e2ec5971e15a943509cfd15a77dab06f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f639218b1404f5f19653582525541b3e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103005#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103005#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103005
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103004
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchUsersModal/SearchUsersModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c15db165b748f2b26a919238ee29802f52d03ae7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 734d283b3600c7755f7d7775f5ef36213d60a01651b6ced5721497b3ebca5208
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0546995d34d6b8ed4117f22aa18a3e9c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103004#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103004#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103004
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103000
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/FossologyClearing/FossologyClearing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a1c96a0f55b659a01481ef09137dd5f80cfb5f47
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9a38d7edcdb627305238c73a1149338763ce86b4406e13449d9e30102f45f10f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 10386f9776e23a44278724fa6e615821
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103000#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103000#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103000
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102996
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/PageSpinner/PageSpinner.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: df119074f74f2ed8b20ca9cc7facd82d732c17ef
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 44c0afc6b858d5911d4aa6eccacddda2dfa30e222bcd429b286c20f1549ea329
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6d9a0f5b7908471ce572cfcb37509c27
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102996#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102996#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102996
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102992
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SuggestionBox/SuggestionBox.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c39c3f7747659da11e3ab7b4cf407df3c10cdb08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 97d3b8e5f278110702831bd7adee04f098173d8a9a60b5b48763162735768053
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4c41d2eb47dd3053580d0a0b58e3bbe4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102992#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102992#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102992
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102990
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchVendorsModal/VendorDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1b6aee3c07dc8decf465090df53ca21144a1623a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b29e1e20fdb04f773a37de6d4e1d34f2aec65f21e37f63167f0e0f6e7e07b1f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: df43bdc56802ac25210fd14f438e6df1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102990#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102990#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102990
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102988
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchVendorsModal/AddVendor.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9a498fe9728a0034e675bb4319638895c06e5e09
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9b05e20d7094b6f225d4385aae278accf0dd4b2d24bbc3bc35fe1a561925ed0d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d066dcb82672072b90541ba38855db42
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102988#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102988#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102988
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102984
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/ThemeSwitcher/ThemeSwitcher.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ddc23e12e81fe93d20c2d83b7093b6a66275c6df
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0f4f861f434a1c5651baeeb697445b64a33ae54a3cec26925cbcf9ab784b44a5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 174bb16b96abe83806e464bf51fc623a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102984#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102984#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102984
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102981
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/ProfileDropdown/ProfileDropdown.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 15808aaed4d639c1c043a783383e6812ba6c3dd8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e156f3bf3a45762d90de47e9c2c7b481228888313283ef212f3d5ad8974d176d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 06749408401b163155c44235f0a5a490
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102981#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102981#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102981
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102977
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Gravatar/Gravatar.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9e604a2dc7fff00425454b75e056e2c41afd439d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bdd6b564fb09e185c1e303fd19e291b93b44152fec79d7454111e2c9429ffc91
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7bdca21d176e00ac7c5b97a269fa5a61
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102977#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102977#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102977
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102974
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/GlobalMessages/index.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 24008de6ae835fa7ae341aa364d3713a5c1f9bd9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8fbc9047b7fa372a0cbd819d51ee3887b64dfd0079445df9895a65470df7cbb9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e0b65217566b0ede098ab59bb08e1e23
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102974#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102974#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102974
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102971
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/PageButtonHeader/PageButtonHeader.types.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 53140ceaf46d4142793e45cbc5c412733c1cccd5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0841d2d71d185ed38777cbeb27d30a799c637802b156434c2fa4ed13b4e53f36
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 80a511244b7c0119060cc0cc49990ad9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102971#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102971#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102971
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102967
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/AdvancedSearch/AdvancedSearch.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9b785b1107299b215248b4bedf8c76d0ab3a7172
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0524cb048e1a2e09c1a01eff5da1cb193e559e34dfb66cd752d5ff98990d499e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6f40cd31c5601b7516b0e3e1b9acfc64
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102967#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102967#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102967
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102963
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/AddKeyValue/AddKeyValue.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4419d27035cb419d60d9a251dd7cb93b12808f50
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 679e4e0eea1b1079660790bd28a74b239f36281ca6c226b99daf14568cd34db0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 84a291727b7ea5746ce3d3cefcc82b55
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102963#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102963#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102963
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102961
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/QuickFilter/QuickFilter.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8a681f287ad85e520bd0da4973199ebf091abecf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 139212798b6f23cef89f059190f95a54feba2272736e49325c8974ac4837a6f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e669974b8d6ff7aae12ef757acf17912
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102961#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102961#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102961
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102959
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/QuickFilter/QuickFilter.stories.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 845268cd389fb34a7e4815e03bbd50728b116c7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 297cc6776a46a1a9d544ce5be737575fa0281b41be019f691380584f63a2b8b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e04158f00796f02fbb5b014641a40256
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102959#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102959#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102959
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102955
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/ShowInfoOnHover/ShowInfoOnHover.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 86f2683f7e0e02ac950e87ee2c6c4b6045266e6d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 466bdf2e0bbb47f797dcb0705fafe1649c942c63cd1fe8fffbecd922d9f75f44
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 91a16847bd4663a19bd6f30dd7e270e2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102955#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102955#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102955
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102951
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchLicensesDialog/LicensesDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9399da24274fc0caec6dd24522930007e5b2461c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 551e8c7f12cd5957a398f51464d9de876ec745548d014383273f5dbc6a222877
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a530ccad88e76997fcc41f08021c4dcc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102951#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102951#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102951
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102947
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchUsersDialog/SelectUsersDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5b83554dfaa3e315204ab2f943b117ee2722029b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b0700bee8dfcad34a7b5ebaa6b23b481f65da55928550ddf29c33802064434b7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c7723b066f85e9a8ca2d8fdad82fa0ef
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102947#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102947#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102947
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102943
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Breadcrumb/Breadcrumb.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7c68c6683f84ffa07e20185e00a69e54c3c77267
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 123f8ef735a4e627b3fabeaaedd235491913b914f6eb21a3e39c6461c3aecbe5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f420503974a901b9c12c808ac790eed1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102943#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102943#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102943
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102939
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/AddAdditionalRoles/AddAdditionalRoles.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f123fe98ab7c0fabfdd723b98764969018678846
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a783e8375ed6b185c29f0ad26670fdc5e3d434779ad794078a77a9923cfe54d6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e4cc6edb8c10cc4bd107a1079ce284ad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102939#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102939#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102939
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102934
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ExpandableList/ExpandableTextLink.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1d7352b110f3773703c4e9d7d7544a85dcc0a6e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f5ca8ec4a6a15bb9ca184a0a9c1e24f3b809bfa8b2af4669cc5316c107dc3f08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c5a164301777f52a68bc414e586846f3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102934#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102934#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102934
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102930
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/Attachments/SelectAttachment/SelectAttachment.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 742411d125c8791c4bd6b82a402462ac9df179de
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: de47764d3c236869c45f24cb05c6eeccbf0aa90477b883a6e3839974b7b9a057
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aecd3cd56b8de75efde629c1bdbc4c7d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102930#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102930#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102930
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102927
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/Attachments/EditAttachments.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 13e11782bdcac1fd857301f56367e3ffd75643e4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3ae8cab254dc80398541fc6e24b0fcffdfd656e4eb3e6517135900daa891181d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 47fb5a5dd0663269d2a55d797d40d3d2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102927#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102927#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102927
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102922
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/i18n/request.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fab488c52128e1c7071ad57c1a800e1f53e4a52f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a1c6887df9bcab8bfdd37e05820c84bae1ef082829bb6d109a70e2819236bd0f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: edb85154245cf070b73ace890c78c4f8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102922#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102922#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102922
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102919
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/services/auth.service.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: aa353cd77cdcb2622013ac0d46c19e2b8d3b2a56
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7a63d6aafb3d18ae40c55664b22b9f8cad52075a3b93f43469f24e5f7accc8b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7852d94e47c7f5d654cadf9bdbe3cfe7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102919#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102919#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102919
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102917
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/services/async.storage.service.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b278738dd422fed559050bbf5889f9c26d2ef447
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7024ab9c049759222910d7ae80a4c0ea223b842eb90744cfe219e9d922d48dcf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2708d6ca8eab29dd1c9e004869744520
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102917#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102917#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102917
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102903
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/images/sw360-logo.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 99e1529902a9cd68a340b5c40962166efb428321
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cf34bc6ab67bab7017052127b6a944b4e86831f4faec8fdd2518fefdb74398a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f9a022651aa2f8333761f85265de513c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102903#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102903#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102903
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102899
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/hooks/useLocalStorage.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c261b067ba4a9cfe111b410879c2378233bfc303
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 530d67bcd4b3f0837510633f73cf15855a12c86dedd70c82697fea25ad7e2c49
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e10508abded1a51d7b117c387553a302
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102899#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102899#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102899
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102898
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/hooks/useUiConfig.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b0812d3daf63b8938f475f52a753d45891570171
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 97396cb4e8813f627fb96c445605e7731f90f716c9e757acac7241f827a18ba5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: adfa8cb390b5b50b014f575bd136fc89
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102898#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102898#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102898
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102894
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/index.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6aa58789cb01fbb5a7906167806099f2250b52a4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2ea7e8f9ed774fda1a44ae67fe40f85a6525922f516132e7c79ff248756e3dcc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b6636945433b12ececf2f9454166a47f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102894#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102894#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102894
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102892
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/common.utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 07ad9c70715683c350be0a880b554af71da03414
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9e27405fa436bd88686129c50c073fd3883d6efa7c734a13a8c43b9a294d96fb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 70f0963b7a3d85d5443fc5c81d99f2a0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102892#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102892#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102892
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102891
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/api/authenticatedApi.util.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0364065f7723b80ee49cabedf15989a960ca5165
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 589e0030e464169fabeaed491c40af190bb71d9463dfd48ac40c63dca34ecc02
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c2556d861f8f1a3e1605f6a54f092220
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102891#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102891#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102891
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102887
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/authRedirect.utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd6a545a5198eeb8cc17055bc9bd8d7ad63dfd49
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 007f2d2066cf0148b3564676f9835db43b5fc3448e41cd23e0a1793a93914bc6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e5f25514d0dd4787d3115770f07c85b8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102887#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102887#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102887
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102881
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/styles/globals.css
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 42bec30d9becd8fd9bd80c082b6eee33a88eb6af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d5708b4fec599be0eaa789e1bf58153586d553d5214aa211230233f74b13f09c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8f9f9d7fe111bf83c5a06048bb09d16c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102881#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102881#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102881
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102880
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/styles/auth.css
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1c758d8216c5fa1e6d7742008ad5dd3b0e6dadc5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 514882cd98090171646cf15d6159463ad8b75d9581935114bd421940c05e3f17
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 43b883d4f36586e2d53e0010b951912f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102880#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102880#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102880
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102863
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/keycloak/.env.keycloak
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fd5395da5c265166fac8e3bf3078abe4c56438b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 02704fc838903d93072b1fd87b8d7a0cedbccfb14ba736cfb872f93a59b95126
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 055d479958744cf7af26a16af46e61a1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102863#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102863#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102863
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) SW360 Frontend Project. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102859
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/front-end/entrypoint.sh
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 160746c52832a5fce5ea06dfc9ac463c46690be8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9b3501e98482a1054a877a6619ae89ae393eb12fb0beae00615f720b69d2eb8f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d9d16fbbe546483133f0161f31e156fd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102859#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102859#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102859
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102839
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/scripts/check-client-directives.mjs
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6fe6940fc6d7dcc86be2b9d33f776fd05041a6b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0f249ca79c8e2caa9e80088189695324108d1df7bef0e4469127f4469c98a095
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d9f2866e91e6e70d234982be44531eb6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102839#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102839#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102839
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102835
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tsconfig.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0b14ce6c3c4722b3e400b0ee118f62b6d6d60553
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ef45c1d92e785d686f01bf24153f899b9e3a72d0e345402dd0a403dfb2bbeb41
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 54ef351f08a5056b7fa3b8884cf5c396
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102835#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102835#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102835
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103146
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/ComponentTabIds.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1ddfd08c92a5a113f3aecc66cf4e30c422219c58
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0996d9eb435aa5f90c5f55049477b8f55312752edc6d15ec640baf69054c2488
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4f262b5dbda5b293e00ffe296dce14f9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103146#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103146#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103146
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103144
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/constants/CommonTabsIds.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e4dff65bb8dbf79a566468e584aa96ecdb3545a1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 11952c29e6ef38e572c76bde2889378e0e643ad54e36e7ced94c892de4c208b6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 015108671281b4a59696dc95b00e6f27
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103144#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103144#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103144
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103141
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ReleaseNode.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fe8d1515acd21e61d30d4b6071db2dc2d1ead887
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e556269148bfdae9172a2278d09dd9fda97f3d501b7cf7ce3345aa1de2e35db0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0bb77d96e3d7104f1a3956660b744029
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103141#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103141#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103141
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103140
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Vulnerability.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd46804821b04d705ec187302eee4c06864c96cb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1f56450b7a33e6a7eb54af58c2cd2e26faccf43f3b68353f9859dd590bd366c9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1041a976001b646ccce2258afcbc62c8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103140#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103140#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103140
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103138
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ReleaseUsages.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 60b170cc499ae738f432b1d75bb83fcb96c18463
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8e921dc168f9675eefe6c3624a3add2c42bcdf82f8f759622d8f214fd77dcc95
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8b08c2882ca3c628ea3f421467f6a673
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103138#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103138#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103138
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103136
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/UpdateCommentModalMetadata.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5be5def5046bb7d27d12e2e05a428a0246f4bcae
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d084456dd5acd43abe9b490723b7d8e65a3e50e4240d4407a01d8822c74fc798
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 162f89078b59432c2ec5b5875e88aeb0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103136#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103136#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103136
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103134
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Changelogs.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 50774e19395574a8bc4d7675925eac581f9dba91
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d4d92b9eae2ac9e452f70c95c5c442321fe136ba938503cdac81e720cff06458
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 65f577af74df8d4bd9c5534f1db52422
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103134#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103134#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103134
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103132
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/UiConfiguration.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4aff53274fcd0f2fb594fafb8027c81b4baeb97b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6990d4a5308d1b96c9f02de51daa1e8069a859e2087238a2c02d7641f4b52070
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9f339d944c01dcdc32a134532b9a9af8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103132#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103132#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103132
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103129
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ServiceDetails.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 336f7e2c62100ae8bdf5445b47b6510218c8d086
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b6ce1609f9f9764821e0f800ee9b8b5775375fb69258a6d526e733fa95a4a42b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ba8ad73bc8cd719ff0fdc1b1aba5b248
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103129#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103129#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103129
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103127
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Repository.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ab8fa513d65e0df5d74e6dcf8e509912d727373a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 922045a5736efb2dad4cdce5e319701baa4931bd60553c2a9f869d4d57e07a82
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1c8383f9d5741b97b4b87f6059d1b59a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103127#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103127#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103127
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103126
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/AdministrationDataType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0c2086ce2f553d125eea4ebb16183ed37b8f82cc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d157c9665d1f78adfd378e4e433b0a37204c97f13abd60ea17bd247742ca407d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aaf8ec63ad1b1934da9c81162043b919
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103126#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103126#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103126
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103124
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ModerationRequestPayload.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 648fc307c2ebf654302dd44e1299c49936684652
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 68489611b590b03c623123ce02fdbda0785642c6d77d558312590a93c05d606b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2097dde7f877bef282194c9557d604e2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103124#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103124#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103124
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103122
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/User.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a609a024c47d687c83f5aa16d19cfdc845127842
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4dfc9ecf2eaf9804a6700feeb4e08790efd3f15032305098f86ad77afad43553
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 03521ac6f67143243b49dbad737ae3d7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103122#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103122#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103122
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103120
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LicenseDetail.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1a08227ed863780606ea04c42fd0f0faa7ce546b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9a0651809a981b1e5ebe63e82b8cb671d45f928522b880734eb8a83737f33443
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b33c307ef2f1a2d1a18238af162b531f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103120#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103120#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103120
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103118
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/CVEReference.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 49751cd8a7233e6a6289aa1729ebd4ecc9f08502
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0c6a2e30bb959782541789419f678dbe1f31f50032f8579e9146fe16b708046d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9bfa9a72cd99eebb426af3cd6aa2af32
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103118#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103118#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103118
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103116
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/LinkedRelease.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 57bc38dcf3c94e7f5eafd8684102b0753d3e466f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e7d6841f2516f12495cf5c8f23017e0c0a4845d2bea523d14a70a22e6521394e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7fd863d77eafc8ccef21e11996567d4f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103116#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103116#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103116
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103114
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/RequestedAction.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7d596709382eb725dff2418efcda729f2cc868a9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: eb3f8f50dc5e77718b9b2ffa36536f255fb154a156a03f4c5f2acb8df7b8966c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 130db56c1f24ffb0052411338df2196e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103114#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103114#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103114
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103112
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/PackageInformation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 15e8f45a66eb98e607d542325e56dad2bf7f77db
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ee8c9feec09d6d813ab74cc2aa0188f798a84ed80443c715003b935c799f4e7d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 46067e5042a906f611c2587772843a30
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103112#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103112#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103112
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103110
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/ExternalReference.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b4746c1c0e9a08317921231a14b8eaf2eaae258a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 35f930195be691f7ace76d091214e20f8b8c0bfb70d8b01db08169cb3e4aa1b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6cccd0c419eb034d3cfc69ac5f3de1cd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103110#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103110#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103110
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103108
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/ModerationState.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bf5b30297369c0ec430927e26cc5625f231ad889
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ccefe92a0b657a3dc96efc7d1cff2b1df4a7124c693cf3dea65392b51d88c11c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6124e86fa67a651728f6c28235b9bca1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103108#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103108#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103108
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103107
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/Annotations.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e8b7e930f4cc68e3dc3d7223032a683f121e5d57
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f024521068451459bd1161b10fa6211d59787ee493fb593b41314ccec76ee7e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e37f8d3849f8f11c00047154b8e89a13
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103107#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103107#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103107
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103105
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/SPDX.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9d38b6f1bfb0246b9e6e42457f5d2746a7014248
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 952b153899198f1e2d51ec1aa08a02a322c4bfbaba0183ff34bd7e249890654e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b8663780bca357047d09719f18b97073
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103105#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103105#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103105
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103103
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/PackageVerificationCode.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4b7c2116cc1da1d528da5d470be81af3c6170371
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b0b790ab3b715a6a87780b9b2daf769a1c931dff3b51277d8274e19bee5814f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6787435e231e7b93cdcc2427099c5480
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103103#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103103#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103103
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103101
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/DocumentCreationInformation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d015bfb73b1a485e88d188784f9e1c57bd597155
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 07c6cb6d2da26f9d9a8977fe3ac0e4200e2a77d59fdf0fe36a6d522aa45ddc9f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d5abcc3c843ff8919e4fdeeb674cd694
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103101#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103101#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103101
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103099
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/spdx/SnippetRange.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 631b6b11c57b7a13e03882906490a24816d6c143
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8f361c01bc406bed5a0bb6ccaea07d9b37c42b2402b69e13e2b81ac5bb078401
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 445e3893ff9082ca0d4ed7ec6fb8a6b1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103099#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103099#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103099
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103096
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/Embedded.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f57f8a18723477982b3a15f3c02affb150f23572
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e6f12b66a941a240b2e2e5bfcfad5837bf245cec167dd433dfce2182d646af3f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3fea56705f8e10459c931242a27d4a31
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103096#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103096#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103096
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Helio Chissini de Castro. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103094
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/error.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a0dfb29304a569ecd007a2d0323f20a8051eaf32
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 744a2d843908daf629e36c21e131076034a6e1852ecdf0d1ada9268be89f7c0c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0ac46f0613cda9cc342967fdcd851e3a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103094#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103094#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103094
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103092
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ClearingDetailsCount.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a26f58808a327ae5df686af6816bf49e2d7e11a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fdebcaa43a7d3d3ca7ed9ee8f674e0c8503d72ebbb04a95c2d399f903e781fb4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: db3d0baddda477031ed22aeba1c89b0c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103092#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103092#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103092
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103090
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/object-types/ClearingRequestComments.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6f21aaf60afad67cee9de90fa329f66fe6327803
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c0d05fb29eb6c8d9fe5c00619dca5a8605553646bbe2a6de26471b80fe557a57
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1a30e88c910c4a2c8558e8e1e4150bac
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103090#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103090#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103090
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103087
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/navigation.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d22f0475d6cfd793598ccac0dfb2da5605c52c41
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 617ede623c8f23e07b42e1e1d976fe7016ca93873d26967975b2f7e932badf0a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: efa1f1d8cfe3922d254c30dcc045694d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103087#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103087#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103087
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103085
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkedReleases/TitleLinkedReleases/TitleLinkedReleases.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7efaaaf1c9034fe17ddb4e573fefdcbbd6ba0af7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1f43ef3b00aa76a7189cf76266c908c004228471867f00726f74a1274936ecab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 159d396a001396cb547cf3b1e08687bc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103085#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103085#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103085
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103080
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/CDXImportStatus/CDXImportStatus.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ccea86df97ff344ffd5fcbdebb4443fcc1ec01bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a10f95b6c6462dc288ffd8dea79638e73ef89629d9e28a08766b12e497cc9ec7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1899a0bc40b813ec8ad261c7d64ae02c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103080#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103080#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103080
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens Healthineers, GmBH 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103077
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/CommercialDetails/AddCommercialDetails.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bcf7e9c86bda5f8e7339c5993ff1764bf68ce924
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: bca18229cd6f86bd1ae3b17349e253bbd2ddfa41f29055497330a9b06c2fb502
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 591560a8a64d122a079a4caf891e0bd5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103077#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103077#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103077
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103074
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ResourcesUsing/ResourcesUsing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 580ce1e1b41ca50068f8be5008c17e880a49f826
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 06a565a7c67271361336b2856e590367c821cde1698b37f8fb9f277a3d4f9d18
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5150780652d20db19a2c603388e27041
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103074#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103074#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103074
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103072
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ResourcesUsing/ProjectsUsing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1aa3d8a361d3522cb1bcef7db384651cbc9d7e15
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cfdfde66c8d41228e04608d7d9f62a39e213aea13de2b9420ce8382ba4c28438
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 54e2c0e9f181f6b66affc1ff51d7ebc6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103072#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103072#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103072
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103069
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 961b234ca840a0fd01b909308320084c4c606fe2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e25db58c878e64aa40a68a56de819b7efee395e3b69424fe576900f97311536d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d2d08bffe3ac683baae0e29eb39207f8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103069#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103069#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103069
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103066
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/Administration.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7e16a625c2a58434839f9221de031fd6c9f1370e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 951d0d993c41cd06d8aa872b8f725f31c1b51f851ec39d9933050e7b27df3601
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6b9f7c18d86b60f92a101f5dd5e13a17
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103066#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103066#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103066
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103064
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedProjects.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f6f2900729af0f9d5c58efcb5d5dfc639644abbd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3d596fa62aa1cdbad21014818ee55b9125ba18603d1c902fd02aa28d353107c2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 255e0cce58be28e83a2e006d7e99a710
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103064#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103064#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103064
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103060
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/Administration/Clearing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a68fc3e4e587893b2b239f2d9b8c50be270bab1a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dff9428244668dc864fb3c1f11428d007dc1f8b22f819bee3fff8951c3f0482d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 64358b52a64b643169f2fe0b664c9ce3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103060#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103060#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103060
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103058
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/component/Administration/LifeCycle.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 392f0a4c07700167be50c1edd559397db08b190d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 570410118100149f34b4bf14018f0e42fbb2ec45a6f76d719cfbefa342c3c359
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 015e375fbfb0df5ac54bffea5cf44d4c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103058#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103058#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103058
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103054
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ProjectAddSummary/LinkedPackages.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6f97ef34d30f5133981f69c1e323a44d6557a18b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a017be559699930f1472b509a1d520bd84237fed677186349ae8a8c596ba055a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 21b341d46eef5da276655fea6d19d88a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103054#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103054#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103054
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103050
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ChangeLog/CreateChangeCard.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ede22d608250e2b223328f5405092a4e1de9f1e3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: aab1cd803de3762ea52758f86688ab1370fafe2f792351ef78578cd55be6075a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8d7e00f20f90fb7a9847075228081247
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103050#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103050#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103050
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103046
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LicenseClearing.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 38edeb88080cc85dde13681724571d37f2910a55
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5df82627bf95de24475333fe5027ec3336567c8b12b82076f09d06416a2617cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ddbd673c739210d0fd6495ef02c0ad21
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103046#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103046#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103046
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103043
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/AccessControl/AccessControl.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c0f405d5e26d0cadabddbe9ee6a35ff791b7e5ce
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8cd2c14f302900aa1c668b6c12373d92a32c15b232230ab021e1a004621facb5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b9dbc98f67e2935694bbdce5551fa1f5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103043#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103043#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103043
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103039
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/EditDepedencyNetwork/EditDependencyNetwork.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5cfd6da39e0dda09a81ebc7cd55e789c458793c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b23e9e9a0e42b7981084192421f20e23cdd2cc035b98f74d98d5322ecc8ff729
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2b3cf398f8516cb84e24626a47e5de95
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103039#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103039#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103039
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103036
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/LinkedObligations/TableLinkedObligations/DeleteObligationDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b0f834377ecc28d420cfdff5ee28866676058dca
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: edfba6c04f438cce62ad6321ba2b9e54a520f0bfec462bcb8a1a2e3626f54e24
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a940379709e746bcd22e296e3a651feb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103036#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103036#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103036
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103032
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ReleaseSummary/ReleaseSummary.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e8ccb50fd1d11fe25bb944e246d9296734dc70b3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 68102616727fc0023d5312f941584c4a97623519be69d0a75a8bbd2678a38635
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 094844c23352e37d3486f4104831536f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103032#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103032#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103032
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103028
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/DateField.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 872c4a0bf78f9aafacb4092d4596d618178021a2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0587179ea48dcf554d3c1778a87680e77db05ff9babea71b3c0aee7957161a71
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cc248e21060678ec3e3219e4ca7c6c1f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103028#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103028#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103028
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103023
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/AdditionalData/AdditionalData.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 82a50e0096b8751e0c884a142c16027890856731
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3ab39fc2f601eab67e96698f4a7d1d7eccbc771ff85ff1912df6ec086dba55bf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a7a3e0d125eaf94c8bd2a687681181b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103023#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103023#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103023
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103020
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/UserEditForm/UserEditForm.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bf6bb09a8bb39312db8dbb1e9d3022c09adff274
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b7104205531d67426098ee45da9851be972e5430b4cd3deb811baa54184bd51c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 37e741e7a7aefa495e8ecc5d35d6e1e3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103020#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103020#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103020
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103019
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/UserEditForm/UserOperationType.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0e40da61b13e3c82a50fb7a912817f78d2443aba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 19e08675171c5033f190ed7a6029d2d00df07c14d4c0741a97bf9964244bd63a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 401a5f88fa3646e8dba4c72b8dd61152
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103019#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103019#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103019
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2025.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103015
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ComponentVulnerabilities/VulnerabilityMatchingStatistics.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e27264b20033f1f043e410bcd173bda697e034b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 63e08f0798e9520ea98887798e6a697553947ef5a2d9039fc68797043b510fa2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a67df171d6eba7f94de0f711d5b4a20a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103015#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103015#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103015
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103013
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/ComponentVulnerabilities/ChangeStateDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4aaa50b8684225dca8b124ea1dd6a764a064b653
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fb21d9ef51597da9e39453a2957e998a70d376b11ab67853a9d3a965129dd758
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 00b1abceaeeca0a88e2b5e652d306560
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103013#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103013#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103013
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103010
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/LocaleSwitcher/LocaleSwitcher.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1ff10b3501a8b122f1f2d41cbfe0cf2bb3753259
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 008f8eba3363ffdf1cde89370529a05a8fd1574d6388d7d59d51b116dfa7338a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 579a74572a111822efefd293f8771a0f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103010#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103010#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103010
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103006
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/UpdateCommentModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3b3022baa4a14eb2f531869c3b75cb394a3b9f7a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 295eec4398f79a2292b7b13b18220e5637a8cc31af78465caabab977f8fdab0a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d92cc97ca9ebcf6854d0dbd9a75f6512
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103006#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103006#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103006
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103002
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/LinkedPackagesModal/LinkPackagesModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b1b1e3193307d42daecbf15285338bd54425bb6e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2bf22ec8a4c248a558c28e5881139eb2b3da5aa0aac9d3d6ab40510494d6f09f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 14b22f2c8fe90e559b84d33e6708dedf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361103002#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361103002#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103002
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102998
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/AuthScreen/AuthScreen.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 43746631ddc491cbb42bd218fc11b41e4d199bab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0e901a08cb5de31f41148b33771a18c3f32791f306ea7bdfb4be0c1d14a1028e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4ab1586764bc2febe5a0b4fc383687b5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102998#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102998#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102998
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102994
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/EnumValueWithToolTip/EnumValueWIthToolTip.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a621e375a9bbfb254170528c5c1cc9c72b543de0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ab785b750cc39235d61c2e5e99d0ad2d8e64133de3618392917eacb67317c52a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3d1fe9a480b5f894fdec734c40680d57
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102994#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102994#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102994
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102989
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchVendorsModal/Vendor.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f61892ec3bda9c5e8d3b269fbf8bbecbf7ebb506
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7876b8941e29fc4c264ad090b5845657e85ffb787dcdcac9b7521ce914bf0c02
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 970c884219eebc2bda96b91091650919
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102989#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102989#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102989
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102986
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Navbar/Navbar.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: afe62f0fceeb3205aca74f46e70498950914955d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 190078f941131eb41f27748cee5daf7aa59f86020a265b2b8a99f35f848b6375
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8428892a13e09e6006ceab1fb2e3d6a8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102986#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102986#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102986
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023.Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102982
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchReleasesModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 36b617397426427c4c113f839dc2eff3db7cd022
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 86124bcc020b8a63d56d7d589c6b090158b75324986cf672b96bc03c3486447f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 751a74bc64514708f8d06dfa8f4783b0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102982#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102982#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102982
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024.Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102979
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Footer/Footer.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 17f4a98e07e9ff2b027611de874e9e6fd0c01fc9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c42aaae54e7e5fff07e631caf11f74b7a76fea87575800cd40c42efcd76af643
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 99d50b0335c2cb0f7498f0907e68d5ce
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102979#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102979#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102979
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023,2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102975
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SidebarCountBadge.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ffa31b4196f2c382a38b1cfd63ea1359b9cb99ee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c074dd5842724d47d92c4932d67122198dd09d695b64b148f1e5771514b860a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9a55d487ae7f535d96f58bc55aa11085
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102975#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102975#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102975
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102972
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/PageButtonHeader/PageButtonHeader.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2772d8dc2a7c773406841eff454f22488e4ad22d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6a67d93e92e72055ed6de48fa4f0001d83e103768051fdc25a2e61d225002f1c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6077d942a3680534f53922c07aa5ab92
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102972#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102972#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102972
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102969
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5a05ecd7ef99e31782abca28b71f60b101aa8b62
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 298a762115e0063bdd4c504358d6a89badcf7afdde17ebe25d77d92d5a9c6010
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 19a1a7e4e1e6ca7612ea14ea45cc2d0a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102969#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102969#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102969
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102965
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/SelectCountry/SelectCountry.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4881f34360c4f23cb49fda7a1525e0b4fec895fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f0b150a023b5fc7cd42266a8d831866a8026b54d081237138a20fa8158c79afb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5ae42fd849d40fad9bfb2bb14100de60
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102965#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102965#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102965
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102960
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/QuickFilter/QuickFilter.types.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d9811443e9279fe3f88b46b9520512d4bb08c138
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 01d3f4f251c84c99da4f23f7d45fd14ad62d3e1b5b7a5ec7c08b4888eba9d2b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fd39d6064e7e905ca093fd20340dc846
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102960#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102960#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102960
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102957
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/DeleteItemWarning/DeleteItemWarning.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: eceeef2cd0d080983e4b1e96b9524c72e3bbf624
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5b43b4e720f5c00a5a751e5a1f82caafa352fec5ca89848881c4c3bd88cd51d9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 901688c94249784ff0bd102a6da97e0d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102957#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102957#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102957
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102953
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/LanguageSwitcher/LanguageSwitcher.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fd2c919599ff46bf36dcd500b6b8d55bc4f73ab4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e6eb3502339f2261931a4fa88a5a3c5312e041f45504738192aa4c8160066db8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 88e50ee4d55f578eff03755dd17565d2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102953#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102953#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102953
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102949
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/Table/Components.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 802a019ddac96f32a476547408f0079c0809a616
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ed672bd97c69f3579c8f9be22eb8db19326c790fc8b5a54bc7407670c9b92cb2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4ea8e8d262591c56ce3429f27ee47acb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102949#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102949#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102949
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102945
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4ccb1204e312b2a2af2d09e5bc2cedc7897593a1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4580c8cf6cc8b0887b06511417776aa7084312065ec1d058769df2b08e9c1bf2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d5d54147465c90d2dc253aa5761fba92
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102945#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102945#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102945
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102941
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/sw360/PillsInput/PillsInput.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: db6e782c9e2a344d0c650cbe5f462010e585e9e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c3899c047d215025901e9bc4f89553d1eaae46f42f5ca17bce3a6d0177da1a56
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 96e0590221e3f748a77cadab5f1a74bb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102941#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102941#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102941
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102936
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/VerificationTooltip/VerificationTooltip.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b8c7c9953162dc236d5fd659bb4caf352abeebd8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 91a94e427f3427629249e2c1c8584c0e37afd133068392463189a016c91eb90e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f797f07643a7ad5a19cbcd62c3fb4b58
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102936#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102936#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102936
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102932
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/CreateMRCommentDialog/CreateMRCommentDialog.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f52ec8f24535677911ac2d372cbb6d7214454d10
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dff904e7ab1fcbb20e05aa8ea1b0a10e3e25bfc06f01ee72da0119f6bcb65a15
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4b49f410f37b43f0ba06b85f3274a7db
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102932#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102932#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102932
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102928
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/Attachments/Attachments.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 21bc84462e28045b0ef02276d08408f078357f93
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e51baaaca91b138d09998792a5ba89c199f6826c89be7815340fd004d356a378
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aea861a647891b90063ab4622636a1cf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102928#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102928#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102928
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102925
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/components/PrettyFormatData/PrettyFormatData.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7abe78520e043e3c6e52bc3867d7253d7fc6fabc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ec0b95fcfe76e1e88ea7c3761eea02e9e9f63239c5436f73d78f374bbede4356
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d7ce07934f3cf6af88f31bb9c3e7a07a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102925#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102925#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102925
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102921
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/i18n/routing.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6aa3f440b89ad83d9efa8c3855905c1002f02d8d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 80d2b893820127cbfad03fe099c4dbddde74b1befdc86e0cd578b8e377304494
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4c4eb6c3cd684e4c0ba6ea626bc1274c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102921#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102921#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102921
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102918
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/services/download.service.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 88e6cba49bcdcd8f3c6b6d095addf2051144977d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 67f82de40177a35ff5224690adca911c68125e9a7e216e462582465a191a5d96
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f70f3f7e364844c22c5c79e5eee255bf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102918#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102918#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102918
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102916
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/services/message.service.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ad640d29b46ca21cd762cbb5ccafd275dfa7f8e2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 491e396b0723534ef36d980c1b05a21876ef7ec8a24ef2ffffb77647e6af89af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a46994b0afd18c19696d801d92ae2d37
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102916#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102916#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102916
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102904
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/images/profile.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1fde33f71f7f975a6f4a5a7483b6595edbd68fe1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2215f0c4efbbda2877436b0423ebc37c2b2a7c7db0eb716902ae26c6dc0d8f3b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8a6bbfa1dac9fb8a19bdbaaf333646ee
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102904#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102904#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102904
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> (C) 2023 Siemens AG </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102900
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/hooks/index.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 593b9ef28cdfecd7f6eeb471d9aa6393275753fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 33ee763cddd21fe43bcc5f65793f9914225f36c3502417b50c11f7e37c8570af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 680fcf7f54322abcccaea681ce450c04
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102900#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102900#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102900
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102897
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/hooks/useSW360BackendConfig.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd0e3a8165523d3f604ae435dbcdc67b362eda3c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1619a764b104b06fc18ea007d3f8a938f7f5c895c4f07cfff50f1744b2c9cef1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 529ee33d6b2c104722f267c4e74a06ae
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102897#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102897#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102897
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102895
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/sessionExpiry.utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a2eb29d9d68e3af12d06afdd954c57b53840aea4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5d872cf74acb179a12845526d294ff54fb43e4ed2406a9a541e003f7d5fe6419
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f3f6207ab5ee2b10c96e83b225f7a7a6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102895#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102895#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102895
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102893
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/env.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 584c312dc7e2bb1045de4c357fc91ba9e207dd52
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a41834dcd52a9da5a35bd1934f1a814d0c9156575023689f484d85445941b495
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 24df362d0f4f085ce993c1369159fd91
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102893#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102893#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102893
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102890
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/api/api.util.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 78105d2915627cf4fc6526021fe0aac71fe19632
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3e615e0aac261f80a78287e03ff5f389eacb62aaa3ef9e220c5125c3e7311b7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a75fd75096afb6209247515ba62e01d1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102890#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102890#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102890
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102889
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/utils/api/authenticatedUser.util.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ed69c41819e3587df6cee4e2dd2a75d2170f2e6b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ae389ec34916292fe1770ff7cda48f7d3c1a18f00fbcd4dc10ca67a8a2c5a01b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb31de525ec2c47da86f74336fbf7c7b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102889#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102889#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102889
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102885
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/contexts/index.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 93ef1815d122b9e40875b4588bbc7b0cab490b20
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e8987ac8e04f03e20a18d64b0cd4dba3f6c862c6dd945f093ba0b512038ee9a1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f2bc7d8daf74c96c597d7b4b9a36f6ed
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102885#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102885#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102885
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102884
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/contexts/SW360BackendConfigContext.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 012d84ab127b9083ea930d41799ccf25662b8cd0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 784e0f8faf50071127e5456ce6eef8a6de063d1f3095c0d84999ce27cf59268f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ca7788c15a2539d20fffd8591b1836af
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102884#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102884#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102884
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102883
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/contexts/UiConfigContext.tsx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 64e1b757bbeea8c589dcee4cf17cc44b4ce3ef0d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e03598b85e5011cfdb3cf45fa8702dc60dada6660318a987a18036b58a2c2524
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 547172fbde7254f6887f2a973e235677
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102883#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102883#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102883
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2025. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102877
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/CONTRIBUTING.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd8e8707c1c49d0191925973c33e966bfd411805
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d2a5e38ec99fb48670b51e514c1729cb3fddce30a8a77126b7488b311dc482c9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0e1230ca5c3be247e68f4de50f15f211
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102877#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102877#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102877
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) SW360 Frontend Authors </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102876
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/next.config.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 719376c059da4300b50389bf5d3bbcb2af5d84df
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5b791a4ba08f49c145eea39988a14b0c9cd1b61a5d7baf4222f3a870b926beda
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 767a5fe85b0fba9b2f611a8716af6788
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102876#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102876#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102876
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102872
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/nginx/.env.web
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 23141c15c1a9043c9a12b23db070a265f6990ef4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 67fb28f85b499140409daba7ff6d894c6e51dfe61e64e8809143634a736fad25
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb1fc9a6e985c2f9814dd1a99263688b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102872#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102872#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102872
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) SW360 Frontend Project. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102860
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/front-end/.env.frontend
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 85c1d4145d2c4bef2734505bc84dda7215b198a0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5021191b9e87feb3e19f3c83b16bef9157783cd61fcdbd8b96d77d03a44d3d4f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ee3463c1aca1219081bd0dd89b7a68a9
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102860#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102860#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102860
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) SW360 Frontend Project. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102853
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/sw360/.env.backend
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 81dd24f308f33876df91db1bdc61f4a9cf605144
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3e363416dc0bc62856a1c63b807d771471ce7b7c71ae77cb43e7a5c43ee6cd80
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 74557655cd60efa0dc11f868a2a1e61f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102853#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102853#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102853
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) SW360 Frontend Project. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102850
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/postgres/.env.postgres
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: de48bf66ae8a14df80709b6700a88292fd2932af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 302ef869e1ab6e04c90e3ee83bede544e176f48cd924531e74b839869e45bee9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 35298c2febb08347e1c0ae93fff091e4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102850#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102850#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102850
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) SW360 Frontend Project. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102836
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/nextauth.d.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7514009585713487a1cbaebed58d934ef39d6c4b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a33d69ee6a9bdcd89d579f99a27c2e7b7ba889cd5ebd3b41929cd7e0d7f751d6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 91e08253e516f00c7166a054d8cb237b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102836#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102836#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102836
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023.Copyright (C) Siemens AG, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102691
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/requests/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d5553f773302fd8fecf57c419ca47f9c2a9ca310
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3ce15740afa27d9977986da40e89288293068a5f7a3912d72ec13817268c3d49
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7e90990650ab769fd073dd70b0552285
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102691#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102691#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102691
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102690
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/requests/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e936bce72b39af2c3d56b610e2a39243455e66e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 99363aaa3ee6db149ab2470ca47e3fd4b1ab1d4c298aca37ffa20d2ab921d492
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 64e70da37d0565d71b8147696d3d3b05
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102690#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102690#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102690
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102689
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/requests/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bbf4af03b92d5641ac3f467cdf0b23d87d479582
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 83c932aecb3fdc8b9e4cfb7f3125efa5263d0f105aa6dd1a7f0b102c6ed3d542
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 980f4f3b61c1f0f923fb16ab0cf9336b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102689#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102689#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102689
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102687
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/auth.setup.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b3c87ee73824bfd6ffda83e6b19ebfcbfa9fcad5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 360b2916b6461003717e8b4debb033904aac076d7858ba1f0cbc315c2065b10e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 33b5d076674498524aeb76776c1dfffa
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102687#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102687#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102687
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102685
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseUpdate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9933c2cc874a7742158acab8b28d75805c7c6d26
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5be33e2c5a4bfb37fd8c3c93a0c3bc24647c63cde7c0db4799b788d7c94dad15
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 48c0faec907491ce711781e88fda1a23
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102685#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102685#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102685
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102684
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseCreate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8cbdf47690cc22d6db6188a5d8f9aff9f783c020
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e6322a0acea1101fdacb4d4644bd153f19f4a476b7015dda9ed48819b1360b20
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8bbd6babacd94ce3b7620b102e96067f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102684#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102684#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102684
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102683
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseSearch.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b3052ee43c04ebe6d77629bc09215854e639f098
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8c026ef270ba53090809e1b70016319b25547405cb3a2327094b6298cc1f11bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 957f0bbc5d73b169bc5fac3e11a537ac
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102683#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102683#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102683
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102682
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseDetail.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d2a25440f6ec66aeb7fcaaf1fff9a901c6beaa69
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 04f735a13125b50fdbd6d7d21ba110b4b370ae81f3e7d4bb2f50e9a0b1f67510
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 494e384224eb0066e4ede48842a3dff6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102682#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102682#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102682
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102681
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseList.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f3b708348d79bab019a4a65cd8a7a1d73bbdc814
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: da9c683da15f7a5b00395ac3aed2829c8c6fd70451d6d4f6144b7a05db55edb3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 28a4428738586ce0a46a0554ebaf15db
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102681#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102681#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102681
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102680
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3b8831804958c813f865b3cd41cc2239b714ac23
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1b96e62eaa17a49791c1ac661545608355612255f1587cff758441bc652944d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7a2d15389b4e1cf0df71786cd218dae8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102680#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102680#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102680
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102679
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8c08711b51b3458fe59f5c5d83e1a23542c9f36d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d1d284323192dc82aa52c0662d0c0aad26bddaa9de7b51d5ff427d47bf267860
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7847305e5fb291fb1e55da18d37ad361
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102679#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102679#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102679
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102678
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3393b5b7aa7f1793db3d04fc1af7821a6ed96310
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d74ebb3c3c6eb70c0c33f739cd8de13f34d34e353ca102ba407471fa6aaf567d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5893e05ae87d334ba94798e302d6b63e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102678#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102678#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102678
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102675
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/home/homePage.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dc4020c1d254b023f9c81ddc9fbce5d988ead0cb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f6a36ed15ddf7ee2d68eabaac5dc1a19a59c2919199260a075a6a0895f435ef3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ded22e92fb2a675da77b3e718a901436
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102675#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102675#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102675
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102677
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/licenses/licenseDelete.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 49211316030dd46b3af09d1be27c8257717bfba0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1b3807956bb24b072a1f5a136a7ed303750bdd55d4022cd32f742444aaf0048e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 42aa3b3d63c62441c8f94a925104a11e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102677#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102677#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102677
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102674
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/home/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 60949dda33baecd6fdda4a0570095d02c5d978fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b01bf7ea0e904abb8697b5917dc69314eb39beeef12d23db70b6f53fae146ba2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 804ae30aefa08a283d9f5eae408ecc40
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102674#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102674#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102674
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102673
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/home/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4a1e3deaa2572946261fa1875ab68fbad3c603b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7546c04b5cab005d63d022af0c86100c1d8c92f7d232bfaade1bea95219f8aff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 36bc3a8fa067b5343b7090267433599a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102673#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102673#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102673
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102672
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/home/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 93499b84a52ac4f16a4d09032d36f099d7122db2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 303551269917cf930adc942f5e449b1815669d0f1f22bfdca2b84ef92ada9e6c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ceebc4a89054930e5b5bdedc6934ce9d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102672#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102672#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102672
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102668
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/config.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bd6b5be7143e4c537bef7ff7a408779a3f036850
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8128e5880ab39264e21a45aa5d8bb32b00c8abf6be9e366f7971fc4989bfd35d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 40e9e58c85fbf8790557856973688000
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102668#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102668#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102668
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102667
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/global-teardown.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fa456730aed5ef5b374b6f86328240b9a39208b8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0d2407c3d544de7695c1e1d635af0f84c5c03316aa2438ab38dff7305ebb0bde
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 43ca22eeac3bb7b3e8292821b83f0497
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102667#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102667#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102667
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102666
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/global-setup.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4365d2f86e070291809b2bef7b68ce4bf8056b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c0bd8482eb76c15a2813076f8eabbbcd2647f02ef72cda1fbbcc380a905320cd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 35b15a1d19b8a2531707963b0f46c48a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102666#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102666#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102666
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102650
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/deny_list.sh
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ae54c68c3eff5c4b1a526bc1788ce292cd1fa0b2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c0c5440f57ba3da1ba013bb5c344dffe0c763fb7d19fde64e237a3347736ddb3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 12edb2bdd25634a8706cf0199f86940d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102650#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102650#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102650
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102648
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/instructions/git-commit-instructions.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bfb6dac614cf370115a7e42aa62a341836ed1a2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 03194f83c390af952751827413d455b7e86969b68f7853a65d1b884c9dd34f6a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 32794261947cc9a0783aede5fef50c4f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102648#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102648#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102648
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright Siemens AG, 2026.Copyright Bosch.IO GmbH, 2025.Copyright Siemens AG, 2023-2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102649
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/instructions/sw360_frontend.instructions.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0485f5c7ff3f8602c363dcc67d664194429664a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c5010f74c8204deab374bd8ebbe1f050c6599d5f1b00f82571913fb5c98b576b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b246f732b3f7ecfc3e88875573277e1c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102649#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102649#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102649
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102646
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/commit_checks.yaml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 36a16f22b4e39618a83a1eb8051805d4aed01905
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3832101589ab5daf917216bc7249a667b5fbdc0d948138ab0d96df7ad7cd3231
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0ce9d7626b1ff7b62fccfd103be970b2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102646#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102646#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102646
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102644
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/biome-schema-update.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f34155ba7acf69e5feaf75c8b0a9e454cf6fb42e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9e6b2e09b5afd4bd69020521c710dbfba030c29e742e68f011e5e7c848b14cbb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4dc592da57643e2dcba5257090506ca8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102644#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102644#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102644
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (c) 2026 Gaurav Mishra <mishra.gaurav@siemens.com>. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102643
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/build_deploy.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3d38178ad1b4717f57ab6f202fb0022087ae1ef6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c7f861b2637885eb0cacda8ecff0464d1ecb0fa83190a67bf5e96ffb95e0f2d3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f2fbbe748c858c6202617576eb39e1c5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102643#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102643#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102643
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102641
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/docker_deploy.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a0803cc4bc48406518a439d862029a5c2f52d433
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 57080e0231acbcd0559d2ac6fbcc03452bd47be32365dec1c9d07a8d660b09e6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0d1fd23ae2f1e70ed0d1be393e4541f7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102641#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102641#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102641
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102639
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/e2e_tests.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8ccf9b72a03abec26a112d8edd9ff9926105ddbd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 38164edb6ef6d43d25b44f2871c5aa94531b6633fe989876e3f2ad434a8042ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: de32198980bf981c9f2e5f5da445dc2a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102639#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102639#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102639
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102634
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/NOTICE
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 062402ff7ea2f8dc3ddde6c64360d30d6474128a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: cf7e04d03ff3b2993bb9ac25949d7fdd08c3399b01a69088d43d9beefb330d5a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e2a7dbfc04cf072eb62bfd3fcf97d800
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102634#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102634#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102634
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro <heliocastro@gmail.com>, 2023Copyright (C) TOSHIBA CORPORATION, 2023.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2023.Copyright (C) Siemens AG, 2023-2026 </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102862
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/keycloak/orgmapping.properties
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd8db71958f8a987acd921a9630a7436811947db
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a902632629031a8c1313b2d3ddf4225eed682b9c89348988417efb76151d8587
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 492a97a21602e627ed04b5aebc64ec3f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102862#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102862#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102862
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright Siemens AG, 2024-2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102630
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress.config.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0ef7a5cf8a28107da463fbbabc5e696e1a6d3d77
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 355c1a9491ae19c1cfd7577625f12ee0a36ae0c33131b68e082cb541ba8c2bbd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c6e04d38299aac25eef4a7bd5fb2227b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102630#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102630#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102630
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102640
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/scorecard.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2fc3aa894708fcf9e6ff0d0a5c41d12aac6270af
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ff0d680d55f622550ee22f7550658581c698701b98428c29d97098886d8e884b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 29b2e203f81c3b05309db6de1cdbe9ad
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102640#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102640#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102640
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright Helio Chissini de Castro 2022. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102830
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/playwright.config.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3c75d2437136f3b023fec728e8c8fe60c89a44b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 64e8c0151b9568a6e2a666338028019e614200adefa032d8f94f7d365761ea88
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1f07312ac7da4e75953d0f2cedb104d6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102830#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102830#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102830
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102829
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/global.d.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 169760ad54a58a6a437109dd414ce64bf47dc590
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b957139d46f382f9db29c751d10c33761953be88b02abc2db97752fa8c7e30ac
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 67fa709cabba75bd0eb3ec24f45fee78
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102829#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102829#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102829
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102828
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/support/commands.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f27b951731ec7823f1827ac766d0ab65f459a81c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 82b3bec727bc434118a5467896c88e37a4263464437ec1468c80e50bb180d773
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8b315d27f6b4a6c285fc70bce099d552
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102828#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102828#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102828
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102834
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/Dockerfile
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e01631f10f0a04b60eb185f31d747dbed7747d2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dd07dac8dae526d935c24e60bfdf9eaa10aad5dd7f90b18b1b55c2b55977699b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bd56e1708bf4e77ae7da71a390e9a245
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102834#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102834#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102834
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102827
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/support/common.sh
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b9aa3a4ca87dcfea4253bd8165a1c93234ff2fef
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 92206584d5036d026f2713d94bb17a97051b0115a1a91ecb96d3e3e742baa194
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1b5c01799d8cc7ef4e1c8f67b86a29db
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102827#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102827#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102827
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102825
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/support/tasks.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e5974dbbae8ee023241878011234cac31b9a4e72
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: df94bc09c8c70493979f0e16a572cd5a40c5c9d60e92b44a3a1a36555d5ece79
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 52905cf82dd6856b1a8c080dff328f70
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102825#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102825#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102825
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102826
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/support/e2e.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 557c7898638318156aa0dccb4b60e36cbd33aa20
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 115a0a1472bb45a362ff5a367f26467c27312cc773c8dc3a27514b8f9b5a9206
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 66f1aed2ab88fab14697aed0d81946a2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102826#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102826#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102826
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102823
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/import.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 95e814f479e65af74cf0304502b280c04a2cc786
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ca71e7ab04d964ba9dcfb81575ced3697e22cbd4666d936900ac70e5e1273401
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f32d842fd6f0c4de61791e880dc5004f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102823#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102823#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102823
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102821
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/export-spreadsheet.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 81728daea12fbd9d4e0438945291709a8bb1c2cb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3e246cd7389f25f47715575b7a4c4678b0f24f4eb431e62cae6f70e518c4a413
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b05ad2c42571559f8377b894a132f5df
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102821#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102821#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102821
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102822
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/delete.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4a55d8081d61292f4acffb4415bb4422e95016c1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6596688d4cdee2bfebb03e4687ed87a0c431fdd188f74e89717cfeb07d032d99
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bb27bdf5a402ff95d2cf8ac6e74dff68
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102822#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102822#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102822
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102819
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/update.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bfc58e5f730005a78af85d7d5607c213e328d8d7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 836f50148dd070958205c9e2735b67eee6069d5bf5b6ff56eb4153c1925b6df5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: aceb16f76b5739dd6fd04128ca24a4d2
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102819#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102819#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102819
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102818
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/utils.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ca595076e6052458eca1849c681c1cae5a90579e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f18d64739547410a7bca8cc1a7cfda9c5c2bea198d9ce1e7de3c97a62a4eb458
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 75a3012607b939d47da9651110df9017
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102818#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102818#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102818
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102815
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/releases/selectors.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ae8e21355d37b940ca957d1334dc2af420965a46
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 73d7a20e589c4091c549d83be95332e416640f91c05f76dcf43740b71f317e9e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 220c30ab735a9454b2b99884cfd76f83
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102815#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102815#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102815
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102820
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/selectors.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f89afc1c3b76eeeb0f3d57af7a5b6da5dfa3b6ea
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2b1be2974443ac117ce2195432cbca7e5b0a94f138ebca0870d63300412f5812
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d9695dbe019ebbbc61baa2b1f048eb53
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102820#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102820#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102820
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102817
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/components/register.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1f996bceb0a99ef1890cee011e073bb2215da20d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c18a7b78a68bcd4e39c59f5abbc8ea10c3ccfc183e8915bff3d36c9892228f64
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7b6f1f0b87cc5b2bfbb2f4d4faec1e4c
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102817#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102817#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102817
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102814
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/releases/update.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9e2df83d55b76724a1db1704128c1703bb22d23d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ddec34302d9a6dd07ab7f3b0f0b8d7ea625d5526070e5d7ad323667b520973ab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6354f16a0dbda0a5aa8d4d5966210541
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102814#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102814#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102814
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102813
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/releases/link-to-project.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 26f43b116cb38531be4a0a160fbbc99ea618adfe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9ae45ead25ce9346ba64ff430a0d65442e7f3f19ec4eb50929a8609690513fe8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f5092c8b0f01d37207b5fa3544e0d946
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102813#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102813#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102813
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102810
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/delete.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7dbe87e1de3afd140f9a7a42bada6ff8353618f4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e0b0737071ff6b96ef5efb75fc12d81f3a7cb0396fcddfad4986d4aa4da0e42b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 766b639024b8e88b74b6824bf7572a95
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102810#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102810#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102810
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102808
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/selectors.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: aa77c302b396266598d995d0d20844543bb45210
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2f9f4aa4abce011ea5dc64ea02959207c72875620fcf16faad6adb03bec72e2a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 82b8772208f154ec37b8e67c86c14657
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102808#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102808#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102808
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102812
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/releases/utils.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fb47ea9b1ff8f0b1a6d4d8ce5898d2c7cb297eda
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5bc3b71bc718dc49332d01fdc89cfbdbc2200db85afa74d56c4de10440cf511f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cfa5eb99e3541b5210a94f26072902b6
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102812#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102812#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102812
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102809
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/export-spreadsheet.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 96f177b0eedb95b08e25ff5b30caef967ec288e6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: ae3f07d8ba19365a5b83370f1f2125a9d343a36f9dbabb0966c18087e97cf367
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 79ad9e639942ba65e7e05a51d8243f4a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102809#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102809#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102809
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102807
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/update.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4be8df7dacebbed1917518632037bcb1a825f9d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 46cbb20a17ba02bf57df291d1c6be877f22ab131e357d061757b98f156a8e1e8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 32ee0f25a9b205d968c3b60d07102966
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102807#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102807#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102807
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102806
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/utils.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fd3938a6d902923098f164b529cc70b353ad91b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b741a0563370ec45a3c3c0dae8a30798775122fc2070601d5027f50cbc7e6dbb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a2b70dba720fde760c31bad79f5eb392
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102806#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102806#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102806
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102805
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/e2e/licenses/register.cy.js
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9d5509d61c365069bbfc0dbb3115b846aae0b2b2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c4c8039541132e60e03299edb02d16bd61fab211bc6c2ec5ef2da1438e62b448
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b54ca5d92a039c73dcbaf3921efa830d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102805#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102805#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102805
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) TOSHIBA CORPORATION, 2024.Copyright (C) Toshiba Software Development (Vietnam) Co., Ltd., 2024. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102772
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/ecc/eccPage.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e5482d65e25170b8a4b83d2931870f9c0f1af2d4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1cdc3c38afd520024fb82c301b572e83cbd55632baa5f1bc15642714caec926c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7e25a616d920f980728a90e773d6882f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102772#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102772#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102772
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102774
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.licenserc.yaml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 92dad098fab4033a9657d878e8935fc85e8ab545
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2d50a043b0488134db8d85f32934ffa9309caab15fda824d60ba9852dffe0c5f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cf315d9477757ababce1bf580d1e507e
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102774#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102774#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102774
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Helio Chissini de Castro, 2023. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102771
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/ecc/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 78cce543b4092b778aa59714fb0cb20daf9ea1b4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: be5fe56ce63036e70b75cf2a2eda45f58028cbef099f028409b85dcc154586da
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f4cd1ac145cb29468f97fdf133937118
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102771#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102771#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102771
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102769
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/ecc/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4df7fd77002f7e4f5d61a1edbb030b4a2c0e72ba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0548cfddffe0b37a7564023b61ee9c2c2d415f703e10be2225dd2a882b6c79d1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f752303696b950c4a4527c1a2e03e3cb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102769#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102769#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102769
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102770
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/ecc/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 31ac6a6657072fdc6b06e2d6b63483ada1e5c6fc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8628f0a15e17e160f4ebe2e5bd99922352968d9fdf7693c046daf22a3a469af0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 972b6a5c43eb8ef643d8b49ab0fa6ae8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102770#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102770#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102770
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102767
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/viewerAccess.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 961b68fc23ffc9147f82e7e69cbb3e4c2068060e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4409af222c4973ee948c79fc51b901e309b26d0a69fb96b54267f90bee9bb810
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2ef6ad2aff74698c495a49450b5122d1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102767#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102767#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102767
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102765
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/userAccess.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 525abfa97f1e544892c555209f3eb59203189ca5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 86d239875f8034ac81503348b90edd304a5d0fa88fb1f880cda4d912d8ec6748
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0c5e9412f948ff190351d663a8b152f8
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102765#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102765#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102765
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102766
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/adminAccess.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f851785e1f3bf50e492d725c7ca8f02edf098b40
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f64d61c152095151119ba25841fe1d010710fb5d04237c9ba1e6f25d64665014
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ddf5ab9bd6ca606997ecc2de62423783
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102766#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102766#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102766
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102764
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/clearingAdminAccess.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 985e6b6667200539ecf457b3e354f0006417fb92
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f15348234bd589f5a3b6844a80ebc4326aa950924afcc49414edcdcb00779651
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2762bf842a7547654396eb07bc0b4a4d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102764#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102764#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102764
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102762
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ba5a72d69b0cce2a07f38664535b59a2b58a637d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fbcfb2c295e5439d3396f639742a0a8864e46382934cabd39e9e99346ee47afe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 265a0cffda5c0b3c6dc095723d4282e3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102762#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102762#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102762
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102763
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c473d828df5eaf701a7c892782d100cccdce50a1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c21e9da13a787f4e078dfd4f22ed0767ab82b4037859142c202f9da346f094bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 512db907ec3cf7f28dda9ae3804c15fc
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102763#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102763#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102763
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102761
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/accessControl/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a4eb347d8ddb454091b44eba46c1fb183ddcc4c4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b0336599f514b5b864fda30a76f320cb2c44e6171d66be535465c7f17863af4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ad9a51931a52e0a43592d3cba99912cd
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102761#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102761#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102761
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102758
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageList.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2f7508dfe54042840e5c05ae285781be4e2408c4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6e05dce3b74df926a17e11960dc54adc38ff88174f0a8f779c6b7c783e7b7f3c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e58d7f9041fa821daf09778e30f3b9ec
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102758#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102758#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102758
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102759
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageSearch.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ddcedbac1c076283cf0e258b9c35c2cb0b2fc098
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b8dc09b76e62db133403e1614623623b984777354ffe4e57c029030200381f23
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8dd2a30faa14a75872db682969379973
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102759#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102759#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102759
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102757
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageDelete.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 79e2dae03a8187d4d32013903e4e06d1c5dcfb9d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b014cbdf7a4e2da93894b4184b20dea19c60cbdb5c2ef8fa8c90ccfab43ccf72
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c4f25e0334a310900338966e1e05a701
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102757#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102757#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102757
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102755
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageUpdate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 22f19f3076493d15f5f8ad2f43efa88f456dc227
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 409bdc35740025b0af91a9fa138fca1028867a9efef16816d9e8df360b34a4d9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3b9d77c74c216afa487afd85517f0154
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102755#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102755#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102755
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102756
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageDetail.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f1570abc9ef4226adee8657da073cc058fb530a6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 660449035aeaf67ec454e32a27c8dc9f8b079c7151774a6a41a964c5222f89ff
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fc0d671cce5a73a56698e78f9cd4dd8b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102756#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102756#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102756
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102754
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 969af455a3533caf1a5ce3034020c0e5923e5b49
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3449e0eac758abd01b2a38db7570df3847f34f537dc3361e1a0cb7923f551d8a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3f7efe8e1d85eb863038b3222b0520df
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102754#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102754#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102754
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102752
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d943ddc81c93fb792496751e6d42c2d9abff9044
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d8d9dc9dcf0ff2dafc9be5b6251d715ffd11f536a028ffc1d24578b901d6dbd2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9a45834d9a07ea28a18794a582dab83a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102752#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102752#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102752
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102753
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageWorkflows.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7a58b872134552eb944fda37ffc4ec05818856f9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4e90234cddff9b5e1b4fab7f54d52ad4c6c5373576c4a1abed04d069cf06374f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 60d77381a6f1c5c1b445aa0ed3e6e25a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102753#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102753#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102753
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102751
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/packageCreate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ae63f92774706aa3a25796f63116e92ed52c9272
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 322b51574f7f54be98501b822364052f24d4e0eb1ad1ba03923cf5557e15f659
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: dba60e75b92649bfb58d76c1d880ef50
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102751#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102751#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102751
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102748
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentDelete.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2d634f559b0371e9faedb5ceb1b490ff90fa3614
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2391723c88b43b5458131e9bfe1bc4810ff1019f8c52faf9ab82b1159e93e49c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 325d3fd46f8aa0aec089dce9c01cfc87
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102748#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102748#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102748
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102750
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/packages/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a6abefd71d11cab192195062fca585ead21cdaf9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7bc3b1e079096b23f49a4753dcdd46f4f3bc7970e0ca95e49fe4c5239fd17453
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 87336a578a7f7c9d5536b7604221854b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102750#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102750#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102750
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102747
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentUpdate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 33b5b85a24436dfc30b4f7afe1f014d9f213283d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 67b400806ef8c881a8a7774755a9d256f6381f604c3dab72927bb03b9af3a643
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d885a442c4b2435bfed466e3e533e811
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102747#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102747#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102747
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102745
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentCreate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: daa4f0f882e27136fe2eb93a26dbf9317ed99b7f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 29c5dcd192a35a4710e12006d66078407b314333d02a2950302bb67ba5725b61
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c610df66a0036084d1ca8f72670e5a96
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102745#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102745#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102745
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102746
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentWorkflows.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1997ac8e13be24add43321107acecfe817193405
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2f0cb078fc4f30d3a85ef2899578d155a2645ba9ae9ce6d4deb7d625ea066020
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ed79f355d3aa486f2051411ebd3e1a5d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102746#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102746#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102746
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102744
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentSearch.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2a5658a196c7c6141053018c4f4518a10fb486e7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 00fa3c10cbff12bbfacecd758a086a9723095ecdbdf01df16659c7a316d4983e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 21b0a6be92bed7cd9047ecb4fd4f5a12
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102744#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102744#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102744
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102742
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3b6d6ceb70e573bec050dd72c35f28621316229e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: af1d3139aa56e87162bc92b94955a573f6855b75a2bff8afc404f12e45bd2c82
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f40e217f21c154a24e3527cacd0fc238
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102742#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102742#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102742
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102743
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentDetail.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 46644fd72a3371a54f09a6032b116250c80fc11b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 186c28ac5eaf8d27ef262754663e2e277182a7ca8506b1fa0a74ab075c1afa5b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4b04bd72c186bd2c14696cd9ef89c5a3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102743#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102743#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102743
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102741
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e97507af0da85d383d1bfc3723352af7c286b478
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f507fa901d98c1f1df0ecd07c2b2a0de982c9e87eefcfe7e319f3c1e983d73c5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f9a25cab6c5f433afb02b94bf86fcc25
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102741#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102741#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102741
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102739
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4fc2b6c07d81bdbf2f0044ea900c73e0694b2057
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 68b8dcd9d1513fd703314efcf9a1220ef44d3452b9cc30208687868eb1db54f5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2fedea02b42e636e068ef2eed8c02404
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102739#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102739#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102739
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102740
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/components/componentList.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 242a493bc109abea5f8cc67720a617e9ddd9db3f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9a9dba479d8fdd636cb19fdcafb1ed2b18dd78c49eeefab7e3948db35d01ebcf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fd1e9e7697a6e7df7272a595ea829c82
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102740#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102740#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102740
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102737
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityList.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 886665d71c63113185a00529e8dc6b64c28f033d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 213c9108a079d8184cb396cc24c4e6933dd4499423839fde18c71fee7ee4ffba
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 479e4ba4d195c1b92810379093ece365
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102737#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102737#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102737
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102735
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilitySearch.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7e90cdc01bbabfc167eae92ea89a1bb24a26f2a5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c62548fed0ac7d280c6cf76f41e1f5fd15d75ca18b42aacd69e3fff40a9f6d1a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b08cabcaa5987bb5938bf84cfb472405
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102735#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102735#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102735
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102736
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityUpdate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cd68cc1a6d2d813a443c5e59651d00109dc3c42d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b253df550fbc259478829bd3b964b25ce11a4bb0a2ea310ec13b36abeede9226
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9e750af1e1d947a3fcea62879c2168cf
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102736#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102736#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102736
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102734
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityCreate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 73536f809ab0a3ec3c541c8ff1b53c608de71990
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 25194a6f58b377d44d9072f23d082be0b41ef8fb908fdf3a40c3c74d335c559c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8cd1af1b1ae642779ed9f75a062acaf0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102734#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102734#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102734
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102733
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 809bb7e4c2209ad6f2cc007d9ac7c4be580c5482
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7cf1c88e1cd0aba0e679097699f7829879bcf31d98296e09a80c3a0f4d4ef333
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3570da2eba865a3dd8f5abd6825f3107
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102733#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102733#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102733
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102732
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityDelete.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9c4f85c48737adf8f083eb39d355fbe82ef2c642
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d1eb960b420ff6d9fb9d937b1548c0290e73ac7abbbf03fbf3f58609c68b8b84
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8d90cebff7cb52a16d6b09d47bc2890a
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102732#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102732#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102732
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102731
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4d67cf6cf23d146b585fc8cdec3c3df86a61a00b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5ae926f9099881d19171e016ef079eae84775615063108e023d788f56c903761
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a2ca1eb49810af7543d06e3b0cf235c3
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102731#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102731#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102731
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102729
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e4c25facc8f15bff8ea53003074df81628802bd8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 08f9efe41bb78f39630c03b6b6688fa8567fa3ea48907f4dcb6f6d005602b356
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 629f72fb9430eec8b2582c4c76314210
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102729#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102729#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102729
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102730
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityWorkflows.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2ddcc29f0ec3c88d10a6cd60886ac2b7b082286d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 55ca2d420001a3a195a56afbda7886bc27afa43446238f81f2c0b44c6a883dc4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 28f469867c5fef352539de0c2d253733
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102730#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102730#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102730
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102728
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/vulnerabilities/vulnerabilityDetail.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8e97fb07ca8939f7e801c9feb0583f86e8dd98c6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 98db4ca77d84a03408bca13e1ad8184b5d5cc4a4ed7b7f8c58238b0b7f4aa9fe
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c44d4727eb170eedf300f7670d7d849b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102728#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102728#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102728
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102725
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/helpers/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0d24ec67595246468657e672b58a05785b34b661
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6a83391ea08ffaff410212bfe954312ac9f67858e6d3aee2f9fa55cd1041fe98
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 769af2deeb0ad0e32d9294f93f892b6d
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102725#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102725#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102725
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102726
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/helpers/testUserSetup.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ba95c271591c810006fb497ba3c7156e76f4736a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a6b6ea98a692de42eb1740f4e0f1cb6fbb2126524042fdb67522318a6c2c7a73
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0e076bad3f1c72aaa1da62f907b5ac08
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102726#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102726#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102726
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102723
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/searchPage.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 66bc8abb26b2a1793cda1723ca5c171c71142c89
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 056abd86d42a1a390452ddb72c5e9c0e6d0f714f77c1670ce48c38e6e9db1452
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4c3ef7be0ac5c083d42b6862559cba2f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102723#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102723#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102723
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102721
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/searchResults.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 85ea2851fe29bac9267ffa395f98c6950c4b8504
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 431ae600c9f147ef5064faf31ced21bc859fdc7972a116e4373a66eb3ef7b539
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3b5ad278e3d19fcc270554981ee65643
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102721#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102721#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102721
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102722
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/searchFilters.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fc32bde005107bb2d6191afff4271704f1f4e3e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2ad1e3e060c307f209086b5e197d11f8af2e2742ba7538bf5c836edf25a9844c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 38aa4746680e3bce7b3edc81cd81ec37
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102722#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102722#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102722
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102720
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/searchNavigation.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6bafc13e49766bd2c96350265fcab281637bb5a8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6e5b325f1455b0aa29467f4d2d8895a030fd2a73f58557d8cb4b87d119d3136e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4ab7952b0d1f6cb61f711fe8f99538ee
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102720#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102720#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102720
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102718
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7c0e54401de5eacc542a861858fab57e6d63766b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6e6d198f696b83f18a775f3d50241b4d0d82e390db7931c01c42e46d18c14224
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 32cba1d91d198e80e841f556a9baca22
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102718#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102718#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102718
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102719
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/search/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 47b7899ec13022264fbc1fe0ba4f80987e2d9b0c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f48d10ce76c8503533b1c69b430a284a7720788f27e63cc981257e8b877bb11d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2768be252e4e14e5c0186f78ec41f13b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102719#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102719#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102719
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102714
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/adminDashboard.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 429e261846cdf061b167cf13a4df45918a014d67
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: efc9da5181a6ef0af140162ca34dd259d79a99f36fd25f3a94df9f39a4cb1c8e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f3888210aecf257c4868f167d16d30b4
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102714#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102714#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102714
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102715
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/adminUsers.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c99a851cab855892a6ab2a981c1a587f98142bfc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9b1e17b2a6afe8fd1039d5f8f5646f04b182ed2af6896d2949bc92f233cee05a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 68fbbb5799378680f2ad1d0c6ad90e03
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102715#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102715#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102715
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102713
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6ccf46939a197e50b91d1ffedb05ae41427ebd83
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 40d6a28deefe527e2ce20b25e83027d17cf5ef282e9aa87cbd4a803d1dcf645d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2b2107d391d2736804419ec28f63108f
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102713#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102713#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102713
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102711
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/adminSubPages.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e0348f2491304979d1b6e0c3d89cc485db73bea8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 90e30fdd1b36bd42418b1af334c0b53393cca96e2ddcaa5a6709ec3784f4ce67
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 10292a692e20270d5f884a5352b0c6e0
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102711#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102711#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102711
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102712
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9ed96dbdb2aaf4ca6b4071348ed08ae1e9d94fdc
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4b269fcef24b23848c19ddbde8d1529a94032a717e362e97bec5eb9ad70bb0fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2369aef35ae9ff157616d2aacae3a280
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102712#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102712#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102712
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102710
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/admin/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bc362b9ee8b229d11b62187411f6aae38415e4c4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d991c1df02b3b0d24f582864c27fc6366380666c7a6073061d2e88dee701bb8d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 218a3cbd27adb7b6557257523f4af5b7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102710#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102710#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102710
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102707
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectUpdate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8706614c92590abb18f06bb380d32cd0891b009f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 205f72f667746596d8b960252504d5ef17b4b472268f3f794e60b857fbc59803
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7a8070d70aa969ced7635ffee40e5fe7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102707#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102707#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102707
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102708
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectSearch.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 349bcee74e32a7bab7d4cdb22bf3a921a2929c08
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1f7e7dc2b54cbc88967d5235ecb1bf16d60fdf690b1d3080836a7e498d960f90
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e97f36f7cc4d0a820efac29697a263f7
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102708#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102708#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102708
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102706
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectDetail.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 59b9afac830dd7182e31b3f6e11a6909e4f43bee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: eed28f4fff13ea8b7ca2f3a295eb21e7be27b15959817427e654f3f7edb5f25e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: f51575779a9db58477397f7fcebe0e32
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102706#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102706#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102706
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102704
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectList.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3f4ea085fc40dae60e0cb88fce1c95d224e03b63
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 14c063c870482a8f7ba3db6b91a75311b52b07bcbf6e0f257c3465a9dca00b88
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9531dba5bebb20800e94ae950936bd51
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102704#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102704#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102704
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102705
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectDelete.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6e8f653e95d1649c1eccbe22183d39d684e4b95a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 66e1cf2c3f76af67188b0e9d59577c88c7e52149fb82253f3bdb4f2510302d8c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6ede2e60b009b73b2908ce49aadd3a32
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102705#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102705#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102705
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102703
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0149666ea757d01f07c1bb130a9051c9627965c5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d330c0258a53999780a9c7fe21fc9d4e445eaa8ff6b9951a9bd4156eae4b3e90
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d6eb50abec3cdd73808a563b28c14983
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102703#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102703#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102703
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102701
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectWorkflows.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: aa7bac348d65d5ac5365f33f86eccae2b22a0f9e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b282fe5b8f1c37a040f882e153006ed142fe7e3fe2b2dfe8127c8a4790055c18
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0eac03c13267f913de4c3e931e8111c1
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102701#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102701#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102701
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102699
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f74a673b1897974e610850e25775c4295a6992c8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f3a88e72b0def4a1e31e4938c0201feefbce1990d6d92de5a432b09e496255ce
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bfbcd11068672d86a23a50ed9464f789
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102699#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102699#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102699
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102696
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/preferences/selectors.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3f4a212577951fe5b2e80df0ad3f80f6e51a5303
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 71e6b0a857b691fcef657cd379657ccabd5427addea14416670b71ee2b196a2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 88a07039608c6963b2882b3bdea66338
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102696#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102696#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102696
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102694
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/preferences/fixtures.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6008fc480de3e185b052651352c6340d261f4ff9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9861ce4cecfc0685e1e0143ac6e2aa1e19614a989254a4b22dbeefa7842866c2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 738c577ac2268c740b204a4f078f52d5
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102694#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102694#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102694
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102702
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 581823408a565a4ce301d3550207654d777f0544
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8dbb770c7e68b1dd957e90e4ec1dc46bdb1dc3086f876f0dfdb232abba74454b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a206f551003df3992ec288f054043ffb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102702#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102702#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102702
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102700
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/projects/projectCreate.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4104c990cc31543b3caefc87aa960ef320e8c91
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0f89bb9a30246e7aed03cbeee690332b36ec12fc96a6fc0f0d946f980c949ba7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d18209b16643adb64ef2495d494ffa20
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102700#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102700#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102700
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102697
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/preferences/preferencesPage.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e5ad2f7b9e062ff30669d0ee7bedce41e0552a87
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1af77196479dd031a030699d2d668d56db9763e157a47552299be609d161ec53
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1ca24fcb22e5ab3c56ffcd39780b1654
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102697#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102697#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102697
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102695
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/preferences/utils.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4aedf7b93162726c6a5512219d795f397cacdb43
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: dcac2dc40d8407c7a67eb839a216647bf03d89da33ac8c7290c38310308df820
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 98d42ffffcefa25668e9ff8fe7c582bb
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102695#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102695#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102695
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102692
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/e2e/requests/requestsPage.test.ts
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 4baee9fed2788a93c93b8e0b20290159f9ac8613
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fadccf997637ae1d73e542bdefc1baea3734d95ec14db0599acdef1677929788
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e0b2564471074a16428c375722794c3b
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102692#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102692#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102692
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: <text> Copyright (C) Siemens AG, 2026. </text>
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102632
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/LICENSE
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: cc1b9f6357720c4005d01f48196e732e6f2415ad
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8c349f80764d0648e645f41ef23772a70c995a0924b5235f735f4a3d09df127c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2dd765ca47a05140be15ebafddbeadfe
+type: simplelicensing_AnyLicenseInfo
+spdxId: SPDXRef-item361102632#EPL-2.0
+creationInfo: creationInfo1
+
+
+type: Annotation
+spdxId: SPDXRef-item361102632#EPL-2.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102632
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102631
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/package.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 633ae88fdf1a16dec6a1959a5f1a960dc248912c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0830b19a31fa15f1555acf33966b13ccdf42de2c6df99b8bb97748c71574f6f0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5961035f963c0a1e86dc19c09d8dddb0
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102631#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102631#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102631
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102633
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/CODE_OF_CONDUCT.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f2c9ebbddc2719b61223d5bb0d6233f27675580f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d0ae84775d18becdd39da76a1958433dfb68fee27f94aa29850e61205521134a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 43dc3873c8c484e47a30a780c7756e35
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102633#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102633#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102633
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102636
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/dependabot.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 991e22c8a9d3b9facb725f883b8418174b6aff7b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: af15d4a48c95e9e179653af81e881c19b1712a2a1da058d1ef36a2f197d7f2eb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 64d3f560dc0769a68f3ba75e7f0ba617
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102636#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102636#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102636
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102637
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/CODEOWNERS
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 14f2582e2a1f8980ad006554dce22c0a68b79206
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1e6711ef3b03e20db4c46a1e66ffde6bc1d837bb7032ac76af383d72c05bcfc2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a9554fe25ade546643dcdd65118a28d0
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102637#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102637#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102637
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102642
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/dependency-review.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0c6b5846436976f5d6ebf5b598a5eb299ce0f7f7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1afa9af86bd4ab1dd5fdd7b22473dc85d9f307e0e8a07d328c0fa4a3f1788db7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 54d0a501e996e07224635e6a30edf1b9
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102642#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102642#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102642
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102645
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.github/workflows/codeql.yml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7dae10911fe48fa8d546db78045962320fb79aed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 397e7f9176511b5aea51bb88550193b7521434f325201f9b22c3610027b1b5eb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 9c9e08fdf2fe437bde9114665115f114
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102645#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102645#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102645
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102651
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.dockerignore
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 468ae7f358af71c0e774bc01d7feb24f9bc18ef6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2a1534f7b8a1b46c998007bf2d8b27fb38b811568842991a7ba138ae4a6c120d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 317555da85895d1343122916cd4b584f
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102651#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102651#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102651
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102663
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.gitignore
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 951b0df3f85e87f6ae0532988840a529acb4d159
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4b77c3e21bce9626ea333369a2d6236d7bd25345f01ecf8107a59627eceff229
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a81bd4e8abf558ac019a2bbcb4fd91c
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102663#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102663#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102663
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102665
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/.gitignore
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 12ca9bc214fead8720fda376b1decbad71603ab8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0c4bd97f2c2afca116a37fc48ebf5fb1dbaa164722cbfef0d14a42590a17cb59
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 15c7f46baf6b957efd04634ed3a1cedd
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102665#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102665#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102665
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102669
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/tests/README.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9ebf184a338adf66e6d46bb9806982afa9142a2d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 729bcbf080316628e2b9deb45ab62544589fb3cf51a96abb95f40cbded116cc2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ae0fd9bc5cf0013fea07373887bafe5d
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102669#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102669#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102669
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102773
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress.env.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1b09807f278c0d88ecd83dea1e9230a3ad931e70
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1789feca889c3cccc1f9cee713d75b8aaf31cc61b6a29902f51c56c8cbd4fb41
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: adc01a1e9f925b9b0a68c93bbdf63146
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102773#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102773#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102773
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102778
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/licenses/update.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a0865531f8e567c0361135756ba197716bba9fab
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 565e6edda5784c6fe1119b33ad632e54dde4024de8138aee1e66affbc563607f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0f81cee564b05f4d7064b1b17a6f745a
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102778#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102778#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102778
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102779
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/licenses/delete.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8aea1f27ba5b9f48f6e64ca49d0ec27fc8c0d7b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d54acbcc44e74bdf28748410b51df8eac0d80f323d531f2cf51f2afe1898f394
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 993b8ff8831f762afe45c479bb86063b
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102779#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102779#Apache-possibility
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102779
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102780
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/licenses/register.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e0dad797ce79aa3d1ceda1d8f908bb07ef6c38fa
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 012e75e2f23f0299ad95efe5dfc0c845f51872dd5c177731f479e4581429a0bb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e5a9179734491272722696a53f2fb181
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102780#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102780#UnclassifiedLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102780
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102782
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/update.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0b23dd0b5f996e6cf226eec10e8ed463b2afaaa6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 44e40ed03671fcf58869198c4daec8945faef2c24456785133774a1edc67e0cb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 1ca6881144e722e35e41db5a2247f2ba
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102782#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102782#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102782
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102783
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/link-to-project.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 64872c18d5f33a3207c93ea1b935c2c0f0c731c0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a403734fcb2693aba4dd2d01e6dc83cf0ed6d2ec237a8fe4965ba38b719fb299
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4cbdcf132714b3813666a68ef7cf113d
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102783#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102783#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102783
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102785
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/attachments/sample.xml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e6a4e37ba18e41439a54f9a2d0d324b921e9494a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: d068bb0eceb25bdacb29a58588ee213b629f42ee5f55362673ef78cbe7aa15f1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 2361d9ec60910b1b57cae5133b6e3d05
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102785#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102785#CC0-1.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102785
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102786
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/attachments/attach2.txt
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: da39a3ee5e6b4b0d3255bfef95601890afd80709
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d41d8cd98f00b204e9800998ecf8427e
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102786#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102786#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102786
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102787
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/attachments/attach1.txt
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: da39a3ee5e6b4b0d3255bfef95601890afd80709
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d41d8cd98f00b204e9800998ecf8427e
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102787#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102787#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102787
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102788
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/releases/register.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c4079d64b168152d9e757665ad983edcc8a0e324
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9ab0a506f6526573bcdc1156c4f1ace4ca752e8c884ebd42363311050c556196
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5ff81eb2ddb3dcb26bf3080703524656
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102788#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102788#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102788
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102789
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/sw360_users.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b899c5dbaa76e353d5cba0934999d6b89c16dbed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0c604fa46bcf8bd5ec8714c0ab5f7817e418e708c6254935095e9f42e871f19e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a405097a6aa66287b812f67f0b1b5a8
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102789#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102789#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102789
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102791
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/update.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 489bb82df497e9b0247b7e66992fede20e07f2a2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 544a72414fde708138286c0202eefb42a34c3fe6451915adbbe594c03518ed63
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5155993e082782ad11f0319a00ddd4c2
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102791#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102791#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102791
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102792
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/delete.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 92892aa574d855610c67f34e0a1b277ef1fad95c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7ce1fcb9497468f606b3e4f7bc35d828edd6076789a9da24e3493f8b127ddef2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 7bdae385ddde0dd4c3b3272a0f44ddd4
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102792#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102792#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102792
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102794
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/attachments/test-import.spdx.rdf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a90ad01f9f43a74f7cdfb7e8565ef8b0750a13f8
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4aefb53b745c987ed3d2823729319840c463e4bc610abad55821e0af0f6246c5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 746372a743ca33b9da5755a64f79faa4
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102794#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102794#CC0-1.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102794
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102795
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/attachments/test-import.spdx
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 19c98bba78983e7409219be2da4bc99ed6a5fb85
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0398944d58d9d91edba32a5a878e85a18ad2a35798e3f3fb43b8b35c6a23af3b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fc8c7c0bccc0fb7a873a1435861749fb
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102795#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102795#CC0-1.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102795
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102796
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/attachments/attachment2.txt
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: da39a3ee5e6b4b0d3255bfef95601890afd80709
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d41d8cd98f00b204e9800998ecf8427e
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102796#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102796#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102796
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102797
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/attachments/attachment1.rdf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3a9442fb8994abf6beb04c7e80dedb168c697f6d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 9caca328e0330907fd8ff50b9c2e4127ccb5f2af95d02f9e72afbf35267461f2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0e599beda20de1382b490e315b8d1161
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102797#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102797#CC0-1.0
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102797
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102798
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/import-spdx.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 53b9541c4aab82ef51c7b528ad24266264016741
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b910c202e7266f0e8430062daae161e5787f6a21f7498dcd04e19c18a9fce341
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8d5a58236463d88161b7d1fbcaa0ca0c
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102798#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102798#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102798
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102799
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/components/register.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: af5e6161d562df999da70a4d95c7abad4de73938
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: c6b451d2cba642fa6236f8f4e8accb53d8fff2321ddacda31bfd3ca68fee8ceb
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4f0f296ba197cb8349a744a0eb9aea00
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102799#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102799#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102799
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102800
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/fixtures/oauth-client.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8495da2bb08e2ffd294a70d49c20ae6d96ef4615
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 30898b18cd2001903d5bae6ec4ce451f2ea52bf530b7ac449f9e4603abd5e430
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 0ac4fc47c8e7a5093a8ac73be1e1fedd
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102800#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102800#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102800
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102801
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/tsconfig.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a063b1317e04e5f1dfb08150c642c810c109fb42
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1373364dce1fb11858a4e0b3c9606bb40fc2bc2c2ae795830b0efc2ddd6cc516
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: fae7344a6257c493ff81da6397a7a45d
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102801#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102801#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102801
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102802
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/cypress/README.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 363ce311a5cbf327a1beea02dc5c4d765643f308
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e86ab3672c05b6e5f741b1bbe64e82aeaad30945572a74bd7dd0762def85ac7c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ba45c479eb36051dbbaea9f1af845753
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102802#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102802#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102802
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102832
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.claude/CLAUDE.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f7a82d5d67bc29503ec6887cb5c3baa18ccb49c3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7be87c09e0602e570995d58f83570854accc5e7c7076f32d97ef1c3146462a97
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 262aa400b39af2fc06f47ba09019d712
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102832#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102832#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102832
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102833
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/biome.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: fc2090e338f415af882574419e208380c5997e6a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 87ab16fbfe6f3c87b979710eeeebbbf84720e3d9f90f3f672f59258d893878d0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a3be6892539daa484ab5a234fce76aba
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102833#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102833#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102833
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102837
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/pnpm-workspace.yaml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: d3bb451ea0996184c2ecf694980862bcd510d5f4
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4f9357a3d94ef15fe1716863414ce59479b1bf514dd891ef85b22531fee6fd6e
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d5976693b6d8cc1f360c555ecf594ade
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102837#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102837#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102837
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102841
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.husky/pre-commit
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 84ec86a703a42fec29a04e50b02420640e0b88ed
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4a342a5b02f494d66255dbdf928d1ed35de2400e1df99014f56cb2bbf7eb15e7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 5a20af023443b84e236a7841cccb0fe1
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102841#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102841#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102841
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102842
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.husky/commit-msg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 6742f5c1e6e6b5f9de7fddcd7955cccb2cec80b1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 123237fb24ec0f91fddd6e1ad1642c210a302a3e8f3dffb7005fa631eb5d3b02
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a6b3d9079377e70e070116175f2f569e
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102842#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102842#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102842
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102844
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/public/favicon.ico
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 750e1d3d2ea2af9d8998fa7b9f1daa723b5496dd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 5d49e5774982c596546c6585c306116487ff09cc4cd81e60373df3fef2f564e0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 4b7f1bd43c3595ed77193f098ee8687d
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102844#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102844#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102844
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102846
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.copilot/prompt.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 3e74ecd71dcd967aec124e92c32bea343cf578e9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 6ede46ea69ac7bbf1ca6679fa116de2ff2995c369ef4bd4776da9470f6bffcee
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 6fd5b4e24b393e8e6994f2b5d29390bd
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102846#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102846#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102846
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102847
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/sw360-frontend.code-workspace
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f4fe8fcf44e8985e9e65a73b217d0200d1f38428
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 528bddd845d4cb52d864a8f229962b4f55e66e05c3b136ca50c0e7e711e77f64
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 3e108da9a27c5394d8b837a2fff8df63
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102847#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102847#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102847
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102851
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/postgres/postgresql_password
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0cffe229b1a49fa2d0fce1fd89b88ab186c0a050
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: fb0f65bad4dc6f57274d18f5296dd44c5709f29dfed319d8b42ffd760360aa00
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: cb80ed1fe338e2aaf75b1b23690979c4
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102851#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102851#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102851
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102854
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/sw360/jwt-keystore.jks
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: b5353658793b1e84d57f29eee5491315369a5782
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 163c549825e16ad2ef1bd7dfda5000a067aee8e0e9bf04d56e36f74830b88498
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c13bc5faa666e4e3472d8ffd2c7bea19
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102854#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102854#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102854
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102855
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/sw360/default_secrets
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: bc65cb5dec3b065d118c5cd375256cccc372e7ac
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: f46235989a51ec4705b37e48218b57140e722c79337bb8555383b17dac14f597
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 38564d4cf6256d03366fb175ff6bd345
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102855#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102855#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102855
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102857
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/front-end/nextauth_secret
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 073fda36187bb3da26374068f0a6667f61eb2f5a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 49b66572878e007e29425c5bd75820c91629333cd456c53b43d32d9d51d760f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ea3c2980a86bdca207374b99572dfda2
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102857#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102857#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102857
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102858
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/front-end/sw360_frontend_kc_secret
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a8c2c6c114d056b50ac9f27743f4e7ffd76d3a28
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 4434223279a4f1fd20bb9172fa05191c18c28066daa10a433f52bc09a7dc9b2b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 44170812866948c2097bc6fa64d18006
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102858#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102858#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102858
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102865
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/couchdb/sw360_log.ini
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: c34355acfab7212b3e012d464612ca228e2b6864
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 509dbf11e1cc38e88d761a5b629e6897a02420a126aa599bc072f3e21d2b7cb1
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: da684388a2c399dc135811c9c9d0d59b
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102865#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102865#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102865
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102866
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/couchdb/nouveau.ini
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: f26cdf754d0d9db2041cddcb6777b638e59dbf17
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 97b8b15907643e87dc5ecf62da617d177c9203fd5adf9900a25a562dd686ef2c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a805b6755f92ba6d8c8a46ff64704eb2
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102866#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102866#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102866
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102867
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/couchdb/sw360_setup.ini
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 5ea979906b85818c2d772ff7414c30bea7568b98
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 19362747432b01215a44aa3d8e53df4ca07d572d87db651853b4e444dd06722d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 548392cdd2ab77be85a3c83a7478c58b
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102867#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102867#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102867
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102868
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/couchdb/default_secrets
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a1d114bc349f2517a051a690e149aba4427848e5
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 214d115c13ea1c7ec105ce7797816409fbcf796342b669be5ae4621d04747409
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8e8d9cd303189567b80fee9fb0ddc670
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102868#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102868#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102868
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102870
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/nginx/rev_proxy.template
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 2caa6aeae9292aa7e51f9b7513b94520210c01c3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 27bb34194dfcecf78e529ce6264658889d17390728ef4001f5bd80cc9f1fe53c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e64bcb303bc82d8fc3dff83f06e1b298
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102870#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102870#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102870
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102871
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/config/nginx/proxy_params
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ca37199fb22bafe8484641ae927dd75274d5f403
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 1561e753e5a08fd7b21914be115c39b98684f329d7e802c95d0f800cc56e52fd
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 029eab8bc724025e1ed6aae639173e83
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102871#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102871#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102871
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102873
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/README.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: ec9bf24ffe9086b0dedd8a95bbaebae1bd25431c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b2dc9d1b034bdfce51cb4d77ac4ce11e262cacebb284dc4c550a8c866ea892a
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: bdfcc34dcd4873a12989ce11d210c186
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102873#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102873#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102873
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102874
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/README_DOCKER.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: e5ee14eaaf44ca8e6c290030a897339774d83b53
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: e3a0554db9f3cf0baf1259a81f4f2b2f33e1cf2f69ab896b94dc46be279eee24
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c2e8bff347a7ef588c0c676d9c3e2953
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102874#NoAssertionLicense
+creationInfo: creationInfo1
+
+type: Annotation
+spdxId: SPDXRef-item361102874#Public-domain
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102874
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102875
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/pnpm-lock.yaml
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 1509352c9d3c83f0fd7b6f5b2672845041d9e868
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b1f3af04fd476b306bcbedd6def4b273f21692aa36ef57e03287e071823101f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b4922acec7dd69f8b0a95b3b65fbac0e
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102875#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102875#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102875
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102907
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/order-arrow.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 9949fda8d802959ba6bb00c60aa44fe4f50b2139
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 896adc2ae13c87a5360a9de72de2b4aa4e1eabb96abe1cae78c00fe0d4111282
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: ad1d58795c7b633efb69c2a5a9fbd8ac
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102907#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102907#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102907
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102908
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/icons.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 42ef0d4eb91ac20afd0ddf0161fb2dabd86950d2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 7e7f33e37a876f03c2b8e6e6bf27bab33ac6037e670070af415b5de4c07748b9
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 43338e6da1bbbea4145508730070f8e4
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102908#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102908#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102908
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102909
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/order-arrow-down.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 8c9f9699507e1cd9bdf7bd631feca188be65793b
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 54966b1acfa1530142503f3a7b47ef98268b11615c59dc8b6ff0229e2fe5c2a3
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 8d30054fe04465a7ff8cc7e6c7189d82
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102909#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102909#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102909
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102910
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/order-arrow-right.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 66b8f558d80307b6f3a0ebcc6e2f4593cd78ffc2
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 0dd7f9ed8c085301fb9153eb58ba4f30f2d765812dfabee4d754788582afe1f6
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 701fe8701017e64b5227d48a44122aa0
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102910#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102910#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102910
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102911
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/search.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 273e26dd51d3d2c06e4b240dbc43f9c594d11d5f
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 22e8d71f045f47a98b7db2002b017cb71ba73b7f5ab3ca3794ace133eb62a537
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: c5e0453d78ae5a3b3c192f90c19470b3
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102911#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102911#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102911
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102912
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/order-arrow-up.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 0420ccb17a17e64b9f5d4427b3d25fa271ffe0bf
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 30c19be0e10e8daf447876d245c47280bef667b4b97d095228c9531db3b2f6c7
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 48eac1e9f6d3389d4a0423d04b479b20
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102912#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102912#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102912
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102913
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/trash.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: a3212acbaa17044921c745148433531e8e8d89b0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 2fbe6453ec191010ca02fbbb61471101368ead2f2f92bd49011c8ebfeb4634f0
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: a7784916401423e950d619ea489f4872
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102913#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102913#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102913
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361102914
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/src/assets/icons/order-arrow-left.svg
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 58e6275ad55134962d3cd2ec1354bf13ec306d66
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: a9da5cbcfc6c27053f94333999f2ad415846b1a02d9fa65c31ffd32acc705c90
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: b8504ab0fee02d9c54f10609ba61675b
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361102914#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361102914#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361102914
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103746
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/SECURITY.md
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 7f738877fe57b9178c1276be7852bcae8017b64d
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: b22f71e29c2eb716251d3d855423a4aeea93b27a0711c9c1eb0ecc7ad145ab56
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: d038b1a4c860843bf68f08249343505a
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361103746#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361103746#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103746
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103748
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.vscode/launch.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: 30d9c42669c6e6815ccd9726b53a8c0d0b3c754c
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 8b8eb6175af897bfc9314ddd20a248286b2ff3c1d4f508a59bf4127103860301
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: e28bf3dadd0b87f34c9c2cd7a76017c5
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361103748#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361103748#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103748
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+##--------------------------
+## File
+##--------------------------
+
+type: software_File
+spdxId: SPDXRef-item361103749
+creationInfo: creationInfo1
+name: sw360-frontend-1.0.0.zip/.vscode/settings.json
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha1
+verifiedUsing.hashValue: dae80ce707794f789259af1f6ae65fa005083884
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: sha256
+verifiedUsing.hashValue: 3a99ade3920457c153ced263bee1deaac0b2a8629d7100f3546ee362a3211591
+
+verifiedUsing.type: Hash
+verifiedUsing.algorithm: md5
+verifiedUsing.hashValue: 306b7058e59a74ddc24a040401368d33
+type: expandedlicensing_IndividualLicensingInfo
+spdxId: SPDXRef-item361103749#NoAssertionLicense
+creationInfo: creationInfo1
+type: Annotation
+spdxId: SPDXRef-item361103749#NoAssertionLicense
+creationInfo: creationInfo1
+annotationType: other
+subject: SPDXRef-item361103749
+statement: SPDX 2.X LicenseInfoInFiles
+
+software_copyrightText: NOASSERTION
+
+
+
+
+##---------------------------------------
+## Package-File Relationship Information
+##---------------------------------------
+
+type: Relationship
+spdxId: SPDXRef-Relationship-0
+from: SPDXRef-upload89931
+
+relationshipType: describes
+creationInfo: creationInfo:creationInfo1


### PR DESCRIPTION
Cleared SW360 Frontend using FOSSology and generated this SPDX report containing all the Licenses and Copyrights found in the repo.

Note: This report is manually curated.