### PR TITLE
fix(Project): Update button lable name

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "Lizenzvereinbarung",
     "LINKED PACKAGES": "VERKNÜPFTE PAKETE",
     "LINKED RELEASES": "VERKNÜPFTE VERÖFFENTLICHUNGEN",
+    "LINKED PROJECTS": "VERKNÜPFTE PROJEKTE",
     "LOCAL": "LOC",
     "LOW": "NIEDRIG",
     "Language Element": "Sprachelement",

--- a/messages/en.json
+++ b/messages/en.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "License agreement",
     "LINKED PACKAGES": "LINKED PACKAGES",
     "LINKED RELEASES": "LINKED RELEASES",
+    "LINKED PROJECTS": "LINKED PROJECTS",
     "LOCAL": "LOCAL",
     "LOW": "LOW",
     "Language Element": "Language Element",

--- a/messages/es.json
+++ b/messages/es.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "Acuerdo de licencia",
     "LINKED PACKAGES": "PAQUETES VINCULADOS",
     "LINKED RELEASES": "LANZAMIENTOS VINCULADOS",
+    "LINKED PROJECTS": "PROYECTOS VINCULADOS",
     "LOCAL": "LOCAL",
     "LOW": "BAJO",
     "Language Element": "Elemento de lenguaje",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "Contrat de licence",
     "LINKED PACKAGES": "FORFAITS LIÉS",
     "LINKED RELEASES": "COMMUNIQUÉS LIÉES",
+    "LINKED PROJECTS": "PROJETS LIÉS",
     "LOCAL": "LOCAL",
     "LOW": "FAIBLE",
     "Language Element": "Élément de langage",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "ライセンス契約",
     "LINKED PACKAGES": "リンクされたパッケージ",
     "LINKED RELEASES": "リンクされたリリース",
+    "LINKED PROJECTS": "リンクされたプロジェクト",
     "LOCAL": "LOCAL",
     "LOW": "低い",
     "Language Element": "言語要素",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "라이센스 계약",
     "LINKED PACKAGES": "연결된 패키지",
     "LINKED RELEASES": "연결된 릴리스",
+    "LINKED PROJECTS": "연결된 프로젝트",
     "LOCAL": "계정 정보",
     "LOW": "낮은",
     "Language Element": "언어 요소",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "Contrato de licença",
     "LINKED PACKAGES": "PACOTES VINCULADOS",
     "LINKED RELEASES": "LANÇAMENTOS VINCULADOS",
+    "LINKED PROJECTS": "PROJETOS VINCULADOS",
     "LOCAL": "LOCAL",
     "LOW": "BAIXO",
     "Language Element": "Elemento de linguagem",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "Thỏa thuận cấp phép",
     "LINKED PACKAGES": "GÓI LIÊN KẾT",
     "LINKED RELEASES": "PHÁT HÀNH LIÊN KẾT",
+    "LINKED PROJECTS": "DỰ ÁN LIÊN KẾT",
     "LOCAL": "ĐỊA PHƯƠNG",
     "LOW": "THẤP",
     "Language Element": "Yếu tố ngôn ngữ",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "许可协议",
     "LINKED PACKAGES": "链接包",
     "LINKED RELEASES": "链接版本",
+    "LINKED PROJECTS": "链接项目",
     "LOCAL": "当地的",
     "LOW": "低的",
     "Language Element": "语言元素",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -775,6 +775,7 @@
     "LICENSE_AGREEMENT": "授權協議",
     "LINKED PACKAGES": "連結包",
     "LINKED RELEASES": "連結版本",
+    "LINKED PROJECTS": "連結項目",
     "LOCAL": "本地",
     "LOW": "低的",
     "Language Element": "語言元素",

--- a/src/app/[locale]/admin/users/edit/page.tsx
+++ b/src/app/[locale]/admin/users/edit/page.tsx
@@ -73,7 +73,7 @@ const AdminEditUserPage = (): JSX.Element => {
                 })
                 setIsUserDeactived(user.deactivated === true)
             } catch (e) {
-                console.error(e)
+                ApiUtils.reportError(e)
             }
         })()
     }, [
@@ -104,7 +104,7 @@ const AdminEditUserPage = (): JSX.Element => {
                 MessageService.error(t('Something went wrong'))
             }
         } catch (e) {
-            console.error(e)
+            ApiUtils.reportError(e)
         }
     }
 

--- a/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedProjects.tsx
+++ b/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedProjects.tsx
@@ -238,7 +238,7 @@ export default function LinkedProjects({ projectPayload, setProjectPayload }: Pr
                             paddingLeft: '0px',
                         }}
                     >
-                        {t('Linked Projects')}
+                        {t('LINKED PROJECTS')}
                         <hr
                             className='my-2 mb-2'
                             style={{

--- a/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx
+++ b/src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx
@@ -321,7 +321,7 @@ export default function LinkedReleases({
                             className='btn btn-secondary'
                             onClick={() => setShowLinkedReleasesModal(true)}
                         >
-                            {t('Link Releases')}
+                            {t('Add Releases')}
                         </button>
                     </div>
                 </div>

--- a/tests/e2e/projects/projectCreate.test.ts
+++ b/tests/e2e/projects/projectCreate.test.ts
@@ -179,7 +179,7 @@ test.describe('Projects - Create', () => {
 
         // Switch to Linked Releases and Projects
         await clickFormTab(page, 'Linked Releases and Projects')
-        await expect(page.getByRole('button', { name: /link releases/i })).toBeVisible()
+        await expect(page.getByRole('button', { name: /add releases/i })).toBeVisible()
 
         // Switch to Linked Packages
         await clickFormTab(page, 'Linked Packages')

--- a/tests/e2e/projects/projectWorkflows.test.ts
+++ b/tests/e2e/projects/projectWorkflows.test.ts
@@ -216,12 +216,12 @@ test.describe('Projects - Export Spreadsheet', () => {
  * Projects — Linked Releases and Projects tab functionality.
  */
 test.describe('Projects - Linked Releases and Projects Tab', () => {
-    test('TC82: Linked Releases tab shows Link Releases button on add page', async ({ page }) => {
+    test('TC82: Linked Releases tab shows Add Releases button on add page', async ({ page }) => {
         await gotoProjectsPage(page, 'add')
         await page.getByText('Linked Releases and Projects').click()
         await page.waitForTimeout(500)
 
-        await expect(page.getByRole('button', { name: /link releases/i })).toBeVisible()
+        await expect(page.getByRole('button', { name: /add releases/i })).toBeVisible()
     })
 
     test('TC83: Linked Releases tab shows Add Projects button on add page', async ({ page }) => {
@@ -232,13 +232,13 @@ test.describe('Projects - Linked Releases and Projects Tab', () => {
         await expect(page.getByRole('button', { name: /add projects/i })).toBeVisible()
     })
 
-    test('TC84: Link Releases button opens search modal', async ({ page }) => {
+    test('TC84: Add Releases button opens search modal', async ({ page }) => {
         test.setTimeout(60000)
         await gotoProjectsPage(page, 'add')
         await page.getByText('Linked Releases and Projects').click()
         await page.waitForTimeout(500)
 
-        await page.getByRole('button', { name: /link releases/i }).click()
+        await page.getByRole('button', { name: /add releases/i }).click()
 
         const modal = page.locator(selectors.common.modalShow)
         await expect(modal).toBeVisible()


### PR DESCRIPTION
### Summary
Fixes incorrect/inconsistent button and section labels on the project summary page:

* Renamed the "Link Releases" button to **"Add Releases"** in [LinkedReleases.tsx](src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedReleases.tsx#L324) to better reflect the button's action.
* Replaced the hardcoded `Linked Projects` label with the translation key `LINKED PROJECTS` in [LinkedProjects.tsx](src/components/ProjectAddSummary/component/LinkedReleasesAndProjects/LinkedProjects.tsx#L241), consistent with the existing `LINKED PACKAGES` / `LINKED RELEASES` keys.
* Added the new `LINKED PROJECTS` translation key to all 10 locale files under [messages/](messages/en.json).

### Issue: https://github.com/eclipse-sw360/sw360-frontend/issues/1979

### Suggest Reviewer
@amritkv 
