### PR TITLE
fix(Release): Ecc info hover text

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -789,6 +789,7 @@
     "Last update": "Letzte Aktualisierung",
     "Lead Architect": "Lead Architect",
     "Learn more about ECC statuses": "Erfahren Sie mehr über ECC-Status",
+    "Learn more about Cryptotechnology": "Erfahren Sie mehr über Kryptotechnologie",
     "Learn more about clearing request priority": "Erfahren Sie mehr über die Priorität von Clearing-Anfragen",
     "Learn more about clearing request status": "Erfahren Sie mehr über den Status der Löschanforderung",
     "Learn more about clearing request type": "Erfahren Sie mehr über den Clearing-Anforderungstyp",

--- a/messages/en.json
+++ b/messages/en.json
@@ -789,6 +789,7 @@
     "Last update": "Last update",
     "Lead Architect": "Lead Architect",
     "Learn more about ECC statuses": "Learn more about ECC statuses",
+    "Learn more about Cryptotechnology": "Learn more about Cryptotechnology",
     "Learn more about clearing request priority": "Learn more about clearing request priority",
     "Learn more about clearing request status": "Learn more about clearing request status",
     "Learn more about clearing request type": "Learn more about clearing request type",

--- a/messages/es.json
+++ b/messages/es.json
@@ -789,6 +789,7 @@
     "Last update": "Última actualización",
     "Lead Architect": "Arquitecto principal",
     "Learn more about ECC statuses": "Más información sobre estatus de ECC",
+    "Learn more about Cryptotechnology": "Más información sobre criptotecnología",
     "Learn more about clearing request priority": "Obtenga más información sobre la prioridad de la solicitud de compensación",
     "Learn more about clearing request status": "Obtenga más información sobre el estado de la solicitud de compensación",
     "Learn more about clearing request type": "Obtenga más información sobre el tipo de solicitud de compensación",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -789,6 +789,7 @@
     "Last update": "Dernière mise à jour",
     "Lead Architect": "Architecte principal",
     "Learn more about ECC statuses": "En savoir plus sur les statuts des CEC",
+    "Learn more about Cryptotechnology": "En savoir plus sur la cryptotechnologie",
     "Learn more about clearing request priority": "En savoir plus sur la priorité des demandes de compensation",
     "Learn more about clearing request status": "En savoir plus sur l'état de la demande de compensation",
     "Learn more about clearing request type": "En savoir plus sur le type de demande de compensation",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -789,6 +789,7 @@
     "Last update": "Last update",
     "Lead Architect": "リードアーキテクト",
     "Learn more about ECC statuses": "Learn more about ECC statuses",
+    "Learn more about Cryptotechnology": "暗号技術についてもっと詳しく",
     "Learn more about clearing request priority": "リクエストの優先順位のクリアについて詳しく見る",
     "Learn more about clearing request status": "リクエストステータスのクリアについて詳しく見る",
     "Learn more about clearing request type": "リクエストタイプのクリアについて詳しく見る",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -789,6 +789,7 @@
     "Last update": "마지막 업데이트",
     "Lead Architect": "지도 건축",
     "Learn more about ECC statuses": "ECC 상태에 대해 자세히 알아보기",
+    "Learn more about Cryptotechnology": "암호화 기술에 대해 자세히 알아보기",
     "Learn more about clearing request priority": "요청 우선순위 지우기에 대해 자세히 알아보기",
     "Learn more about clearing request status": "요청 상태 지우기에 대해 자세히 알아보기",
     "Learn more about clearing request type": "요청 유형 삭제에 대해 자세히 알아보기",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -789,6 +789,7 @@
     "Last update": "última atualização",
     "Lead Architect": "Arquiteto de lead",
     "Learn more about ECC statuses": "Saiba mais sobre os status do ECC",
+    "Learn more about Cryptotechnology": "Saiba mais sobre criptotecnologia",
     "Learn more about clearing request priority": "Saiba mais sobre como limpar a prioridade da solicitação",
     "Learn more about clearing request status": "Saiba mais sobre como limpar o status da solicitação",
     "Learn more about clearing request type": "Saiba mais sobre o tipo de solicitação de compensação",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -789,6 +789,7 @@
     "Last update": "Cập nhật cuối cùng",
     "Lead Architect": "Kiến trúc sư trưởng",
     "Learn more about ECC statuses": "Tìm hiểu thêm về trạng thái ECC",
+    "Learn more about Cryptotechnology": "Tìm hiểu thêm về công nghệ mật mã",
     "Learn more about clearing request priority": "Tìm hiểu thêm về việc xóa mức độ ưu tiên của yêu cầu",
     "Learn more about clearing request status": "Tìm hiểu thêm về việc xóa trạng thái yêu cầu",
     "Learn more about clearing request type": "Tìm hiểu thêm về loại yêu cầu xóa",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -789,6 +789,7 @@
     "Last update": "最后更新",
     "Lead Architect": "首席架构师",
     "Learn more about ECC statuses": "了解有关 ECC 状态的更多信息",
+    "Learn more about Cryptotechnology": "了解有关密码技术的更多信息",
     "Learn more about clearing request priority": "了解有关清算请求优先级的更多信息",
     "Learn more about clearing request status": "了解有关清算请求状态的更多信息",
     "Learn more about clearing request type": "了解有关清算请求类型的更多信息",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -789,6 +789,7 @@
     "Last update": "上次更新",
     "Lead Architect": "首席建筑师",
     "Learn more about ECC statuses": "了解更多ECC 狀態",
+    "Learn more about Cryptotechnology": "了解更多密碼技術",
     "Learn more about clearing request priority": "了解有關清算請求優先順序的更多信息",
     "Learn more about clearing request status": "了解有關清算請求狀態的更多信息",
     "Learn more about clearing request type": "了解有關清算請求類型的更多信息",

--- a/src/app/[locale]/components/editRelease/[id]/components/EditECCDetails.tsx
+++ b/src/app/[locale]/components/editRelease/[id]/components/EditECCDetails.tsx
@@ -233,8 +233,8 @@ const EditECCDetails = ({ releasePayload, setReleasePayload }: Props) => {
                                     className='form-text'
                                     id='containsCryptography.HelpBlock'
                                 >
-                                    <ShowInfoOnHover text={t('Contains Cryptography')} />
-                                    {t('cryptoinfo')}.
+                                    <ShowInfoOnHover text={t('cryptoinfo')} />
+                                    {t('Learn more about Cryptotechnology')}.
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Issue: The _(i)_ info popup button text in the "ECC Details" tab in Edit Release page has its pop up text written next to the button, not in the pop-up.

before:
<img width="820" height="331" alt="image" src="https://github.com/user-attachments/assets/2dba8a02-ad58-4fba-83c1-f62ab06569f4" />

after:
<img width="779" height="443" alt="image" src="https://github.com/user-attachments/assets/9b049ff1-7488-4b76-a2cd-38b9f3068c82" />
