### PR TITLE
fix(Fossology): Updating fossology config error msg

### DIFF
--- a/src/app/[locale]/admin/fossology/components/FossologyOverview.tsx
+++ b/src/app/[locale]/admin/fossology/components/FossologyOverview.tsx
@@ -104,7 +104,17 @@ export default function FossologyOverview(): ReactNode {
             MessageService.warn(t('Unauthorized request'))
             return
         } else {
-            MessageService.error(t('Fossology configuration update failed'))
+            try {
+                const errorData = await response.json()
+                const detail = errorData?.message ?? errorData?.detail ?? errorData?.error
+                if (detail) {
+                    MessageService.error(detail)
+                } else {
+                    MessageService.error(t('Fossology configuration update failed'))
+                }
+            } catch {
+                MessageService.error(t('Fossology configuration update failed'))
+            }
         }
     }
 


### PR DESCRIPTION
Description: When saving the FOSSology configuration with an invalid URL, the backend returns a 400 response with a descriptive error message (e.g. "Base URL for API must be 'v2'."), but the frontend was discarding the response body and always showing a generic "Fossology configuration update failed" toast. The fix reads the error detail from the response JSON and displays it directly in the error toast, falling back to the generic message if no detail is available.

Before:
<img width="549" height="188" alt="image" src="https://github.com/user-attachments/assets/37f33100-9dea-43d7-9aa1-6cc421acd87d" />

After:
<img width="1395" height="513" alt="image" src="https://github.com/user-attachments/assets/928dc7a6-823c-4d21-8c71-26cc85113139" />
<img width="1117" height="522" alt="image" src="https://github.com/user-attachments/assets/0794bad6-5883-405d-97ab-10d5a68a817b" />
<img width="1067" height="542" alt="image" src="https://github.com/user-attachments/assets/6ef10d20-c15a-4f9c-b8c8-fcae8b6bfb69" />

