### PR TITLE
fix(Project): Project Mainline State column

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
@@ -455,7 +455,7 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
                     if (row.original.node.type === 'release') {
                         return (
                             <div className='text-center'>
-                                {Capitalize(row.original.node.entity.mainlineState ?? '')}
+                                {Capitalize(row.original.node.entity.releaseMainLineState ?? '')}
                             </div>
                         )
                     }
@@ -470,7 +470,11 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
                 enableColumnFilter: false,
                 cell: ({ row }) => {
                     if (row.original.node.type === 'release') {
-                        return <div className='text-center'></div>
+                        return (
+                            <div className='text-center'>
+                                {Capitalize(row.original.node.entity.mainlineState ?? '')}
+                            </div>
+                        )
                     }
                 },
                 meta: {

--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -42,6 +42,7 @@ interface ListViewProject extends Project {
 interface ListViewRelease extends Release {
     releaseRelation?: string
     path?: string
+    projectMainlineState?: string
 }
 
 type TypedProject = TypedEntity<ListViewProject, 'project'>
@@ -189,6 +190,7 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
                     ...release,
                     path: path.join(' -> '),
                     releaseRelation: l.relation,
+                    projectMainlineState: l.mainlineState,
                 },
             })
         }
@@ -222,6 +224,7 @@ const extractLinkedReleases = (
                 ...release,
                 path: path.join('->'),
                 releaseRelation: l.relation,
+                projectMainlineState: l.mainlineState,
             },
         })
     }
@@ -567,7 +570,11 @@ export default function ListView({
                 enableSorting: false,
                 cell: ({ row }) => {
                     if (row.original.type === 'release') {
-                        return <div className='text-center'></div>
+                        return (
+                            <div className='text-center'>
+                                {Capitalize((row.original.entity as ListViewRelease).projectMainlineState ?? '')}
+                            </div>
+                        )
                     }
                 },
                 meta: {

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -44,7 +44,11 @@ const Capitalize = (text: string) =>
 
 type TypedProject = TypedEntity<Project, 'project'>
 
-type TypedRelease = TypedEntity<Release, 'release'>
+interface TreeViewRelease extends Release {
+    projectMainlineState?: string
+}
+
+type TypedRelease = TypedEntity<TreeViewRelease, 'release'>
 
 const typeFilterOptions: FilterOption[] = [
     {
@@ -194,7 +198,10 @@ const buildTable = (
         const nodeRelease: NestedRows<TypedProject | TypedRelease> = {
             node: {
                 type: 'release',
-                entity: release,
+                entity: {
+                    ...release,
+                    projectMainlineState: l.mainlineState,
+                },
             },
             children: [],
         }
@@ -238,7 +245,10 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
             const nodeRelease: NestedRows<TypedProject | TypedRelease> = {
                 node: {
                     type: 'release',
-                    entity: release,
+                    entity: {
+                        ...release,
+                        projectMainlineState: l.mainlineState,
+                    },
                 },
                 children: [],
             }
@@ -590,7 +600,11 @@ export default function TreeView({
                 enableColumnFilter: false,
                 cell: ({ row }) => {
                     if (row.original.node.type === 'release') {
-                        return <div className='text-center'></div>
+                        return (
+                            <div className='text-center'>
+                                {Capitalize((row.original.node.entity as TreeViewRelease).projectMainlineState ?? '')}
+                            </div>
+                        )
                     }
                 },
                 meta: {


### PR DESCRIPTION
Description: 
Project Mainline State column is always empty in license clearing table in project page.

Before:
<img width="1841" height="536" alt="image" src="https://github.com/user-attachments/assets/30550b42-5191-43e0-b9d4-df9efe2177ab" />

After:
<img width="1555" height="426" alt="image" src="https://github.com/user-attachments/assets/3de657ad-1df4-40b1-8daa-db60a383996b" />
