### PR TITLE
feat(api): Make max page size configurable

### DIFF
--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -357,6 +357,16 @@ The backend container is configured via
 [backend Docker documentation](https://github.com/eclipse-sw360/sw360/blob/main/README_DOCKER.md#environment-variables)
 for the full variable list.
 
+Pagination cap override for backend REST endpoints:
+
+```env
+SPRING_DATA_REST_MAX_PAGE_SIZE=1000
+```
+
+`page_entries` values above this limit are capped by Spring Data REST. The
+theoretical maximum is Java `Integer.MAX_VALUE` (`2147483647`), but large values
+can cause high memory usage and slow responses.
+
 Keep the backend trusted-issuer list aligned with the token issuers used by the
 selected auth provider:
 

--- a/config/sw360/.env.backend
+++ b/config/sw360/.env.backend
@@ -36,6 +36,9 @@ BACKEND_THRIFT_CONNECTION_TTL_SECONDS=60
 # Spring controllers
 #
 ENABLE_DISKSPACE=false
+# Maximum allowed page_entries value for paginated REST requests.
+# Theoretical max: Integer.MAX_VALUE (2147483647); use lower practical values.
+SPRING_DATA_REST_MAX_PAGE_SIZE=1000
 # Trusted JWT issuers. Spring Boot maps these to
 # sw360.security.jwt.issuers[N].{issuer-uri,jwk-set-uri}.
 # *_ISSUER_URI must match the JWT `iss` claim exactly.


### PR DESCRIPTION
Make the max page size configurable with
`spring.data.rest.max-page-size` and pass on the value to Docker setup with `SPRING_DATA_REST_MAX_PAGE_SIZE` environment variable.

Backend PR: https://github.com/eclipse-sw360/sw360/pull/4525