### PR TITLE
chore(ci): Fixed hardcoded pnpm version

### DIFF
--- a/.github/workflows/biome-schema-update.yml
+++ b/.github/workflows/biome-schema-update.yml
@@ -40,10 +40,7 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          # Pinned to 11.11.0: A bare "11" resolves to 11.12.0, whose self-installer
-          # crashes action-setup with "Cannot use 'in' operator to search for
-          # 'integrity' in undefined". Need to Bump once pnpm/action-setup#276 is fixed upstream.
-          version: 11.11.0
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -32,11 +32,7 @@ jobs:
       - name: pnpm-setup
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          # Pinned to 11.11.0: A bare "11" resolves to 11.12.0, whose self-installer
-          # crashes action-setup with "Cannot use 'in' operator to search for
-          # 'integrity' in undefined". Need to Bump once pnpm/action-setup#276 is fixed upstream.
-          version: 11.11.0
-
+          version: 11
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:


### PR DESCRIPTION
The `pnpm v11` was automatically resolving to `pnpm v11.12.0` which had bugs. So, hardcoded the `pnpm` version to `v11.11.0`.
But as of now, the bugs are fixed in upstream, so reverted back to major `pnpm v11`.