### PR TITLE
fix(Fossology): Trigger fossology workflow

### DIFF
--- a/src/components/sw360/FossologyClearing/FossologyClearing.tsx
+++ b/src/components/sw360/FossologyClearing/FossologyClearing.tsx
@@ -321,11 +321,13 @@ const FossologyClearing = ({ show, setShow, releaseId }: Props): JSX.Element => 
                     showMessage(clearingMessages.CLEARING_SUCCESS)
                     return
                 }
+                if (numberOfSourceAttachment.current !== 1) {
+                    return
+                }
                 if (
-                    countDownInterval.current !== undefined &&
-                    progressInterval.current !== undefined &&
-                    progressStatus.percent === 0 &&
-                    numberOfSourceAttachment.current == 1
+                    countDownInterval.current === undefined &&
+                    progressInterval.current === undefined &&
+                    progressStatus.percent === 0
                 ) {
                     handleFossologyClearing({}).catch((err) => console.error(err))
                 }


### PR DESCRIPTION
**Title**  
FOSSology modal does not start workflow on first open due to incorrect trigger condition

**Before Fix**  
- Opening the FOSSology modal only called status check.  
- Workflow trigger was gated by `countDownInterval` and `progressInterval` being already defined.  
- Those intervals are created only *after* trigger runs, so trigger never executed on first open.  
- Result: no workflow start, no meaningful auto-refresh progression.

**Root Cause**  
A circular condition in `useEffect`: trigger required active intervals, but intervals depended on trigger.

**After Fix**  
- Trigger now runs when:
  - modal is open and release is loaded,
  - exactly one SOURCE attachment exists,
  - intervals are **not** running yet,
  - progress is `0`.
- Existing completed/in-progress flows are still respected:
  - `SUCCESS` status does not re-trigger,
  - invalid source-attachment count does not trigger.

**Impact**  
FOSSology workflow starts correctly on first valid modal open, while preventing duplicate/unwanted triggers.