### PR TITLE
chore(Footer): Added deployed frontend repo info

### DIFF
--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -1,4 +1,5 @@
 # Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+# Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
 #
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -84,6 +85,11 @@ jobs:
             org.opencontainers.image.licenses=EPL-2.0
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
+      # Compute short commit SHA so the footer matches `git rev-parse --short HEAD` (7 chars).
+      - name: Compute short commit SHA
+        id: shortsha
+        run: echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Build sw360 frontend build container
         id: build_frontend
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -95,6 +101,8 @@ jobs:
           labels: ${{ steps.meta_runtime.outputs.labels }}
           build-args: |
             NEXT_PUBLIC_SW360_API_URL=https://localhost
+            SOURCE_BRANCH=${{ github.ref_name }}
+            SOURCE_COMMIT=${{ steps.shortsha.outputs.sha }}
           cache-from: type=gha,scope=runtime
           cache-to: type=gha,scope=runtime,mode=max
           provenance: mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+# Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
 
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -17,6 +18,13 @@ ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
 # define build-time args
 ARG NEXT_PUBLIC_SW360_API_URL
 ARG NEXT_PUBLIC_SW360_AUTH_PROVIDER=sw360basic
+
+# Frontend build metadata — .git is excluded via .dockerignore, so pass these
+# from CI (e.g. `docker build --build-arg SOURCE_BRANCH=$(git rev-parse --abbrev-ref HEAD) ...`).
+ARG SOURCE_BRANCH
+ARG SOURCE_COMMIT
+ENV SOURCE_BRANCH=${SOURCE_BRANCH}
+ENV SOURCE_COMMIT=${SOURCE_COMMIT}
 
 # define run-time args
 ARG NEXTAUTH_URL=http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,13 @@ services:
         NEXT_PUBLIC_SW360_API_URL: ${NEXT_PUBLIC_SW360_API_URL:-https://localhost}
         NEXT_PUBLIC_SW360_AUTH_PROVIDER: ${NEXT_PUBLIC_SW360_AUTH_PROVIDER:-sw360basic}
         NEXTAUTH_URL: https://localhost
+        # Footer build metadata. Export SOURCE_BRANCH/SOURCE_COMMIT in your shell before
+        # `docker compose build`, e.g.:
+        #   export SOURCE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        #   export SOURCE_COMMIT=$(git rev-parse --short HEAD)
+        # If unset, the frontend footer will display 'unknown' (build still succeeds).
+        SOURCE_BRANCH: ${SOURCE_BRANCH:-}
+        SOURCE_COMMIT: ${SOURCE_COMMIT:-}
     secrets:
       - NEXTAUTH_SECRET
       - SW360_FRONTEND_KC_SECRET

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,5 @@
 // Copyright (c) Helio Chissini de Castro, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2026. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -7,12 +8,69 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+import { execSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { NextConfig } from 'next'
 import createNextIntlPlugin from 'next-intl/plugin'
 
 const withNextIntl = createNextIntlPlugin()
 const isDev = process.env.NODE_ENV === 'development'
 const sw360ApiUrl = process.env.NEXT_PUBLIC_SW360_API_URL || ''
+
+/**
+ * Resolved frontend build  metadata (version, git branch, git commit)
+ *
+ * Resolution order for git values:
+ *   1. Explicit env vars (NEXT_PUBLIC_APP_GIT_* / SOURCE_BRANCH / SOURCE_COMMIT)
+ *         — set by CI / Docker build-args.
+ *   2. `git` command against the local working tree — for `pnpm build` in a dev checkout.
+ *   3. 'unknown' — final fallback so the build never fails on missing metadata.
+ *
+ * Values are inlined into the client bundle via the Next.js `env` field.
+ */
+function resolveFrontendBuildInfo(): Record<string, string> {
+    const pkg = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+        version: string
+    }
+
+    const tryGit = (args: string): string | undefined => {
+        try {
+            const out = execSync(`git ${args}`, {
+                stdio: [
+                    'ignore',
+                    'pipe',
+                    'ignore',
+                ],
+            })
+                .toString()
+                .trim()
+            return out || undefined
+        } catch {
+            return undefined
+        }
+    }
+
+    const gitBranch =
+        process.env.NEXT_PUBLIC_APP_GIT_BRANCH ||
+        process.env.SOURCE_BRANCH ||
+        tryGit('rev-parse --abbrev-ref HEAD') ||
+        'unknown'
+
+    const gitCommit =
+        process.env.NEXT_PUBLIC_APP_GIT_COMMIT ||
+        process.env.SOURCE_COMMIT ||
+        tryGit('rev-parse --short HEAD') ||
+        'unknown'
+
+    return {
+        NEXT_PUBLIC_APP_VERSION: pkg.version,
+        NEXT_PUBLIC_APP_GIT_BRANCH: gitBranch,
+        NEXT_PUBLIC_APP_GIT_COMMIT: gitCommit,
+    }
+}
+
+const frontendBuildInfo = resolveFrontendBuildInfo()
 
 const csp = `
   default-src 'self';
@@ -34,6 +92,8 @@ const config: NextConfig = {
     typescript: {
         ignoreBuildErrors: false,
     },
+    // Inline frontend build metadata into the client bundle (compile-time constants).
+    env: frontendBuildInfo,
     // biome-ignore-start lint: Next.js config requires this async method pattern for custom headers
     async headers() {
         return [

--- a/src/components/sw360/Footer/Footer.tsx
+++ b/src/components/sw360/Footer/Footer.tsx
@@ -19,8 +19,15 @@ import { type JSX, useEffect, useState } from 'react'
 import { VersionInfo } from '@/object-types'
 import { ApiUtils } from '@/utils'
 
+// Compile-time constants injected by next.config.ts `env` block.
+const frontendVersionInfo: VersionInfo = {
+    sw360FrontendVersion: process.env.NEXT_PUBLIC_APP_VERSION ?? 'unknown',
+    gitBranch: process.env.NEXT_PUBLIC_APP_GIT_BRANCH ?? 'unknown',
+    buildNumber: process.env.NEXT_PUBLIC_APP_GIT_COMMIT ?? 'unknown',
+}
+
 function Footer(): JSX.Element {
-    const [versionInfo, setVersionInfo] = useState<VersionInfo>()
+    const [backendVersionInfo, setBackendVersionInfo] = useState<VersionInfo>()
 
     useEffect(() => {
         const controller = new AbortController()
@@ -31,7 +38,7 @@ function Footer(): JSX.Element {
                 const response = await ApiUtils.GET('version', '', signal)
                 if (response.status == StatusCodes.OK) {
                     const data = (await response.json()) as VersionInfo
-                    setVersionInfo(data)
+                    setBackendVersionInfo(data)
                 }
             } catch {
                 // Silently fail - version display is non-critical
@@ -88,14 +95,21 @@ function Footer(): JSX.Element {
                     </Link>
                 </div>
                 <div className='footerVersion'>
-                    {versionInfo ? (
+                    {frontendVersionInfo ? (
                         <>
-                            Version: {versionInfo.sw360Version} | Branch: {versionInfo.gitBranch} (
-                            {versionInfo.buildNumber}) | Build time: {versionInfo.buildTime} | API:{' '}
-                            {versionInfo.apiVersion}
+                            Frontend: {frontendVersionInfo.sw360FrontendVersion} | Branch:{' '}
+                            {frontendVersionInfo.gitBranch} ({frontendVersionInfo.buildNumber}) |&nbsp;
                         </>
                     ) : (
-                        'No build information available.'
+                        'No frontend build information available.'
+                    )}
+                    {backendVersionInfo ? (
+                        <>
+                            Backend: {backendVersionInfo.sw360Version} | Branch: {backendVersionInfo.gitBranch} (
+                            {backendVersionInfo.buildNumber}) | API: {backendVersionInfo.apiVersion}
+                        </>
+                    ) : (
+                        'No backend build information available.'
                     )}
                 </div>
             </footer>

--- a/src/object-types/VersionInfo.ts
+++ b/src/object-types/VersionInfo.ts
@@ -8,10 +8,11 @@
 // License-Filename: LICENSE
 
 interface VersionInfo {
-    apiVersion: string
-    buildTime: string
+    apiVersion?: string
+    buildTime?: string
     buildNumber: string
-    sw360Version: string
+    sw360Version?: string
+    sw360FrontendVersion?: string
     gitBranch: string
 }
 


### PR DESCRIPTION
Added deployed frontend repo info at the footer. Attached a screenshot herewith:

<img width="1077" height="103" alt="image" src="https://github.com/user-attachments/assets/c2a6e8c3-442d-4965-ad1b-8f9ea8abded7" />
