### PR TITLE
fix(release): Sorting of release version in dropdown

### DIFF
--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -184,7 +184,11 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 fetchData(`components/${release._links['sw360:component'].href.split('/').at(-1)}/releases`)
                     .then((embeddedReleaseLinks) => {
                         if (embeddedReleaseLinks) {
-                            setReleasesSameComponent(embeddedReleaseLinks['_embedded']['sw360:releaseLinks'])
+                            setReleasesSameComponent(
+                                embeddedReleaseLinks['_embedded']['sw360:releaseLinks']
+                                    .slice()
+                                    .sort((left, right) => left.version.localeCompare(right.version)),
+                            )
                         }
                     })
                     .catch((err) => console.error(err))


### PR DESCRIPTION
Description: 
now the release version in dropdown are sorted.

<img width="581" height="388" alt="image" src="https://github.com/user-attachments/assets/9eef3455-3c2d-4ad6-9c7e-17dfd0b45ba4" />
