### PR TITLE
fix(Project): Update clearing state colors for better visibility

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -526,14 +526,24 @@ export default function ListView({
                                         )}`}</Tooltip>
                                     }
                                 >
-                                    {clearingState === 'NEW_CLEARING' ? (
+                                    {clearingState === 'NEW_CLEARING' ? ( // red
                                         <span className='badge bg-danger overlay-badge'>{'CS'}</span>
-                                    ) : clearingState === 'REPORT_AVAILABLE' ? (
+                                    ) : clearingState === 'UNDER_CLEARING' ? ( // yellow
+                                        <span className='badge bg-warning overlay-badge'>{'CS'}</span>
+                                    ) : clearingState === 'SENT_TO_CLEARING_TOOL' ||
+                                      clearingState === 'SCAN_AVAILABLE' ? ( // orange
+                                        <span className='badge clearingStateSentToClearingTool overlay-badge'>
+                                            {'CS'}
+                                        </span>
+                                    ) : clearingState === 'REPORT_AVAILABLE' ? ( // blue
                                         <span className='badge bg-primary overlay-badge'>{'CS'}</span>
-                                    ) : clearingState === 'INTERNAL_USE_SCAN_AVAILABLE' ? (
+                                    ) : clearingState === 'INTERNAL_USE_SCAN_AVAILABLE' ? ( // purple
                                         <span className='badge bg-internal-use-scan overlay-badge'>{'CS'}</span>
-                                    ) : (
+                                    ) : clearingState === 'APPROVED' ? ( // green
                                         <span className='badge bg-success overlay-badge'>{'CS'}</span>
+                                    ) : (
+                                        // gray: unknown state (null/undefined/empty/unmapped)
+                                        <span className='badge bg-secondary overlay-badge'>{'CS'}</span>
                                     )}
                                 </OverlayTrigger>
                             </div>

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -750,14 +750,24 @@ export default function TreeView({
                                         )}`}</Tooltip>
                                     }
                                 >
-                                    {clearingState === 'NEW_CLEARING' ? (
+                                    {clearingState === 'NEW_CLEARING' ? ( // red
                                         <span className='badge bg-danger overlay-badge'>{'CS'}</span>
-                                    ) : clearingState === 'REPORT_AVAILABLE' ? (
+                                    ) : clearingState === 'UNDER_CLEARING' ? ( // yellow
+                                        <span className='badge bg-warning overlay-badge'>{'CS'}</span>
+                                    ) : clearingState === 'SENT_TO_CLEARING_TOOL' ||
+                                      clearingState === 'SCAN_AVAILABLE' ? ( // orange
+                                        <span className='badge clearingStateSentToClearingTool overlay-badge'>
+                                            {'CS'}
+                                        </span>
+                                    ) : clearingState === 'REPORT_AVAILABLE' ? ( // blue
                                         <span className='badge bg-primary overlay-badge'>{'CS'}</span>
-                                    ) : clearingState === 'INTERNAL_USE_SCAN_AVAILABLE' ? (
+                                    ) : clearingState === 'INTERNAL_USE_SCAN_AVAILABLE' ? ( // purple
                                         <span className='badge bg-internal-use-scan overlay-badge'>{'CS'}</span>
-                                    ) : (
+                                    ) : clearingState === 'APPROVED' ? ( // green
                                         <span className='badge bg-success overlay-badge'>{'CS'}</span>
+                                    ) : (
+                                        // gray: unknown state (null/undefined/empty/unmapped)
+                                        <span className='badge bg-secondary overlay-badge'>{'CS'}</span>
                                     )}
                                 </OverlayTrigger>
                             </div>


### PR DESCRIPTION
> Please provide a summary of your changes here.
In the **License Clearing** tab's **Tree View**, the release clearing-state (`CS`) badge does not have distinct colors for all clearing states. States such as `UNDER_CLEARING`, `SENT_TO_CLEARING_TOOL`, and `SCAN_AVAILABLE` are not explicitly mapped to a color, and unknown/unmapped states do not fall back to a neutral color, making it hard to quickly distinguish a release's clearing progress at a glance.
> * Which issue is this pull request belonging to and how is it solving it? (*https://github.com/eclipse-sw360/sw360-frontend/issues/2022*)
> * Did you add or update any new dependencies that are required for your change?

Closes #2022

Updates the release clearing-state (`CS`) badge colors in the Tree View of the License Clearing tab (`TreeView.tsx`) for better visibility and consistency:
- Added `UNDER_CLEARING` state with a yellow (`bg-warning`, `#ffd350`) badge.
- Added `SENT_TO_CLEARING_TOOL` / `SCAN_AVAILABLE` states with an orange (`clearingStateSentToClearingTool`, `#f7941e`) badge, reusing the existing CSS class instead of introducing a new one.
- Added an explicit `APPROVED` condition with a green (`bg-success`, `#69c17d`) badge.
- Changed the fallback/default badge color to gray (`bg-secondary`, `#dee2e6`) for unknown, null, undefined, empty, or unmapped clearing states.
- Added a one-line comment per condition documenting the color mapping.
- Removed an unused temporary `.bg-clearing-orange` CSS class from `globals.css` in favor of the existing `clearingStateSentToClearingTool` class.

| Icon | Clearing State | Color | Hex |
|---|---|---|---|
| 🟥 | `NEW_CLEARING` | Red | `#e6717c` |
| 🟨 | `UNDER_CLEARING` | Yellow | `#ffd350` |
| 🟧 | `SENT_TO_CLEARING_TOOL` / `SCAN_AVAILABLE` | Orange | `#f7941e` |
| 🟦 | `REPORT_AVAILABLE` | Blue | `#0d6efd` |
| 🟪 | `INTERNAL_USE_SCAN_AVAILABLE` | Purple | `#9370db` |
| 🟩 | `APPROVED` | Green | `#69c17d` |
| ⬜ | Unknown/unmapped | Gray | `#dee2e6` |

Issue: 

### Suggest Reviewer
> @GMishx @amritkv .

### How To Test?
>

1. Open a project's **License Clearing** tab and switch to **Tree View**.
2. Verify releases with `UNDER_CLEARING` state show a yellow `CS` badge.
3. Verify releases with `SENT_TO_CLEARING_TOOL` or `SCAN_AVAILABLE` state show an orange `CS` badge (matching `clearingStateSentToClearingTool` color, `#f7941e`).
4. Verify releases with `APPROVED` state show a green `CS` badge.
5. Verify releases with an unknown/missing clearing state show a gray `CS` badge.
