### PR TITLE
fix(UI): Attachment Usage save prevents LicenseInfo generation

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "Sie bearbeiten das Originaldokument.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "Sie sind der letzte Moderator dieser Anfrage, eine Abmeldung ist nicht möglich!",
     "You can write to the entity": "Sie können Änderungen vornehmen. \nMR ist nicht erforderlich!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "Sie haben die Moderationsanfrage angenommen",
     "You have assigned yourself to this moderation request": "Sie haben sich dieser Moderationsanfrage zugeordnet.",
     "You have postponed the moderation request": "Sie haben die Moderationsanfrage verschoben",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "You are editing the original document.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "You are the last moderator for this request, you are not allowed to unsubscribe !",
     "You can write to the entity": "You can perform modifications. MR is not required!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "You have accepted the moderation request",
     "You have assigned yourself to this moderation request": "You have assigned yourself to this moderation request.",
     "You have postponed the moderation request": "You have postponed the moderation request",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "Estás editando el documento original.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "Usted es el último moderador de esta solicitud, ¡no puede darse de baja!",
     "You can write to the entity": "Puedes realizar modificaciones. \n¡Mr no es obligatorio!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "Has aceptado la solicitud de moderación.",
     "You have assigned yourself to this moderation request": "Te has asignado a esta solicitud de moderación.",
     "You have postponed the moderation request": "Has pospuesto la solicitud de moderación",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "Vous modifiez le document original.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "Vous êtes le dernier modérateur de cette demande, vous n'avez pas le droit de vous désinscrire !",
     "You can write to the entity": "Vous pouvez effectuer des modifications. \nM. n'est pas requis!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "Vous avez accepté la demande de modération",
     "You have assigned yourself to this moderation request": "Vous vous êtes assigné à cette demande de modération.",
     "You have postponed the moderation request": "Vous avez reporté la demande de modération",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "元のドキュメントを編集しています。",
     "You are the last moderator for this request you are not allowed to unsubscribe": "あなたはこのリクエストの最後のモデレータです。登録を解除することはできません。",
     "You can write to the entity": "変更を実行できます。\nミスターは必要ありません！",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "モデレーションリクエストを承認しました",
     "You have assigned yourself to this moderation request": "あなたはこのモデレーションリクエストに自分自身を割り当てました。",
     "You have postponed the moderation request": "モデレートリクエストを延期しました",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "원본 문서를 편집하고 있습니다.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "귀하는 이 요청의 마지막 중재자이므로 구독을 취소할 수 없습니다!",
     "You can write to the entity": "수정을 수행 할 수 있습니다. \nMR은 필요하지 않습니다!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "중재 요청을 수락했습니다.",
     "You have assigned yourself to this moderation request": "귀하는 이 중재 요청에 자신을 할당했습니다.",
     "You have postponed the moderation request": "검토 요청을 연기했습니다.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "Você está editando o documento original.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "Você é o último moderador desta solicitação, não tem permissão para cancelar a inscrição!",
     "You can write to the entity": "Você pode executar modificações. \nMR não é necessário!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "Você aceitou o pedido de moderação",
     "You have assigned yourself to this moderation request": "Você se atribuiu a esta solicitação de moderação.",
     "You have postponed the moderation request": "Você adiou o pedido de moderação",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "Bạn đang chỉnh sửa tài liệu gốc.",
     "You are the last moderator for this request you are not allowed to unsubscribe": "Bạn là người kiểm duyệt cuối cùng cho yêu cầu này, bạn không được phép hủy đăng ký!",
     "You can write to the entity": "Bạn có thể thực hiện sửa đổi. \nÔng không bắt buộc!",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "Bạn đã chấp nhận yêu cầu kiểm duyệt",
     "You have assigned yourself to this moderation request": "Bạn đã tự giao cho mình yêu cầu kiểm duyệt này.",
     "You have postponed the moderation request": "Bạn đã trì hoãn yêu cầu kiểm duyệt",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "您正在编辑原始文档。",
     "You are the last moderator for this request you are not allowed to unsubscribe": "您是此请求的最后一位版主，您不能取消订阅！",
     "You can write to the entity": "您可以执行修改。\n不需要先生！",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "您已接受审核请求",
     "You have assigned yourself to this moderation request": "您已将自己分配给此审核请求。",
     "You have postponed the moderation request": "您已推迟审核请求",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1595,6 +1595,7 @@
     "You are editing the original document": "您正在編輯原始文檔。",
     "You are the last moderator for this request you are not allowed to unsubscribe": "您是此請求的最後一位版主，您不能取消訂閱！",
     "You can write to the entity": "您可以執行修改。不需要先生！",
+    "You do not have permission to save attachment usages for this project": "You do not have permission to save attachment usages for this project",
     "You have accepted the moderation request": "您已接受審核請求",
     "You have assigned yourself to this moderation request": "您已將自己指派給此審核請求。",
     "You have postponed the moderation request": "您已延後審核請求",

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -20,7 +20,6 @@ import {
 } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { notFound } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { Dispatch, type JSX, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
@@ -41,6 +40,7 @@ import {
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import { getAttachmentTypeShortForm } from '@/utils/attachments.utils'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
@@ -210,6 +210,8 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
     })
     const [saveUsagesLoading, setSaveUsagesLoading] = useState(false)
 
+    const [canEditUsage, setCanEditUsage] = useState(false)
+
     const [showProcessingLinkedProjects, setShowProcessingLinkedProjects] = useState(false)
     const [showProcessingAttachmentUsages, setShowProcessingAttachmentUsages] = useState(false)
     const [isTableBuilding, setIsTableBuilding] = useState(false)
@@ -246,12 +248,16 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
     )
 
     const handleSaveUsages = async () => {
+        if (!canEditUsage) {
+            MessageService.warn(t('You do not have permission to save attachment usages for this project'))
+            return
+        }
         try {
             setSaveUsagesLoading(true)
             const response = await ApiUtils.POST(`projects/${projectId}/saveAttachmentUsages`, saveUsagesPayload)
             if (response.status !== StatusCodes.CREATED) {
                 MessageService.error(t('Something went wrong'))
-                return notFound()
+                return
             }
 
             // Check for warnings in response (e.g. stale sub-project or release references)
@@ -277,6 +283,31 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
             setSaveUsagesLoading(false)
         }
     }
+
+    useEffect(() => {
+        const controller = new AbortController()
+        const signal = controller.signal
+
+        void (async () => {
+            try {
+                const [projectResponse, userIdentity] = await Promise.all([
+                    ApiUtils.GET(`projects/${projectId}`, signal),
+                    getAuthenticatedUserIdentity(),
+                ])
+                if (projectResponse.status !== StatusCodes.OK) return
+                const project = (await projectResponse.json()) as Project
+                setCanEditUsage(
+                    CommonUtils.canManageAttachmentUsage(project, userIdentity.email, userIdentity.userGroup),
+                )
+            } catch (error) {
+                ApiUtils.reportError(error)
+            }
+        })()
+
+        return () => controller.abort()
+    }, [
+        projectId,
+    ])
 
     useEffect(() => {
         const controller = new AbortController()
@@ -637,7 +668,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                                                     <input
                                                         type='checkbox'
                                                         className='form-check-input'
-                                                        disabled={!isLicenseInfoEnabled(attachmentType ?? '')}
+                                                        disabled={
+                                                            !canEditUsage || !isLicenseInfoEnabled(attachmentType ?? '')
+                                                        }
                                                         checked={
                                                             saveUsagesPayload.selected.indexOf(
                                                                 `${
@@ -707,7 +740,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                                             <input
                                                 type='checkbox'
                                                 className='form-check-input'
-                                                disabled={!isSourceCodeBundleEnabled(attachmentType ?? '')}
+                                                disabled={
+                                                    !canEditUsage || !isSourceCodeBundleEnabled(attachmentType ?? '')
+                                                }
                                                 checked={
                                                     saveUsagesPayload.selected.indexOf(
                                                         `${r._links?.self.href.split('/').at(-1) ?? ''}_sourcePackage_${attachmentContentId}`,
@@ -758,7 +793,9 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                                             <input
                                                 type='checkbox'
                                                 className='form-check-input'
-                                                disabled={!isSourceCodeBundleEnabled(attachmentType ?? '')}
+                                                disabled={
+                                                    !canEditUsage || !isSourceCodeBundleEnabled(attachmentType ?? '')
+                                                }
                                                 checked={
                                                     saveUsagesPayload.selected.indexOf(
                                                         `${r._links?.self.href.split('/').at(-1) ?? ''}_manuallySet_${attachmentContentId}`,
@@ -808,6 +845,7 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
             memoizedAttachmentUsages,
             saveUsagesPayload,
             releaseFilter,
+            canEditUsage,
         ],
     )
 
@@ -963,6 +1001,12 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 type='button'
                 className='btn btn-secondary mb-2'
                 onClick={() => void handleSaveUsages()}
+                disabled={!canEditUsage}
+                title={
+                    canEditUsage
+                        ? undefined
+                        : t('You do not have permission to save attachment usages for this project')
+                }
             >
                 {t('Save Usages')}{' '}
                 {saveUsagesLoading === true && (

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/DownloadLicenseInfoModal.tsx
@@ -77,6 +77,7 @@ export default function DownloadLicenseInfoModal({
     projectId,
     isCalledFromProjectLicenseTab,
     projectRelationships,
+    canEditUsage,
 }: {
     show: boolean
     setShow: Dispatch<SetStateAction<boolean>>
@@ -85,6 +86,7 @@ export default function DownloadLicenseInfoModal({
     projectId: string
     isCalledFromProjectLicenseTab: boolean
     projectRelationships: string[]
+    canEditUsage: boolean
 }): ReactNode {
     const t = useTranslations('default')
     const params = useSearchParams()
@@ -179,6 +181,14 @@ export default function DownloadLicenseInfoModal({
     const handleLicenseInfoDownload = async (projectId: string) => {
         try {
             setLoading(true)
+            if (!canEditUsage) {
+                await downloadHandler(
+                    new Response(null, {
+                        status: StatusCodes.OK,
+                    }),
+                )
+                return
+            }
             const response = await ApiUtils.POST(`projects/${projectId}/saveAttachmentUsages`, saveUsagesPayload)
             if (response.status === StatusCodes.CREATED || response.status === StatusCodes.OK) {
                 await downloadHandler(response)

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/object-types'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 import DownloadLicenseInfoModal from './DownloadLicenseInfoModal'
 import LicenseInfoDownloadConfirmationModal from './LicenseInfoDownloadConfirmation'
 
@@ -288,6 +289,8 @@ function GenerateLicenseInfo({
     const t = useTranslations('default')
     const [project, setProject] = useState<Project>()
     const params = useSearchParams()
+    // Only Admins, Clearing Admins/Experts and project contributors may save attachment usages.
+    const [canEditUsage, setCanEditUsage] = useState(false)
     const [saveUsagesPayload, setSaveUsagesPayload] = useState<SaveUsagesPayload>({
         selected: [],
         deselected: [],
@@ -356,6 +359,22 @@ function GenerateLicenseInfo({
         project,
     ])
 
+    useEffect(() => {
+        if (!project) return
+        void (async () => {
+            try {
+                const userIdentity = await getAuthenticatedUserIdentity()
+                setCanEditUsage(
+                    CommonUtils.canManageAttachmentUsage(project, userIdentity.email, userIdentity.userGroup),
+                )
+            } catch (error) {
+                ApiUtils.reportError(error)
+            }
+        })()
+    }, [
+        project,
+    ])
+
     const columns = useMemo<
         ColumnDef<ExtendedNestedRows<TypedAttachment | TypedRelease | TypedProject | TypedLicense>>[]
     >(
@@ -387,6 +406,7 @@ function GenerateLicenseInfo({
                                 <input
                                     type='checkbox'
                                     className='form-check-input'
+                                    disabled={!canEditUsage}
                                     checked={saveUsagesPayload.selected.indexOf(key) !== -1}
                                     onChange={() => {
                                         if (saveUsagesPayload.selected.indexOf(key) === -1) {
@@ -449,6 +469,7 @@ function GenerateLicenseInfo({
                             <input
                                 type='checkbox'
                                 className='form-check-input'
+                                disabled={!canEditUsage}
                                 checked={checked}
                                 onChange={() => {
                                     let ignoredList: string[] = saveUsagesPayload.ignoredLicenses[key] ?? []
@@ -710,6 +731,7 @@ function GenerateLicenseInfo({
         [
             t,
             saveUsagesPayload,
+            canEditUsage,
         ],
     )
 
@@ -938,6 +960,7 @@ function GenerateLicenseInfo({
                 projectId={projectId}
                 isCalledFromProjectLicenseTab={isCalledFromProjectLicenseTab}
                 projectRelationships={projectRelationships}
+                canEditUsage={canEditUsage}
             />
             <LicenseInfoDownloadConfirmationModal
                 show={showConfirmation}

--- a/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
+++ b/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
@@ -12,7 +12,7 @@
 import { ColumnDef, ExpandedState, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
-import { notFound, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { PaddedCell, SW360Table } from 'next-sw360'
 import { Dispatch, ReactNode, SetStateAction, useEffect, useMemo, useState } from 'react'
@@ -35,6 +35,7 @@ import DownloadService from '@/services/download.service'
 import MessageService from '@/services/message.service'
 import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
+import { getAuthenticatedUserIdentity } from '@/utils/api/authenticatedUser.util'
 
 type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
@@ -67,6 +68,7 @@ function GenerateSourceCodeBundle({
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
     const [showProcessing, setShowProcessing] = useState(false)
     const [project, setProject] = useState<Project>()
+    const [canEditUsage, setCanEditUsage] = useState(false)
 
     const [linkedProjects, setLinkedProjects] = useState<Project[]>(() => [])
     const memoizedLinkedProjects = useMemo(
@@ -107,26 +109,28 @@ function GenerateSourceCodeBundle({
             if (Object.hasOwn(searchParams, 'withSubProjects') === false) {
                 return
             }
+
+            const currentDate = new Date().toISOString().split('T')[0]
+            const downloadUrl = `reports?withlinkedreleases=false&projectId=${projectId}&module=licenseResourceBundle&excludeReleaseVersion=false&withSubProject=${searchParams.withSubProjects}`
+
+            // Skip save if user doesn't have permission, proceed directly to download
+            if (!canEditUsage) {
+                await DownloadService.download(downloadUrl, `SourceCodeBundle-${currentDate}.zip`)
+                return
+            }
+
             const response = await ApiUtils.POST(`projects/${projectId}/saveAttachmentUsages`, saveUsagesPayload)
             if (response.status === StatusCodes.CREATED || response.status === StatusCodes.OK) {
-                const currentDate = new Date().toISOString().split('T')[0]
-                DownloadService.download(
-                    `reports?withlinkedreleases=false&projectId=${projectId}&module=licenseResourceBundle&excludeReleaseVersion=false&withSubProject=${searchParams.withSubProjects}`,
-                    `SourceCodeBundle-${currentDate}.zip`,
-                )
+                await DownloadService.download(downloadUrl, `SourceCodeBundle-${currentDate}.zip`)
             } else if (response.status === StatusCodes.FORBIDDEN) {
                 MessageService.warn(t('Could not save the attachment usages'))
-                const currentDate = new Date().toISOString().split('T')[0]
-                DownloadService.download(
-                    `reports?withlinkedreleases=false&projectId=${projectId}&module=licenseResourceBundle&excludeReleaseVersion=false&withSubProject=${searchParams.withSubProjects}`,
-                    `SourceCodeBundle-${currentDate}.zip`,
-                )
+                await DownloadService.download(downloadUrl, `SourceCodeBundle-${currentDate}.zip`)
             } else {
                 MessageService.error(t('Something went wrong'))
-                return notFound()
             }
-        } catch (e) {
-            console.error(e)
+        } catch (error) {
+            MessageService.error(t('Download failed'))
+            ApiUtils.reportError(error)
         } finally {
             setLoading(false)
         }
@@ -235,6 +239,22 @@ function GenerateSourceCodeBundle({
         memoizedAttachmentUsages,
         hideWithUsage,
         saveUsagesPayload,
+    ])
+
+    useEffect(() => {
+        if (!project) return
+        void (async () => {
+            try {
+                const userIdentity = await getAuthenticatedUserIdentity()
+                setCanEditUsage(
+                    CommonUtils.canManageAttachmentUsage(project, userIdentity.email, userIdentity.userGroup),
+                )
+            } catch (error) {
+                ApiUtils.reportError(error)
+            }
+        })()
+    }, [
+        project,
     ])
 
     // function to add attachments to a release
@@ -371,6 +391,7 @@ function GenerateSourceCodeBundle({
                                 <input
                                     type='checkbox'
                                     className='form-check-input'
+                                    disabled={!canEditUsage}
                                     checked={
                                         saveUsagesPayload.selected.indexOf(
                                             `${r._links?.self.href.split('/').at(-1) ?? ''}_sourcePackage_${attachmentContentId}`,
@@ -612,6 +633,7 @@ function GenerateSourceCodeBundle({
         [
             t,
             saveUsagesPayload,
+            canEditUsage,
         ],
     )
 

--- a/src/utils/common.utils.ts
+++ b/src/utils/common.utils.ts
@@ -10,7 +10,7 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
-import { InputKeyValue, User } from '@/object-types'
+import { InputKeyValue, Project, User, UserGroupType } from '@/object-types'
 
 /**
  * Checks if the given object is void, null or undefined.
@@ -351,6 +351,43 @@ const formatObligationText = (text: string): string =>
         .replace(/\s*\n\s*/g, '\n')
         .trim()
 
+/**
+ * User groups with global permission to save attachment usages.
+ */
+const ATTACHMENT_USAGE_WRITE_GROUPS: UserGroupType[] = [
+    UserGroupType.ADMIN,
+    UserGroupType.SW360_ADMIN,
+    UserGroupType.CLEARING_ADMIN,
+]
+
+const isProjectContributor = (project: Project, userEmail?: string | null): boolean => {
+    if (isNullEmptyOrUndefinedString(userEmail)) return false
+    const projectMembers = [
+        project.createdBy,
+        project.leadArchitect,
+        project.projectResponsible,
+        ...(project.moderators ?? []),
+        ...(project.contributors ?? []),
+    ]
+    return projectMembers.includes(userEmail)
+}
+
+/**
+ * Checks whether a user is allowed to save attachment usages. Global admins and
+ * clearing admins may always edit; other users need to be project contributors.
+ */
+const canManageAttachmentUsage = (
+    project: Project | undefined | null,
+    userEmail?: string | null,
+    userGroup?: UserGroupType,
+): boolean => {
+    if (userGroup !== undefined && ATTACHMENT_USAGE_WRITE_GROUPS.includes(userGroup)) {
+        return true
+    }
+    if (isNullOrUndefined(project)) return false
+    return isProjectContributor(project, userEmail)
+}
+
 const CommonUtils = {
     isNullOrUndefined,
     isNullEmptyOrUndefinedString,
@@ -369,6 +406,7 @@ const CommonUtils = {
     readDateTime,
     nullToEmptyString,
     formatObligationText,
+    canManageAttachmentUsage,
 }
 
 export default CommonUtils


### PR DESCRIPTION
### Summary

Users without attachment-usage write permission were hitting save API failures (403/permission denied), which blocked report generation flows (LicenseInfo, Source Code Bundle, Clearing Info related paths).

### Code dependency 
PR: https://github.com/eclipse-sw360/sw360-frontend/pull/1665

### What was fixed

- Added permission-aware UI behavior for attachment usages:
   - Editable for authorized users only (Admin/SW360 Admin/Clearing Admin/project contributor logic).
   - Read-only for unauthorized users (checkboxes and save action disabled).
- Added guard in download/generation flows:
   - If user cannot edit attachment usage, skip save call and continue with report download.
- Centralized permission decision in shared utility logic for consistency across pages/components.

How To Test?
How should these changes be tested by the reviewer?
Have you implemented any additional tests?

Step 2: Test Different User Roles
Create test scenarios with these user types:

Test Case 1: Admin User (Should have full access)

Steps:
1. Login as user with ADMIN or SW360_ADMIN role
2. Go to Projects → Select any project
3. Expand "Attachment Usages" tab
4. Verify: Checkboxes are ENABLED (not greyed out)
5. Click "Generate License Info" button
6. Verify: All checkboxes in modal are ENABLED
7. Select some checkboxes and click Download
8. Verify: Save API call is made (check browser DevTools → Network tab)
9. Verify: Report downloads successfully



Test Case 2: Project Contributor (Should have access)

Steps:
1. Login as user who is in project's contributors list
2. Go to Projects → Select that project
3. Expand "Attachment Usages" tab
4. Verify: Checkboxes are ENABLED
5. Try to generate LicenseInfo
6. Verify: Checkboxes are ENABLED
7. Verify: Save API call is made
8. Verify: Report downloads


Test Case 3: Viewer/Regular User (Should NOT have write access)

Steps:
1. Login as regular user (not in contributors/moderators)
2. Go to Projects → Select any project
3. Expand "Attachment Usages" tab
4. Verify: Checkboxes are DISABLED (greyed out)
5. Verify: "Save Usages" button is DISABLED
6. Try to click disabled checkbox (nothing happens)
7. Click "Generate License Info"
8. Verify: Checkboxes in modal are DISABLED
9. Select/deselect doesn't work (they're read-only)
10. Click Download
11. Verify: NO save API call is made (check Network tab)
12. Verify: Report downloads successfully WITHOUT save
13. Verify: No error messages


Same as Test Case 1 but login as CLEARING_ADMIN role

Step 3: Check Browser DevTools
Network Tab Analysis:

For Admin/Contributor:
- POST /api/projects/{id}/saveAttachmentUsages → Status 201/200 ✅

For Viewer:
- NO POST call to saveAttachmentUsages ✅
- Directly goes to GET /api/reports ✅

Console Tab:
- No errors or warnings (except expected ones)
- No 403/401 errors


Step 4: Test All 4 Affected Pages
1. ✅ Attachment Usages Tab (Projects → Details → Attachment Usages)
   - Test checkbox disable/enable based on permissions

2. ✅ Generate License Info (Projects → Generate License Info)
   - Test with authorized and unauthorized users

3. ✅ Generate Source Code Bundle (Projects → Generate Source Code Bundle)
   - Test checkbox disable/enable
   - Test download without error message for unauthorized

4. ✅ Clearing Info (If available in your version)
   - Uses same AttachmentUsages component
   - Should work same way
   
Step 5: Test Edge Cases

# Case 1: User permission changes during session
- Login as Viewer
- Admin adds you to contributors in backend
- Refresh page
- Verify: Permission updates correctly

# Case 2: Session expires
- Login as user
- Navigate to attachment usage page
- Wait for session to expire (or manually expire)
- Try to generate report
- Verify: Proper error handling

# Case 3: API failure scenarios
- Open DevTools Network tab
- Go to Attachment Usages
- Throttle network (DevTools → Network conditions → Offline)
- Try to save
- Verify: Error handled gracefully


