### PR TITLE
fix(Fossology): Fossology clearing process stuck at step 2

### DIFF
--- a/src/components/sw360/FossologyClearing/FossologyClearing.tsx
+++ b/src/components/sw360/FossologyClearing/FossologyClearing.tsx
@@ -171,9 +171,13 @@ const FossologyClearing = ({ show, setShow, releaseId }: Props): JSX.Element => 
         if (response === undefined) return
 
         if (response.status === 'SUCCESS') {
+            // Check number of steps to determine final message
+            const stepCount = response.fossologyProcessInfo?.processSteps?.length ?? 0
+            const finalStepName = stepCount === 2 ? 'Scanning source done' : 'Report generation done'
+
             setProgressStatus({
                 percent: PERCENT_DONE,
-                stepName: 'Report generation done',
+                stepName: finalStepName,
             })
             showMessage(clearingMessages.CLEARING_SUCCESS)
             clearAllInterval()
@@ -260,7 +264,13 @@ const FossologyClearing = ({ show, setShow, releaseId }: Props): JSX.Element => 
 
         if (fossologyProcessInfo.processSteps.at(-1)?.stepStatus === 'DONE') {
             progressText += ' done'
-            progressPercent += 2 * STEP_PERCENT
+            // When report download is disabled and we have 2 steps, show 100%
+            // When report download is enabled and we have 3 steps, add bonus as before
+            if (fossologyProcessInfo.processSteps.length === 2) {
+                progressPercent = PERCENT_DONE
+            } else {
+                progressPercent += 2 * STEP_PERCENT
+            }
         } else if (fossologyProcessInfo.processSteps.at(-1)?.stepStatus === 'IN_WORK') {
             progressText += ' in progress'
             progressPercent += 1 * STEP_PERCENT


### PR DESCRIPTION
Problem
When FOSSology clearing process completes with report download disabled (2 steps instead of 3), the frontend UI:

- Shows incorrect progress percentage (66.64% instead of 100%)
- Displays wrong completion message ("Report generation done" instead of "Scanning source done")
- Remains stuck at "in progress" status even after backend returns SUCCESS

Root Cause
Frontend logic hardcoded assumptions about:

- Always expecting 3 process steps
- Always showing the same completion message regardless of actual step count
- Not handling the dynamic 2-step completion scenario

Related backend PR: https://github.com/eclipse-sw360/sw360/pull/4565