### PR TITLE
fix(attachmentusages): Fix filtering on generate license info page

### DIFF
--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -41,7 +41,11 @@ type LinkedProjects = Embedded<Project, 'sw360:projects'>
 
 type TypedProject = TypedEntity<Project, 'project'>
 
-type TypedRelease = TypedEntity<Release, 'release'>
+interface ReleaseWithAttachmentInfo extends Release {
+    hasMultipleAttachments: boolean
+}
+
+type TypedRelease = TypedEntity<ReleaseWithAttachmentInfo, 'release'>
 
 type TypedAttachment = TypedEntity<Attachment, 'attachment'>
 
@@ -84,18 +88,8 @@ const formatReleaseAttachmentDataToTableData = (
     },
     release: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>,
     projectPath: string[],
-    approvedOnly: boolean,
-    filterWithoutUsage: boolean,
-    saveUsagesPayload: SaveUsagesPayload,
 ) => {
-    if (filterWithoutUsage && hasCliUsageSet(r, projectPath.join(':'), saveUsagesPayload)) {
-        return
-    }
-
     for (const att of r.attachments ?? []) {
-        if (approvedOnly) {
-            if (att.checkStatus === undefined || att.checkStatus !== 'ACCEPTED') break
-        }
         const relId = r._links?.self.href.split('/').at(-1) ?? ''
         const attachment: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense> = {
             node: {
@@ -127,9 +121,6 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
     },
     project: Project,
     projectPath: string[],
-    approvedOnly: boolean,
-    filterWithoutUsage: boolean,
-    saveUsagesPayload: SaveUsagesPayload,
 ): ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[] => {
     const rows: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[] = []
 
@@ -140,15 +131,7 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
                 type: 'project',
                 entity: p,
             },
-            children: extractLinkedProjectsAndTheirLinkedReleases(
-                attachmentUsages,
-                licenses,
-                p,
-                projectPath,
-                approvedOnly,
-                filterWithoutUsage,
-                saveUsagesPayload,
-            ),
+            children: extractLinkedProjectsAndTheirLinkedReleases(attachmentUsages, licenses, p, projectPath),
         }
         projectPath.pop()
         if (nodeProject.children && nodeProject.children.length !== 0) {
@@ -158,26 +141,18 @@ const extractLinkedProjectsAndTheirLinkedReleases = (
 
     for (const l of project['linkedReleases'] ?? []) {
         for (const r of attachmentUsages['_embedded']['sw360:release']) {
-            if (approvedOnly) {
-                if (r.clearingState === undefined || r.clearingState !== 'APPROVED') break
-            }
             if (r._links?.self.href.split('/').at(-1) === l.release.split('/').at(-1)) {
                 const nodeRelease: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense> = {
                     node: {
-                        entity: r,
+                        entity: {
+                            ...r,
+                            hasMultipleAttachments: (r.attachments?.length ?? 0) > 1,
+                        },
                         type: 'release',
                     },
                     children: [],
                 }
-                formatReleaseAttachmentDataToTableData(
-                    r,
-                    licenses,
-                    nodeRelease,
-                    projectPath,
-                    approvedOnly,
-                    filterWithoutUsage,
-                    saveUsagesPayload,
-                )
+                formatReleaseAttachmentDataToTableData(r, licenses, nodeRelease, projectPath)
                 if (nodeRelease.children && nodeRelease.children.length !== 0) {
                     rows.push(nodeRelease)
                 }
@@ -195,7 +170,7 @@ const buildTable = (
     licenses: {
         [id: string]: License[]
     },
-    approvedOnly: boolean,
+    key: string,
     filterWithoutUsage: boolean,
     saveUsagesPayload: SaveUsagesPayload,
 ) => {
@@ -206,26 +181,18 @@ const buildTable = (
     // adding releases and attachments of the base project
     for (const id in attachmentUsages.releaseIdToUsage) {
         for (const r of attachmentUsages['_embedded']['sw360:release']) {
-            if (approvedOnly) {
-                if (r.clearingState === undefined || r.clearingState !== 'APPROVED') break
-            }
             if (id === r._links?.self.href.split('/').at(-1)) {
                 const nodeRelease: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense> = {
                     node: {
-                        entity: r,
+                        entity: {
+                            ...r,
+                            hasMultipleAttachments: (r.attachments?.length ?? 0) > 1,
+                        },
                         type: 'release',
                     },
                     children: [],
                 }
-                formatReleaseAttachmentDataToTableData(
-                    r,
-                    licenses,
-                    nodeRelease,
-                    projectPath,
-                    approvedOnly,
-                    filterWithoutUsage,
-                    saveUsagesPayload,
-                )
+                formatReleaseAttachmentDataToTableData(r, licenses, nodeRelease, projectPath)
                 if (nodeRelease.children && nodeRelease.children.length !== 0) {
                     tableData.push(nodeRelease)
                 }
@@ -250,22 +217,86 @@ const buildTable = (
                 entity: project,
             },
             // adding releases and attachments of > 1st level linked projects
-            children: extractLinkedProjectsAndTheirLinkedReleases(
-                attachmentUsages,
-                licenses,
-                project,
-                projectPath,
-                approvedOnly,
-                filterWithoutUsage,
-                saveUsagesPayload,
-            ),
+            children: extractLinkedProjectsAndTheirLinkedReleases(attachmentUsages, licenses, project, projectPath),
         }
         projectPath.pop()
         if (nodeProject.children && nodeProject.children.length !== 0) {
             tableData.push(nodeProject)
         }
     }
-    return tableData
+    const approvedReleaseData = key === 'only_approved' ? filterApprovedReleases(tableData) : tableData
+    return filterWithoutUsage
+        ? filterReleasesWithUsage(
+              approvedReleaseData,
+              [
+                  projectId,
+              ],
+              saveUsagesPayload,
+          )
+        : approvedReleaseData
+}
+
+function filterApprovedReleases(
+    tableData: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[],
+): ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[] {
+    return tableData.reduce<ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[]>(
+        (rows, row) => {
+            if (row.node.type === 'release' && row.node.entity.clearingState !== 'APPROVED') return rows
+
+            if (row.node.type === 'project') {
+                const children = filterApprovedReleases(row.children ?? [])
+                if (children.length === 0) return rows
+                rows.push({
+                    ...row,
+                    children,
+                })
+                return rows
+            }
+
+            rows.push(row)
+            return rows
+        },
+        [],
+    )
+}
+
+function filterReleasesWithUsage(
+    tableData: ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[],
+    projectPath: string[],
+    saveUsagesPayload: SaveUsagesPayload,
+): ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[] {
+    return tableData.reduce<ExtendedNestedRows<TypedProject | TypedRelease | TypedAttachment | TypedLicense>[]>(
+        (rows, row) => {
+            if (
+                row.node.type === 'release' &&
+                hasCliUsageSet(row.node.entity, projectPath.join(':'), saveUsagesPayload)
+            ) {
+                return rows
+            }
+
+            if (row.node.type === 'project') {
+                const projectId = row.node.entity._links.self.href.split('/').at(-1) ?? ''
+                const filteredChildren = filterReleasesWithUsage(
+                    row.children ?? [],
+                    [
+                        ...projectPath,
+                        projectId,
+                    ],
+                    saveUsagesPayload,
+                )
+                if (filteredChildren.length === 0) return rows
+                rows.push({
+                    ...row,
+                    children: filteredChildren,
+                })
+                return rows
+            }
+
+            rows.push(row)
+            return rows
+        },
+        [],
+    )
 }
 
 const fetchReleaseRelationsFromLinkedProjects = (linkedProjects: Project[], filters: string[]) => {
@@ -424,7 +455,11 @@ function GenerateLicenseInfo({
                     } else if (row.original.node.type === 'release') {
                         return (
                             <div
-                                className={(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             ></div>
                         )
                     } else if (row.original.node.type === 'license') {
@@ -521,7 +556,11 @@ function GenerateLicenseInfo({
                         )
                     } else if (row.original.node.type === 'release') {
                         return (
-                            <div className={(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}>
+                            <div
+                                className={`text-center ${
+                                    (row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'
+                                }`}
+                            >
                                 <PaddedCell row={row}>
                                     <div className='text-center'>{row.depth + 1}</div>
                                 </PaddedCell>
@@ -551,7 +590,12 @@ function GenerateLicenseInfo({
                     if (row.original.node.type === 'attachment') {
                         return (
                             <div
-                                className={`text-center ${(row.getParentRow()?.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    ((row.getParentRow()?.original.node.entity as ReleaseWithAttachmentInfo | undefined)
+                                        ?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {row.original.node.entity.filename}
                             </div>
@@ -559,7 +603,13 @@ function GenerateLicenseInfo({
                     } else if (row.original.node.type === 'release') {
                         const { name, version } = row.original.node.entity
                         return (
-                            <div className={(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}>
+                            <div
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
+                            >
                                 <Link
                                     className='text-link'
                                     href={`/components/releases/detail/${row.original.node.entity._links?.self.href.split('/').at(-1)}`}
@@ -592,7 +642,11 @@ function GenerateLicenseInfo({
                     if (row.original.node.type === 'release') {
                         return (
                             <div
-                                className={`text-center ${(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {Capitalize(row.original.node.entity.componentType ?? '')}
                             </div>
@@ -605,11 +659,12 @@ function GenerateLicenseInfo({
                         const att = row.original.node.entity
                         return (
                             <p
-                                className={
-                                    (row.getParentRow()?.original?.children?.length ?? 0) > 1
+                                className={`text-center ${
+                                    ((row.getParentRow()?.original.node.entity as ReleaseWithAttachmentInfo | undefined)
+                                        ?.hasMultipleAttachments ?? false)
                                         ? 'orange-cell'
                                         : 'green-cell'
-                                }
+                                }`}
                             >
                                 {att.attachmentUsageCount === undefined || att.attachmentUsageCount === 0
                                     ? t('not used in any project yet')
@@ -635,7 +690,11 @@ function GenerateLicenseInfo({
                     if (row.original.node.type === 'release') {
                         return (
                             <div
-                                className={`text-center ${(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {Capitalize(row.original.node.entity.clearingState ?? '')}
                             </div>
@@ -649,7 +708,12 @@ function GenerateLicenseInfo({
                     } else if (row.original.node.type === 'attachment') {
                         return (
                             <div
-                                className={`text-center ${(row.getParentRow()?.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    ((row.getParentRow()?.original.node.entity as ReleaseWithAttachmentInfo | undefined)
+                                        ?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {Capitalize(row.original.node.entity.checkStatus ?? '')}
                             </div>
@@ -667,7 +731,12 @@ function GenerateLicenseInfo({
                     if (row.original.node.type === 'attachment') {
                         return (
                             <div
-                                className={`text-center ${(row.getParentRow()?.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    ((row.getParentRow()?.original.node.entity as ReleaseWithAttachmentInfo | undefined)
+                                        ?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {row.original.node.entity.createdBy}
                             </div>
@@ -675,7 +744,11 @@ function GenerateLicenseInfo({
                     } else if (row.original.node.type === 'release') {
                         return (
                             <div
-                                className={`text-center ${(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             ></div>
                         )
                     }
@@ -691,7 +764,12 @@ function GenerateLicenseInfo({
                     if (row.original.node.type === 'attachment') {
                         return (
                             <div
-                                className={`text-center ${(row.getParentRow()?.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    ((row.getParentRow()?.original.node.entity as ReleaseWithAttachmentInfo | undefined)
+                                        ?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             >
                                 {row.original.node.entity.checkedTeam}
                             </div>
@@ -699,7 +777,11 @@ function GenerateLicenseInfo({
                     } else if (row.original.node.type === 'release') {
                         return (
                             <div
-                                className={`text-center ${(row.original?.children?.length ?? 0) > 1 ? 'orange-cell' : 'green-cell'}`}
+                                className={`text-center ${
+                                    (row.original.node.entity?.hasMultipleAttachments ?? false)
+                                        ? 'orange-cell'
+                                        : 'green-cell'
+                                }`}
                             ></div>
                         )
                     }
@@ -916,7 +998,7 @@ function GenerateLicenseInfo({
                 memoizedAttachmentUsages,
                 memoizedLinkedProjects,
                 memoizedLicenses,
-                key === 'only_approved',
+                key,
                 hideWithUsage,
                 saveUsagesPayload,
             ),


### PR DESCRIPTION
- Precalculate whether to show orange coloured row or to show green coloured row. Do not infer it based on the number of children as the children can reduce on filtering.
- For this, I separated the logic of creating the nested table row structure and filtering it. Precalculation needed for row color was done during the creation phase.
- buildTable function first builds the entire nested structure which is then filtered if relevant flags are set. 