### PR TITLE
fix(licenseClearing): Optimize performance and add empty state for 0 linked releases (#2016)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -950,6 +950,7 @@
     "No previous selection found If you have writing permissions to this project your selection will be stored automatically when downloading": "No previous selection found. If you have writing permissions to this project, your selection will be stored automatically when downloading.",
     "No recent components available": "No recent components available",
     "No recent releases available": "No recent releases available",
+    "No releases linked to this project. Add releases to view license clearing information.": "No releases linked to this project. Add releases to view license clearing information.",
     "No source release found": "No source release found",
     "No subscriptions available": "No subscriptions available.",
     "No token found": "No token found. Please add new token here!",

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
@@ -495,6 +495,9 @@ const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
                     <SW360Table
                         table={table}
                         showProcessing={showProcessing}
+                        noRecordsFoundMessage={t(
+                            'No releases linked to this project. Add releases to view license clearing information.',
+                        )}
                     />
                     <ClientSideTableFooter table={table} />
                 </>

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
@@ -708,6 +708,9 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
                         <SW360Table
                             table={table}
                             showProcessing={showProcessing}
+                            noRecordsFoundMessage={t(
+                                'No releases linked to this project. Add releases to view license clearing information.',
+                            )}
                         />
                     </>
                 ) : (

--- a/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LicenseClearing.tsx
@@ -52,6 +52,7 @@ function LicenseClearing({
     businessUnit,
     clearingState,
     visibility,
+    totalReleases,
 }: {
     projectId: string
     projectName: string
@@ -61,6 +62,7 @@ function LicenseClearing({
     businessUnit: string
     clearingState: string
     visibility?: string
+    totalReleases?: number
 }): JSX.Element {
     const t = useTranslations('default')
     const [key, setKey] = useState('tree-view')
@@ -89,6 +91,12 @@ function LicenseClearing({
         const signal = controller.signal
 
         setIsLoadingLinkedProjects(true)
+
+        if (totalReleases === 0) {
+            setLinkedProjectsData([])
+            setIsLoadingLinkedProjects(false)
+            return
+        }
 
         void (async () => {
             try {
@@ -120,6 +128,7 @@ function LicenseClearing({
         return () => controller.abort()
     }, [
         projectId,
+        totalReleases,
     ])
 
     useEffect(() => {
@@ -127,6 +136,14 @@ function LicenseClearing({
         const signal = controller.signal
 
         setIsLoadingLicenseClearing(true)
+
+        if (totalReleases === 0) {
+            setLicenseClearingData({
+                linkedReleases: [],
+            } as unknown as LicenseClearingData)
+            setIsLoadingLicenseClearing(false)
+            return
+        }
 
         void (async () => {
             try {
@@ -156,6 +173,7 @@ function LicenseClearing({
     }, [
         projectId,
         columnFilters,
+        totalReleases,
     ])
 
     const generateSourceCodeBundle = (withSubProjects: boolean) => {

--- a/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ListView.tsx
@@ -706,6 +706,9 @@ export default function ListView({
                         <SW360Table
                             table={table}
                             showProcessing={showProcessing}
+                            noRecordsFoundMessage={t(
+                                'No releases linked to this project. Add releases to view license clearing information.',
+                            )}
                         />
                         <ClientSideTableFooter table={table} />
                     </>

--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -624,6 +624,7 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                                                 businessUnit={summaryData.businessUnit ?? ''}
                                                 clearingState={summaryData.clearingState ?? ''}
                                                 visibility={summaryData.visibility}
+                                                totalReleases={clearingDetailCount?.totalReleases}
                                             />
                                         )}
                                     </Tab.Pane>

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -1011,6 +1011,9 @@ export default function TreeView({
                     <SW360Table
                         table={table}
                         showProcessing={showProcessing}
+                        noRecordsFoundMessage={t(
+                            'No releases linked to this project. Add releases to view license clearing information.',
+                        )}
                     />
                 ) : (
                     <div className='col-12 mt-1 text-center'>


### PR DESCRIPTION
### Summary of Changes
Fixes #2016

When navigating to a project with 0 linked releases, the License Clearing tab (`#/tab-licenseClearing`) experienced severe performance degradation and excessive load times because it unconditionally executed heavy transitive API queries (`projects/${projectId}/licenseClearing?transitive=true` and `projects/${projectId}/linkedProjects?transitive=true`). In addition, the table lacked contextual guidance when empty.

This pull request optimizes the load behavior by short-circuiting unnecessary API calls when no releases are linked and provides a clear, localized empty state message.

---

### Key Modifications

1. **Short-Circuit Transitive API Requests (0ms Fast-Path):**
   - **`ProjectDetailTab.tsx`**: Passed `totalReleases` (obtained from the existing `clearingDetailCount` fetch) into `<LicenseClearing />`.
   - **`LicenseClearing.tsx`**: When `totalReleases === 0`, immediately set `licenseClearingData` to `{ linkedReleases: [] }` and `linkedProjectsData` to `[]`, resolving `isLoadingLicenseClearing` and `isLoadingLinkedProjects` instantly in 0ms without hitting the backend.

2. **Contextual Empty State Message:**
   - In `TreeView.tsx`, `ListView.tsx`, `DependencyNetworkTreeView.tsx`, and `DependencyNetworkListView.tsx`, passed `noRecordsFoundMessage` to `SW360Table` displaying:
     > *"No releases linked to this project. Add releases to view license clearing information."*

3. **Internationalization (i18n):**
   - Added the empty state string to `messages/en.json` to adhere to `next-intl` guidelines.

4. **Code Quality & Formatting:**
   - Verified that all modified files conform to Biome formatting and pass TypeScript type checks.

---

### Verification & Testing

- [x] **Project with 0 releases:** Navigated to a project without linked releases; verified that the License Clearing tab opens instantly without network delay.
- [x] **Empty state display:** Confirmed that the table shows the descriptive message: *"No releases linked to this project. Add releases to view license clearing information."*
- [x] **Normal projects:** Verified that projects containing linked releases continue to fetch and render full clearing details as expected.
- [x] **Code quality:** Verified with `npx biome check` and `npx tsc --noEmit`.

Closes #2016