### PR TITLE
fix(projects): Stop treating External URLs as mailto links

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Summary.tsx
@@ -174,7 +174,8 @@ export default function Summary({ summaryData }: { summaryData: SummaryDataType 
                                     <span className='fw-bold'>{name}</span>{' '}
                                     <Link
                                         className='text-link'
-                                        href={`mailto:${value}`}
+                                        href={value}
+                                        target='_blank'
                                     >
                                         {value}
                                     </Link>


### PR DESCRIPTION
Closes #2032 
Fixed External URLs in Project Summary incorrectly opening as mailto: links instead of navigating to the actual URL.