### PR TITLE
fix(project): Linked to projects bug

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/ProjectDetailTab.tsx
@@ -175,6 +175,8 @@ export default function ViewProjects({ projectId }: { projectId: string }): JSX.
                 })
                 setProjectPayload({
                     id: projectId,
+                    name: project.name ?? '',
+                    version: project.version ?? '',
                     linkedProjects: ob,
                 })
             } catch (error) {

--- a/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
+++ b/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) Siemens AG, 2023. Part of the SW360 Frontend Project.
+// Copyright (C) Siemens AG, 2023-2026. Part of the SW360 Frontend Project.
 
 // This program and the accompanying materials are made
 // available under the terms of the Eclipse Public License 2.0
@@ -30,8 +30,13 @@ import { ApiError, CommonUtils } from '@/utils'
 import ApiUtils from '@/utils/api/authenticatedApi.util'
 
 interface AlertData {
-    variant: string
-    message: JSX.Element
+    [k: string]: {
+        variant?: string
+        name?: string
+        id?: string
+        version?: string
+        message?: JSX.Element
+    }
 }
 
 interface Props {
@@ -56,7 +61,7 @@ export default function LinkProjectsModal({
 }: Props): JSX.Element {
     const t = useTranslations('default')
     const [linkProjects, setLinkProjects] = useState<Map<string, LinkedProjectData>>(new Map())
-    const [alert, setAlert] = useState<AlertData | null>(null)
+    const [alert, setAlert] = useState<AlertData[] | null>([])
     const [searchText, setSearchText] = useState<string | undefined>(undefined)
     const [byNameOnly, setByNameOnly] = useState(true)
     const [linking, setLinking] = useState(false)
@@ -392,121 +397,154 @@ export default function LinkProjectsModal({
             }),
         )
 
-    const formatProjectDisplayName = (
-        name: string | undefined,
-        version: string | undefined,
-        fallback: string,
-    ): string => {
-        if (CommonUtils.isNullEmptyOrUndefinedString(name)) {
-            return fallback
-        }
-
-        if (CommonUtils.isNullEmptyOrUndefinedString(version)) {
-            return name
-        }
-
-        return `${name}(${version})`
-    }
-
     const handleLinkProjects = async (projectId: string) => {
         setLinking(true)
         try {
-            let sourceProjectName = projectPayload.name
-            let sourceProjectVersion = projectPayload.version
-            if (CommonUtils.isNullEmptyOrUndefinedString(sourceProjectName)) {
-                const sourceProjectResponse = await ApiUtils.GET(`projects/${projectId}`)
-                if (sourceProjectResponse.status === StatusCodes.OK) {
-                    const sourceProject = (await sourceProjectResponse.json()) as Project
-                    sourceProjectName = sourceProject.name ?? projectId
-                    sourceProjectVersion = sourceProject.version
-                }
-            }
-
-            for (const [selectedProjectId, selectedProjectData] of linkProjects.entries()) {
-                const selectedProjectResponse = await ApiUtils.GET(`projects/${selectedProjectId}`)
-                if (selectedProjectResponse.status !== StatusCodes.OK) {
-                    const err = (await selectedProjectResponse.json()) as ErrorDetails
+            const sourceProjectName = projectPayload.name
+            const sourceProjectVersion = projectPayload.version
+            const completeAlertData: AlertData[] = []
+            for (const [targetProjectId, targetProjectData] of linkProjects.entries()) {
+                let singleAlertData: AlertData = {}
+                const targetProjectResponse = await ApiUtils.GET(`projects/${targetProjectId}`)
+                if (targetProjectResponse.status !== StatusCodes.OK) {
+                    const err = (await targetProjectResponse.json()) as ErrorDetails
                     throw new ApiError(err.message, {
-                        status: selectedProjectResponse.status,
+                        status: targetProjectResponse.status,
                     })
                 }
 
-                const selectedProject = (await selectedProjectResponse.json()) as Project
-                const selectedProjectLinkedProjects = toLinkedProjectsPayload(selectedProject)
+                const targetProject = (await targetProjectResponse.json()) as Project
+                const selectedProjectLinkedProjects = toLinkedProjectsPayload(targetProject)
 
                 selectedProjectLinkedProjects[projectId] = {
                     enableSvm: false,
                     name: '',
-                    projectRelationship: selectedProjectData.projectRelationship,
+                    projectRelationship: targetProjectData.projectRelationship,
                     version: '',
                 }
 
-                const patchResponse = await ApiUtils.PATCH(`projects/${selectedProjectId}`, {
+                const patchResponse = await ApiUtils.PATCH(`projects/${targetProjectId}`, {
                     linkedProjects: selectedProjectLinkedProjects,
                 })
 
                 if (patchResponse.status === StatusCodes.FORBIDDEN) {
-                    const err = (await patchResponse.json()) as ErrorDetails
-                    throw new ApiError(err.message || t('Access Denied'), {
-                        status: patchResponse.status,
-                    })
+                    singleAlertData = {
+                        [targetProjectId]: {
+                            variant: 'danger',
+                            name: targetProjectData.name,
+                            id: targetProjectId,
+                            version: targetProjectData.version,
+                            message: (
+                                <>
+                                    <p>
+                                        You do not have permission to link the project
+                                        <span className='fw-bold'>
+                                            {sourceProjectName} ({sourceProjectVersion})
+                                        </span>{' '}
+                                        to the target project{' '}
+                                        <span className='fw-bold'>
+                                            {targetProjectData.name} ({targetProjectData.version})
+                                        </span>
+                                        .
+                                    </p>
+                                </>
+                            ),
+                        },
+                    }
                 }
-                if (patchResponse.status !== StatusCodes.OK) {
-                    const err = (await patchResponse.json()) as ErrorDetails
-                    throw new ApiError(err.message, {
-                        status: patchResponse.status,
-                    })
+                if (patchResponse.status === StatusCodes.BAD_REQUEST) {
+                    singleAlertData = {
+                        [targetProjectId]: {
+                            variant: 'danger',
+                            name: targetProjectData.name,
+                            id: targetProjectId,
+                            version: targetProjectData.version,
+                            message: (
+                                <>
+                                    <p>
+                                        The project
+                                        <span className='fw-bold'>
+                                            {sourceProjectName} ({sourceProjectVersion})
+                                        </span>{' '}
+                                        is already linked to the target project
+                                        <span className='fw-bold'>
+                                            {targetProjectData.name} ({targetProjectData.version})
+                                        </span>
+                                        .
+                                    </p>
+                                </>
+                            ),
+                        },
+                    }
                 }
+                if (patchResponse.status === StatusCodes.ACCEPTED) {
+                    singleAlertData = {
+                        [targetProjectId]: {
+                            variant: 'success',
+                            name: targetProjectData.name,
+                            id: targetProjectId,
+                            version: targetProjectData.version,
+                            message: (
+                                <>
+                                    <p>
+                                        Moderation request is created to link the project
+                                        <span className='fw-bold'>
+                                            {sourceProjectName} ({sourceProjectVersion})
+                                        </span>{' '}
+                                        to the target project
+                                        <span className='fw-bold'>
+                                            {targetProjectData.name} ({targetProjectData.version})
+                                        </span>
+                                        .
+                                    </p>
+                                </>
+                            ),
+                        },
+                    }
+                }
+                if (patchResponse.status === StatusCodes.OK) {
+                    singleAlertData = {
+                        [targetProjectId]: {
+                            variant: 'success',
+                            name: targetProjectData.name,
+                            id: targetProjectId,
+                            version: targetProjectData.version,
+                            message: (
+                                <>
+                                    <p>
+                                        The project{' '}
+                                        <span className='fw-bold'>
+                                            {sourceProjectName} ({sourceProjectVersion})
+                                        </span>{' '}
+                                        has been successfully linked to project{' '}
+                                        <span className='fw-bold'>
+                                            {targetProjectData.name} ({targetProjectData.version})
+                                        </span>
+                                        .
+                                    </p>
+                                    <p>
+                                        {t('Click')}{' '}
+                                        <Link
+                                            href={`/projects/edit/${targetProjectId}?tab=linkedProjectsAndReleases`}
+                                            className='text-link'
+                                        >
+                                            {t('here')}
+                                        </Link>{' '}
+                                        {t('to edit the project relation')}.
+                                    </p>
+                                </>
+                            ),
+                        },
+                    }
+                }
+                completeAlertData.push(singleAlertData)
             }
 
-            const sourceProjectDisplayName = formatProjectDisplayName(
-                sourceProjectName,
-                sourceProjectVersion,
-                projectId,
-            )
-
-            const linkedToProjectDisplayName = Array.from(linkProjects.entries())
-                .map(([linkedProjectId, linkedProject]) =>
-                    formatProjectDisplayName(linkedProject.name, linkedProject.version, linkedProjectId),
-                )
-                .join(', ')
-
-            setAlert({
-                variant: 'success',
-                message: (
-                    <>
-                        <p>
-                            The project <span className='fw-bold'>{sourceProjectDisplayName}</span> has been
-                            successfully linked to project <span className='fw-bold'>{linkedToProjectDisplayName}</span>
-                            .
-                        </p>
-                        <p>
-                            {t('Click')}{' '}
-                            <Link
-                                href={`/projects/edit/${projectId}?tab=linkedProjectsAndReleases`}
-                                className='text-link'
-                            >
-                                {t('here')}
-                            </Link>{' '}
-                            {t('to edit the project relation')}.
-                        </p>
-                    </>
-                ),
-            })
+            setAlert(completeAlertData)
         } catch (error) {
             if (error instanceof ApiError && error.isAborted) {
                 return
             }
-            const message =
-                error instanceof ApiError ? error.message : error instanceof Error ? error.message : String(error)
-            setAlert({
-                variant: 'danger',
-                message: (
-                    <>
-                        <p>{message}</p>
-                    </>
-                ),
-            })
             ApiUtils.reportError(error)
         } finally {
             setLinking(false)
@@ -548,13 +586,16 @@ export default function LinkProjectsModal({
                 <Modal.Title id='linked-projects-modal'>{t('Link Projects')}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                {alert && (
-                    <Alert
-                        variant={alert.variant}
-                        id='linkProjects.alert'
-                    >
-                        {alert.message}
-                    </Alert>
+                {alert?.map((alertData) =>
+                    Object.entries(alertData).map(([targetProjectId, targetAlert]) => (
+                        <Alert
+                            key={`linkProjects.alert.${targetProjectId}`}
+                            variant={targetAlert.variant}
+                            id={`linkProjects.alert.${targetProjectId}`}
+                        >
+                            {targetAlert.message}
+                        </Alert>
+                    )),
                 )}
                 <Form>
                     <Col>

--- a/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
+++ b/src/components/sw360/LinkedProjectsModal/LinkProjectsModal.tsx
@@ -62,10 +62,17 @@ export default function LinkProjectsModal({
     const [linking, setLinking] = useState(false)
 
     useEffect(() => {
-        setLinkProjects(new Map(Object.entries(projectPayload.linkedProjects ?? {})))
+        if (mode === 'SET') {
+            setLinkProjects(new Map(Object.entries(projectPayload.linkedProjects ?? {})))
+            return
+        }
+
+        // In update mode, the selected list should only contain user-picked parent projects from this modal session.
+        setLinkProjects(new Map())
     }, [
         projectPayload,
         show,
+        mode,
     ])
 
     const columns = useMemo<ColumnDef<Project>[]>(
@@ -365,34 +372,113 @@ export default function LinkProjectsModal({
         setLinkProjects(m)
     }
 
+    const toLinkedProjectsPayload = (project: Project): Record<string, LinkedProjectData> =>
+        Object.fromEntries(
+            (project.linkedProjects ?? []).flatMap((linkedProject) => {
+                const linkedProjectId = linkedProject.project.split('/').at(-1)
+                if (!linkedProjectId) return []
+
+                return [
+                    [
+                        linkedProjectId,
+                        {
+                            enableSvm: linkedProject.enableSvm === 'true',
+                            name: '',
+                            projectRelationship: linkedProject.relation,
+                            version: '',
+                        } satisfies LinkedProjectData,
+                    ],
+                ]
+            }),
+        )
+
+    const formatProjectDisplayName = (
+        name: string | undefined,
+        version: string | undefined,
+        fallback: string,
+    ): string => {
+        if (CommonUtils.isNullEmptyOrUndefinedString(name)) {
+            return fallback
+        }
+
+        if (CommonUtils.isNullEmptyOrUndefinedString(version)) {
+            return name
+        }
+
+        return `${name}(${version})`
+    }
+
     const handleLinkProjects = async (projectId: string) => {
         setLinking(true)
         try {
-            const data = {
-                linkedProjects: Object.fromEntries(linkProjects),
+            let sourceProjectName = projectPayload.name
+            let sourceProjectVersion = projectPayload.version
+            if (CommonUtils.isNullEmptyOrUndefinedString(sourceProjectName)) {
+                const sourceProjectResponse = await ApiUtils.GET(`projects/${projectId}`)
+                if (sourceProjectResponse.status === StatusCodes.OK) {
+                    const sourceProject = (await sourceProjectResponse.json()) as Project
+                    sourceProjectName = sourceProject.name ?? projectId
+                    sourceProjectVersion = sourceProject.version
+                }
             }
 
-            const response = await ApiUtils.PATCH(`projects/${projectId}`, data)
-            if (response.status === StatusCodes.FORBIDDEN) {
-                const err = (await response.json()) as ErrorDetails
-                throw new ApiError(err.message || t('Access Denied'), {
-                    status: response.status,
+            for (const [selectedProjectId, selectedProjectData] of linkProjects.entries()) {
+                const selectedProjectResponse = await ApiUtils.GET(`projects/${selectedProjectId}`)
+                if (selectedProjectResponse.status !== StatusCodes.OK) {
+                    const err = (await selectedProjectResponse.json()) as ErrorDetails
+                    throw new ApiError(err.message, {
+                        status: selectedProjectResponse.status,
+                    })
+                }
+
+                const selectedProject = (await selectedProjectResponse.json()) as Project
+                const selectedProjectLinkedProjects = toLinkedProjectsPayload(selectedProject)
+
+                selectedProjectLinkedProjects[projectId] = {
+                    enableSvm: false,
+                    name: '',
+                    projectRelationship: selectedProjectData.projectRelationship,
+                    version: '',
+                }
+
+                const patchResponse = await ApiUtils.PATCH(`projects/${selectedProjectId}`, {
+                    linkedProjects: selectedProjectLinkedProjects,
                 })
+
+                if (patchResponse.status === StatusCodes.FORBIDDEN) {
+                    const err = (await patchResponse.json()) as ErrorDetails
+                    throw new ApiError(err.message || t('Access Denied'), {
+                        status: patchResponse.status,
+                    })
+                }
+                if (patchResponse.status !== StatusCodes.OK) {
+                    const err = (await patchResponse.json()) as ErrorDetails
+                    throw new ApiError(err.message, {
+                        status: patchResponse.status,
+                    })
+                }
             }
-            if (response.status !== StatusCodes.OK) {
-                const err = (await response.json()) as ErrorDetails
-                throw new ApiError(err.message, {
-                    status: response.status,
-                })
-            }
-            const res = (await response.json()) as Project
+
+            const sourceProjectDisplayName = formatProjectDisplayName(
+                sourceProjectName,
+                sourceProjectVersion,
+                projectId,
+            )
+
+            const linkedToProjectDisplayName = Array.from(linkProjects.entries())
+                .map(([linkedProjectId, linkedProject]) =>
+                    formatProjectDisplayName(linkedProject.name, linkedProject.version, linkedProjectId),
+                )
+                .join(', ')
+
             setAlert({
                 variant: 'success',
                 message: (
                     <>
                         <p>
-                            {`${t('The projects have been successfully linked to project')} `}
-                            <span className='fw-bold'>{res.name}</span>.{' '}
+                            The project <span className='fw-bold'>{sourceProjectDisplayName}</span> has been
+                            successfully linked to project <span className='fw-bold'>{linkedToProjectDisplayName}</span>
+                            .
                         </p>
                         <p>
                             {t('Click')}{' '}


### PR DESCRIPTION
Issue summary:

- The Link to Projects flow was linking in the wrong direction.
- Expected: from Project A, selecting Project B should make A a child of B.
- Actual: B was becoming child of A.


What was changed:

1. Direction fix in submit logic:

- In LinkProjectsModal.tsx:389, linking now updates each selected target project and injects the current project into that target’s linkedProjects map.
- This preserves existing target links while adding the new child relation.

2. Payload conversion helper:

- LinkProjectsModal.tsx:354 converts backend linkedProjects entries into the PATCH object shape, so existing links are not overwritten.

3. Update-mode selection cleanup:

- LinkProjectsModal.tsx:62 clears preselected entries in UPDATE mode to avoid stale/extra names in the success message.

4. Success message formatting:

- LinkProjectsModal.tsx:369 formats display as Name(version) when version exists.
- LinkProjectsModal.tsx:437 now lists all selected target projects explicitly (no +N more), matching the requested sentence style.