### PR TITLE
Potential fix for code scanning alert no. 61: Incomplete multi-character sanitization

### DIFF
--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
@@ -47,6 +47,18 @@ const decodeHtmlEntities = (value: string): string => {
         .replace(/&amp;/gi, '&')
 }
 
+const stripHtmlTagsSafely = (value: string): string => {
+    let previous: string
+    let current = value
+
+    do {
+        previous = current
+        current = current.replace(/<[^>]*>/g, '')
+    } while (current !== previous)
+
+    return current
+}
+
 const formatVulnerabilityHistory = (comment: string): string => {
     if (CommonUtils.isNullEmptyOrUndefinedString(comment)) {
         return ''
@@ -61,7 +73,7 @@ const formatVulnerabilityHistory = (comment: string): string => {
             .map((part, index) => {
                 let item = part
                 item = item.replace(/<\/(span|b|div|p)>/gi, ' ')
-                item = item.replace(/<[^>]*>/g, '')
+                item = stripHtmlTagsSafely(item)
                 item = item.replace(/[ \t]+/g, ' ').trim()
                 return `${index + 1}. ${item}`
             })
@@ -70,7 +82,7 @@ const formatVulnerabilityHistory = (comment: string): string => {
 
     let item = normalizedComment
     item = item.replace(/<\/(span|b|div|p)>/gi, ' ')
-    item = item.replace(/<[^>]*>/g, '')
+    item = stripHtmlTagsSafely(item)
     item = item.replace(/[ \t]+/g, ' ').trim()
     return item
 }


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-sw360/sw360-frontend/security/code-scanning/61](https://github.com/eclipse-sw360/sw360-frontend/security/code-scanning/61)

Use a safer sanitization approach for tag stripping in this file by applying the tag-removal replacement repeatedly until the string stops changing. This directly addresses incomplete multi-character sanitization without changing intended behavior (still returns plain text with tags removed).

**Best targeted fix in this snippet:**
- In `src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx`, add a small helper function (e.g., `stripHtmlTagsSafely`) that loops:
  - `next = current.replace(/<[^>]*>/g, '')`
  - stop when `next === current`
- Replace both direct uses of `item.replace(/<[^>]*>/g, '')` (line 64 and line 73 in shown snippet) with `stripHtmlTagsSafely(item)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
