### PR TITLE
feat(Project): Add export functionality for obligations report

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -638,6 +638,7 @@
     "Expert": "Sachverständige",
     "Expiration Date": "Verfallsdatum",
     "Export": "Export",
+    "Export Obligations Report": "Verpflichtungsbericht exportieren",
     "Export Project SBOM": "Project Project SBOM?",
     "Export SBOM": "Ausfuhr SBOM",
     "Export Spreadsheet": "Export Spreadsheet",

--- a/messages/en.json
+++ b/messages/en.json
@@ -638,6 +638,7 @@
     "Expert": "Expert",
     "Expiration Date": "Expiration Date",
     "Export": "Export",
+    "Export Obligations Report": "Export Obligations Report",
     "Export Project SBOM": "Export Project SBOM ?",
     "Export SBOM": "Export SBOM",
     "Export Spreadsheet": "Export Spreadsheet",

--- a/messages/es.json
+++ b/messages/es.json
@@ -638,6 +638,7 @@
     "Expert": "Expert",
     "Expiration Date": "Fecha de caducidad",
     "Export": "Exportar",
+    "Export Obligations Report": "Exportar informe de obligaciones",
     "Export Project SBOM": "Proyecto de exportación SBOM?",
     "Export SBOM": "Export SBOM",
     "Export Spreadsheet": "hoja de cálculo de exportación",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -638,6 +638,7 @@
     "Expert": "Expert",
     "Expiration Date": "Date d'expiration",
     "Export": "Exporter",
+    "Export Obligations Report": "Exporter le rapport d'obligations",
     "Export Project SBOM": "Projet d'exportation SBOM?",
     "Export SBOM": "Exportation",
     "Export Spreadsheet": "Feuille de calcul des exportations",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -638,6 +638,7 @@
     "Expert": "エキスパート",
     "Expiration Date": "有効期限",
     "Export": "輸出",
+    "Export Obligations Report": "義務レポートをエクスポート",
     "Export Project SBOM": "輸出プロジェクトSBOM？",
     "Export SBOM": "Export SBOM",
     "Export Spreadsheet": "SBOMのインポート",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -638,6 +638,7 @@
     "Expert": "주요 특징",
     "Expiration Date": "만료 날짜",
     "Export": "내보내다",
+    "Export Obligations Report": "의무 보고서 내보내기",
     "Export Project SBOM": "수출 프로젝트 SBOM?",
     "Export SBOM": "SBOM 수출",
     "Export Spreadsheet": "수출 스프레드 시트",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -638,6 +638,7 @@
     "Expert": "Especialista",
     "Expiration Date": "Data de validade",
     "Export": "Exportar",
+    "Export Obligations Report": "Exportar relatório de obrigações",
     "Export Project SBOM": "Projeto de exportação SBOM?",
     "Export SBOM": "Exportar SBOM",
     "Export Spreadsheet": "Exportar Planilha",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -638,6 +638,7 @@
     "Expert": "Chuyên gia",
     "Expiration Date": "Ngày hết hạn",
     "Export": "Xuất khẩu",
+    "Export Obligations Report": "Xuất báo cáo nghĩa vụ",
     "Export Project SBOM": "Xuất dự án SBOM?",
     "Export SBOM": "Xuất SBOM",
     "Export Spreadsheet": "Xuất bảng tính",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -638,6 +638,7 @@
     "Expert": "专家",
     "Expiration Date": "截止日期",
     "Export": "出口",
+    "Export Obligations Report": "导出义务报告",
     "Export Project SBOM": "出口项目SBOM？",
     "Export SBOM": "导出SBOM",
     "Export Spreadsheet": "导出电子表格",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -638,6 +638,7 @@
     "Expert": "專家",
     "Expiration Date": "截止日期",
     "Export": "出口",
+    "Export Obligations Report": "匯出義務報告",
     "Export Project SBOM": "出口項目SBOM？",
     "Export SBOM": "匯出 SBOM",
     "Export Spreadsheet": "匯出电子表格",

--- a/src/app/[locale]/projects/components/Obligations/Obligations.tsx
+++ b/src/app/[locale]/projects/components/Obligations/Obligations.tsx
@@ -12,9 +12,10 @@
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Dispatch, type JSX, SetStateAction, useState } from 'react'
-import { Dropdown, Nav, Tab } from 'react-bootstrap'
+import { Button, Dropdown, Nav, Spinner, Tab } from 'react-bootstrap'
 import { AccessControl } from '@/components/AccessControl/AccessControl'
 import { ActionType, ObligationEntry, UserGroupType } from '@/object-types'
+import DownloadService from '@/services/download.service'
 import ObligationView from './ObligationsView/ObligationsView'
 import ReleaseView from './ReleaseView'
 
@@ -29,11 +30,27 @@ function Obligations({ projectId, actionType, payload, setPayload }: Props): JSX
     const router = useRouter()
     const t = useTranslations('default')
     const [key, setKey] = useState('obligations-view')
+    const [exportingObligations, setExportingObligations] = useState<boolean>(false)
 
     const generateLicenseInfo = (withSubProjects: boolean) => {
         const isCalledFromProjectLicenseTab = false
         sessionStorage.setItem('isCalledFromProjectLicenseTab', JSON.stringify(isCalledFromProjectLicenseTab))
         router.push(`/projects/generateLicenseInfo/${projectId}?withSubProjects=${withSubProjects}&variant=REPORT`)
+    }
+
+    // Download the current project's obligations as an XLSX report.
+    const handleExportObligations = async () => {
+        if (!projectId) return
+        setExportingObligations(true)
+        try {
+            const currentDate = new Date().toISOString().split('T')[0]
+            await DownloadService.download(
+                `reports?module=Obligations&projectId=${projectId}&format=xlsx`,
+                `obligations-${currentDate}.xlsx`,
+            )
+        } finally {
+            setExportingObligations(false)
+        }
     }
 
     return (
@@ -62,17 +79,35 @@ function Obligations({ projectId, actionType, payload, setPayload }: Props): JSX
                         </Nav>
                     </div>
                     {actionType === ActionType.DETAIL && (
-                        <Dropdown className='col-auto'>
-                            <Dropdown.Toggle variant='primary'>{t('Create Project Clearing Report')}</Dropdown.Toggle>
-                            <Dropdown.Menu>
-                                <Dropdown.Item onClick={() => generateLicenseInfo(false)}>
-                                    {t('Projects only')}
-                                </Dropdown.Item>
-                                <Dropdown.Item onClick={() => generateLicenseInfo(true)}>
-                                    {t('Projects with sub projects')}
-                                </Dropdown.Item>
-                            </Dropdown.Menu>
-                        </Dropdown>
+                        <div className='col-auto d-flex gap-2'>
+                            <Button
+                                variant='secondary'
+                                aria-label={t('Export Obligations Report')}
+                                disabled={!projectId || exportingObligations}
+                                onClick={() => void handleExportObligations()}
+                            >
+                                {t('Export Obligations Report')}
+                                {exportingObligations && (
+                                    <Spinner
+                                        size='sm'
+                                        className='ms-1 spinner'
+                                    />
+                                )}
+                            </Button>
+                            <Dropdown>
+                                <Dropdown.Toggle variant='primary'>
+                                    {t('Create Project Clearing Report')}
+                                </Dropdown.Toggle>
+                                <Dropdown.Menu>
+                                    <Dropdown.Item onClick={() => generateLicenseInfo(false)}>
+                                        {t('Projects only')}
+                                    </Dropdown.Item>
+                                    <Dropdown.Item onClick={() => generateLicenseInfo(true)}>
+                                        {t('Projects with sub projects')}
+                                    </Dropdown.Item>
+                                </Dropdown.Menu>
+                            </Dropdown>
+                        </div>
                     )}
                 </div>
                 <Tab.Content className='mt-4'>

--- a/tests/e2e/projects/projectDetail.test.ts
+++ b/tests/e2e/projects/projectDetail.test.ts
@@ -184,6 +184,49 @@ test.describe('Projects - Detail Page', () => {
         }
     })
 
+    test('TC71: Export obligations report', async ({ page }) => {
+        const downloadedFileName = 'obligations-report.xlsx'
+        await clickDetailTab(page, /Obligations/)
+        await page.route('**/reports?**', async (route) => {
+            const url = new URL(route.request().url())
+            if (
+                url.pathname === '/resource/api/reports' &&
+                url.searchParams.get('module') === 'Obligations' &&
+                url.searchParams.get('projectId') === projectId &&
+                url.searchParams.get('format') === 'xlsx'
+            ) {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                    headers: {
+                        'Content-Disposition': `attachment; filename="${downloadedFileName}"`,
+                    },
+                    body: 'obligations report',
+                })
+                return
+            }
+
+            await route.continue()
+        })
+
+        const [download, request] = await Promise.all([
+            page.waitForEvent('download'),
+            page.waitForRequest((request) => {
+                const url = new URL(request.url())
+                return (
+                    url.pathname === '/resource/api/reports' &&
+                    url.searchParams.get('module') === 'Obligations' &&
+                    url.searchParams.get('projectId') === projectId &&
+                    url.searchParams.get('format') === 'xlsx'
+                )
+            }),
+            page.getByRole('button', { name: 'Export Obligations Report' }).click(),
+        ])
+
+        expect(request.method()).toBe('GET')
+        expect(download.suggestedFilename()).toBe(downloadedFileName)
+    })
+
     // ─── Detail Page Buttons ─────────────────────────────────
 
     test('TC67: Edit Projects button is visible on detail page', async ({ page }) => {


### PR DESCRIPTION
### Summary

Adds project-level obligations report export as an XLSX download from the project Obligations tab and translations for all supported locales.

- Issue: https://github.com/eclipse-sw360/sw360-frontend/issues/2043
- No new dependencies were added or updated.

### Changes

- Added an `Export Obligations Report` action to the project detail Obligations tab.
- Requests `GET /reports?module=Obligations&projectId={projectId}&format=xlsx`.
- Uses the existing download service and preserves the filename from `Content-Disposition` when provided.
- Added the translation key to all supported locale files.

### Suggest Reviewer

@amritkv @GMishx 

### How To Test?

Run the focused Playwright test:

```bash
pnpm exec playwright test tests/e2e/projects/projectDetail.test.ts --grep "TC71: Export obligations report"
```

The test authenticates the configured test users, opens a project's Obligations tab, verifies the obligations report request parameters, and checks the downloaded filename from `Content-Disposition`.

Additional test coverage was added for the obligations export flow.

### Backend Related PR 
https://github.com/eclipse-sw360/sw360/pull/4586