### PR TITLE
fix(project): Link project table pagination fix

### DIFF
--- a/src/components/sw360/Table/Components.tsx
+++ b/src/components/sw360/Table/Components.tsx
@@ -148,6 +148,7 @@ function TableFooterUI({
                 <ul className='pagination mb-0'>
                     <li className={`page-item ${currentPage === 0 ? 'disabled' : ''}`}>
                         <button
+                            type='button'
                             className='page-link'
                             onClick={() => goToPage(currentPage - 1)}
                             disabled={currentPage === 0}
@@ -171,6 +172,7 @@ function TableFooterUI({
                                 key={page}
                             >
                                 <button
+                                    type='button'
                                     className='page-link'
                                     onClick={() => goToPage(page)}
                                 >
@@ -182,6 +184,7 @@ function TableFooterUI({
 
                     <li className={`page-item ${currentPage === totalPages - 1 ? 'disabled' : ''}`}>
                         <button
+                            type='button'
                             className='page-link'
                             onClick={() => goToPage(currentPage + 1)}
                             disabled={currentPage === totalPages - 1}


### PR DESCRIPTION
Description:
Pagination controls in the Link Projects modal were rendered inside a form, and their buttons did not specify a button type. In HTML, a button inside a form defaults to submit, so clicking Next or a page number submitted the form, closed the modal, and reloaded the project page instead of changing pagination.

The fix was made in Components.tsx. Updated the shared pagination buttons for Previous, page numbers, and Next to use type='button', which prevents form submission and allows the modal pagination to work normally.