### PR TITLE
fix(project): Project name display while editing

### DIFF
--- a/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
+++ b/src/app/[locale]/projects/edit/[id]/components/EditProject.tsx
@@ -835,7 +835,11 @@ function EditProject({
                                                     lg={4}
                                                     className='text-truncate buttonheader-title'
                                                 >
-                                                    {t('Update Project')}
+                                                    {`${projectPayload.name}${
+                                                        CommonUtils.isNullEmptyOrUndefinedString(projectPayload.version)
+                                                            ? ''
+                                                            : ` (${projectPayload.version})`
+                                                    }`}
                                                 </Col>
                                             </Row>
                                             <Row className='mt-5'>


### PR DESCRIPTION
Description:
Project name was not displayed on top right corner while editing the project. The issue has now been fixed.