### PR TITLE
Fix the brief empty table flash before data shows after processing

### DIFF
--- a/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
+++ b/src/app/[locale]/admin/bulkreleaseedit/components/ReleaseEditPage.tsx
@@ -410,14 +410,18 @@ export default function BulkReleaseEdit(): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        search,
         reloadKey,
     ])
 

--- a/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
+++ b/src/app/[locale]/admin/departments/components/SecondaryDepartmentsTable.tsx
@@ -119,11 +119,16 @@ const SecondaryDepartmentsTable = (): JSX.Element => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [])
 
     const table = useReactTable({

--- a/src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx
+++ b/src/app/[locale]/admin/licenseTypes/components/LicenseTypesDetail.tsx
@@ -124,11 +124,16 @@ export default function LicenseTypesDetail(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         quickFilter,
     ])

--- a/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/admin/obligations/changelog/[id]/components/Changelog.tsx
@@ -93,11 +93,16 @@ function ChangeLog({ obligationId }: { obligationId: string }): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         obligationId,

--- a/src/app/[locale]/admin/obligations/components/ImportElementDialog.tsx
+++ b/src/app/[locale]/admin/obligations/components/ImportElementDialog.tsx
@@ -138,11 +138,16 @@ function ImportElementDialog({ show, setShow, onImport }: Props): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [])
 
     const table = useReactTable({

--- a/src/app/[locale]/admin/obligations/components/Obligations.tsx
+++ b/src/app/[locale]/admin/obligations/components/Obligations.tsx
@@ -238,14 +238,18 @@ function Obligations(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        search,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/admin/users/components/UserAdministration.tsx
+++ b/src/app/[locale]/admin/users/components/UserAdministration.tsx
@@ -253,7 +253,7 @@ export default function UserAdminstration(): JSX.Element {
 
     useEffect(() => {
         const controller = new AbortController()
-        const _signal = controller.signal
+        const signal = controller.signal
 
         const timeLimit = userData.length !== 0 ? 700 : 0
         const timeout = setTimeout(() => {
@@ -275,7 +275,7 @@ export default function UserAdminstration(): JSX.Element {
                         ]),
                     ),
                 )
-                const response = await ApiUtils.GET(queryUrl)
+                const response = await ApiUtils.GET(queryUrl, signal)
                 if (response.status !== StatusCodes.OK) {
                     const err = (await response.json()) as ErrorDetails
                     throw new ApiError(err.message, {
@@ -295,14 +295,18 @@ export default function UserAdminstration(): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
         refreshTrigger,
     ])
 

--- a/src/app/[locale]/admin/vendors/components/VendorsList.tsx
+++ b/src/app/[locale]/admin/vendors/components/VendorsList.tsx
@@ -259,11 +259,16 @@ export default function VendorsList(): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx
+++ b/src/app/[locale]/admin/vendors/merge/[id]/components/VendorsTable.tsx
@@ -142,11 +142,16 @@ export default function VendorTable({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/components/components/ComponentsTable.tsx
+++ b/src/app/[locale]/components/components/ComponentsTable.tsx
@@ -252,14 +252,18 @@ export default function ComponentsTable({ setNumberOfComponent }: Props) {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
     ])
 
     useEffect(() => {

--- a/src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ComponentTable.tsx
@@ -36,14 +36,14 @@ export default function ComponentTable({
         name: '',
     })
 
-    const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch({
                 name: '',
             })
         } else {
             setSearch({
-                name: event.currentTarget.value,
+                name: value,
                 luceneSearch: true,
             })
         }
@@ -160,11 +160,16 @@ export default function ComponentTable({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         search,

--- a/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/DetailOverview.tsx
@@ -279,11 +279,16 @@ const DetailOverview = ({ componentId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         componentId,

--- a/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
+++ b/src/app/[locale]/components/detail/[id]/components/ReleaseOverview.tsx
@@ -18,7 +18,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { PageSizeSelector, SW360Table, TableFooter, TableSearch } from 'next-sw360'
-import { KeyboardEvent, ReactNode, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useEffect, useMemo, useState } from 'react'
 import { Button, Modal, OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { BsClipboard, BsDownload, BsFillTrashFill, BsGit, BsLink45Deg, BsPencil } from 'react-icons/bs'
 import fossologyIcon from '@/assets/images/fossology.svg'
@@ -172,14 +172,14 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
         )
     }
 
-    const searchFunction = (event: KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch({
                 searchText: '',
             })
         } else {
             setSearch({
-                searchText: event.currentTarget.value,
+                searchText: value,
                 luceneSearch: true,
             })
         }
@@ -391,11 +391,16 @@ const ReleaseOverview = ({ componentId, calledFromModerationRequestDetail }: Pro
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         componentId,
         pageableQueryParam,

--- a/src/app/[locale]/components/edit/[id]/components/Releases.tsx
+++ b/src/app/[locale]/components/edit/[id]/components/Releases.tsx
@@ -109,11 +109,16 @@ const Releases = ({ componentId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         componentId,
     ])

--- a/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/DetailOverview.tsx
@@ -308,11 +308,16 @@ const DetailOverview = ({ releaseId, isSPDXFeatureEnabled }: Props): ReactNode =
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         releaseId,

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedPackagesTab.tsx
@@ -276,11 +276,16 @@ export default function LinkedPackagesTab({ releaseId }: Props): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [])
 
     const table = useReactTable({

--- a/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/LinkedReleases.tsx
@@ -89,11 +89,16 @@ const LinkedReleases = ({ releaseId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         releaseId,
     ])

--- a/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/components/SPDXAttachments.tsx
@@ -285,11 +285,16 @@ const SPDXAttachments = ({ releaseId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         releaseId,
     ])

--- a/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseTable.tsx
+++ b/src/app/[locale]/components/releases/detail/[id]/merge/components/MergeReleaseTable.tsx
@@ -40,14 +40,14 @@ export default function MergeReleaseTable({
         name: '',
     })
 
-    const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch({
                 name: '',
             })
         } else {
             setSearch({
-                name: event.currentTarget.value,
+                name: value,
                 luceneSearch: true,
             })
         }
@@ -156,11 +156,16 @@ export default function MergeReleaseTable({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         search,
     ])

--- a/src/app/[locale]/ecc/components/ECC.tsx
+++ b/src/app/[locale]/ecc/components/ECC.tsx
@@ -162,11 +162,16 @@ function ECC(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/home/components/MyComponentsWidget.tsx
+++ b/src/app/[locale]/home/components/MyComponentsWidget.tsx
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, SortingState, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
@@ -122,11 +124,16 @@ export default function MyComponentsWidget(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         reload,

--- a/src/app/[locale]/home/components/MyProjectsWidget.tsx
+++ b/src/app/[locale]/home/components/MyProjectsWidget.tsx
@@ -197,11 +197,16 @@ export default function MyProjectsWidget(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         reload,

--- a/src/app/[locale]/home/components/MyTaskAssignmentsWidget.tsx
+++ b/src/app/[locale]/home/components/MyTaskAssignmentsWidget.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
@@ -137,11 +139,16 @@ function MyTaskAssignmentsWidget(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         reload,

--- a/src/app/[locale]/home/components/MyTaskSubmissionsWidget.tsx
+++ b/src/app/[locale]/home/components/MyTaskSubmissionsWidget.tsx
@@ -8,6 +8,8 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
@@ -172,11 +174,16 @@ function MyTaskSubmissionsWidget(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         reload,

--- a/src/app/[locale]/licenses/components/LicensePage.tsx
+++ b/src/app/[locale]/licenses/components/LicensePage.tsx
@@ -200,14 +200,18 @@ function LicensePage(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        search,
     ])
 
     const table = useReactTable({

--- a/src/app/[locale]/licenses/detail/components/LicenseDetailOverview.tsx
+++ b/src/app/[locale]/licenses/detail/components/LicenseDetailOverview.tsx
@@ -209,11 +209,16 @@ const LicenseDetailOverview = ({ licenseId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         licenseId,

--- a/src/app/[locale]/packages/components/Packages.tsx
+++ b/src/app/[locale]/packages/components/Packages.tsx
@@ -330,14 +330,18 @@ function Packages(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
     ])
 
     useEffect(() => {

--- a/src/app/[locale]/packages/detail/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/packages/detail/[id]/components/Changelog.tsx
@@ -91,11 +91,16 @@ function ChangeLog({ packageId }: { packageId: string }): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         packageId,

--- a/src/app/[locale]/preferences/components/TokensTable.tsx
+++ b/src/app/[locale]/preferences/components/TokensTable.tsx
@@ -153,11 +153,16 @@ const TokensTable = ({ generatedToken }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         revoked,
         generatedToken,

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/AllObligations.tsx
@@ -262,11 +262,16 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setIsLoadingObligations(false)
+                if (!signal.aborted) {
+                    setIsLoadingObligations(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])
@@ -284,8 +289,7 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
         const controller = new AbortController()
         const signal = controller.signal
 
-        const timeLimit =
-            (!CommonUtils.isNullEmptyOrUndefinedArray(linkedProjects) && linkedProjects.length) !== 0 ? 700 : 0
+        const timeLimit = !CommonUtils.isNullEmptyOrUndefinedArray(linkedProjects) ? 700 : 0
         const timeout = setTimeout(() => {
             setIsLoadingLinkedProjects(true)
         }, timeLimit)
@@ -302,16 +306,21 @@ export default function LicenseObligation({ projectId }: { projectId: string }):
                 }
 
                 const linkedProjectsData = (await response.json()) as LinkedProjects
-                setLinkedProjects(linkedProjectsData['_embedded']['sw360:projects'])
+                setLinkedProjects(linkedProjectsData['_embedded']?.['sw360:projects'] ?? [])
             } catch (error) {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setIsLoadingLinkedProjects(false)
+                if (!signal.aborted) {
+                    setIsLoadingLinkedProjects(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
     ])

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseDbObligationsModal.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseDbObligationsModal.tsx
@@ -319,11 +319,16 @@ export default function LicenseDbObligationsModal({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/LicenseObligation.tsx
@@ -489,11 +489,16 @@ export default function LicenseObligation({ projectId, actionType, payload, setP
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         refresh,

--- a/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ObligationsView/ObligationTab.tsx
@@ -356,11 +356,16 @@ export default function ObligationTab({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
+++ b/src/app/[locale]/projects/components/Obligations/ReleaseView.tsx
@@ -154,7 +154,9 @@ export default function ReleaseView({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 

--- a/src/app/[locale]/projects/components/Projects.tsx
+++ b/src/app/[locale]/projects/components/Projects.tsx
@@ -798,14 +798,18 @@ function Project(): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
     ])
 
     useEffect(() => {

--- a/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/AttachmentUsages.tsx
@@ -353,11 +353,16 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessingLinkedProjects(false)
+                if (!signal.aborted) {
+                    setShowProcessingLinkedProjects(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
     ])
@@ -433,11 +438,16 @@ function AttachmentUsagesComponent({ projectId }: { projectId: string }): JSX.El
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessingAttachmentUsages(false)
+                if (!signal.aborted) {
+                    setShowProcessingAttachmentUsages(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
     ])

--- a/src/app/[locale]/projects/detail/[id]/components/Changelog.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Changelog.tsx
@@ -99,11 +99,16 @@ function ChangeLog({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         projectId,

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkListView.tsx
@@ -22,7 +22,7 @@ import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { ClientSidePageSizeSelector, ClientSideTableFooter, FilterComponent, SW360Table, TableSearch } from 'next-sw360'
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import { ErrorDetails, FilterOption } from '@/object-types'
@@ -472,14 +472,14 @@ const DependencyNetworkListView = ({ projectId }: { projectId: string }) => {
         projectId,
     ])
 
-    const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch({
                 search: '',
             })
         } else {
             setSearch({
-                search: event.currentTarget.value,
+                search: value,
             })
         }
     }

--- a/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/DependencyNetworkTreeView.tsx
@@ -23,7 +23,7 @@ import { StatusCodes } from 'http-status-codes'
 import Link from 'next/link'
 import { useTranslations } from 'next-intl'
 import { FilterComponent, PaddedCell, SW360Table, TableSearch } from 'next-sw360'
-import React, { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { OverlayTrigger, Spinner, Tooltip } from 'react-bootstrap'
 import { BsPencil } from 'react-icons/bs'
 import ExpandableTextList from '@/components/ExpandableList/ExpandableTextLink'
@@ -689,11 +689,11 @@ const DependencyNetworkTreeView = ({ projectId }: Props) => {
         expandLevel,
     ])
 
-    const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch('')
         } else {
-            setSearch(event.currentTarget.value)
+            setSearch(value)
         }
     }
 

--- a/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/Ecc.tsx
@@ -173,11 +173,16 @@ function EccDetails({ projectId, projectName, projectVersion }: Props): JSX.Elem
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/LinkedPackagesTab.tsx
@@ -328,11 +328,16 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowPackagesProcessing(false)
+                if (!signal.aborted) {
+                    setShowPackagesProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
     ])
@@ -362,11 +367,16 @@ export default function LinkedPackagesTab({ projectId }: Props): JSX.Element {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProjectProcessing(false)
+                if (!signal.aborted) {
+                    setShowProjectProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
     ])

--- a/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/TreeView.tsx
@@ -935,9 +935,9 @@ export default function TreeView({
 
     useEffect(() => {
         if (memoizedLicenseClearing === undefined) {
-            setIsDataReady(!isLoadingClearingData)
             return
         }
+        setIsDataReady(false)
         buildTable(setRowData, memoizedLicenseClearing, memoizedLinkedProjects, searchTerm, sort)
         // Mark data as ready only after setting row data
         setIsDataReady(true)

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTab.tsx
@@ -375,11 +375,16 @@ export default function VulnerabilityTab({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         hasVulnerabilityDisplay,

--- a/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
+++ b/src/app/[locale]/projects/detail/[id]/components/VulnerabilityTrackingStatus.tsx
@@ -133,11 +133,16 @@ export default function VulnerabilityTrackingStatusComponent({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
     ])

--- a/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
+++ b/src/app/[locale]/projects/generateLicenseInfo/[id]/components/GenerateLicenseInfo.tsx
@@ -391,7 +391,8 @@ function GenerateLicenseInfo({
         isAsc: true,
     })
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
-    const [showProcessing, setShowProcessing] = useState(false)
+    const [isFetchingData, setIsFetchingData] = useState(false)
+    const [isBuildingTable, setIsBuildingTable] = useState(false)
     const [attachmentUsages, setAttachmentUsages] = useState<AttachmentUsages | undefined>(undefined)
     const [linkedProjects, setLinkedProjects] = useState<Project[]>(() => [])
 
@@ -929,7 +930,7 @@ function GenerateLicenseInfo({
 
         const timeLimit = data.length !== 0 ? 700 : 0
         const timeout = setTimeout(() => {
-            setShowProcessing(true)
+            setIsFetchingData(true)
         }, timeLimit)
 
         void (async () => {
@@ -1068,10 +1069,17 @@ function GenerateLicenseInfo({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setIsFetchingData(false)
+                    // keep the overlay up until the table effect rebuilds `data` from the fetched pieces
+                    setIsBuildingTable(true)
+                }
             }
         })()
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
         params,
@@ -1084,6 +1092,7 @@ function GenerateLicenseInfo({
             memoizedLicenses === undefined
         )
             return
+        setIsBuildingTable(true)
         setData(
             buildTable(
                 projectId,
@@ -1096,6 +1105,7 @@ function GenerateLicenseInfo({
                 sort,
             ),
         )
+        setIsBuildingTable(false)
     }, [
         key,
         memoizedLinkedProjects,
@@ -1195,7 +1205,7 @@ function GenerateLicenseInfo({
                                             {table ? (
                                                 <SW360Table
                                                     table={table}
-                                                    showProcessing={showProcessing}
+                                                    showProcessing={isFetchingData || isBuildingTable}
                                                 />
                                             ) : (
                                                 <div className='col-12 mt-1 text-center'>
@@ -1209,7 +1219,7 @@ function GenerateLicenseInfo({
                                             {table ? (
                                                 <SW360Table
                                                     table={table}
-                                                    showProcessing={showProcessing}
+                                                    showProcessing={isFetchingData || isBuildingTable}
                                                 />
                                             ) : (
                                                 <div className='col-12 mt-1 text-center'>

--- a/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
+++ b/src/app/[locale]/projects/generateSourceCode/[id]/components/GenerateSourceCodeBundle.tsx
@@ -65,7 +65,8 @@ function GenerateSourceCodeBundle({
     const [loading, setLoading] = useState(false)
     const [hideWithUsage, setHideWithUsage] = useState(false)
     const [expandedState, setExpandedState] = useState<ExpandedState>({})
-    const [showProcessing, setShowProcessing] = useState(false)
+    const [isFetchingData, setIsFetchingData] = useState(false)
+    const [isBuildingTable, setIsBuildingTable] = useState(false)
     const [project, setProject] = useState<Project>()
     const [linkedProjects, setLinkedProjects] = useState<Project[]>(() => [])
     const [attachmentUsages, setAttachmentUsages] = useState<AttachmentUsages | undefined>(undefined)
@@ -139,7 +140,7 @@ function GenerateSourceCodeBundle({
 
         const timeLimit = data.length !== 0 ? 700 : 0
         const timeout = setTimeout(() => {
-            setShowProcessing(true)
+            setIsFetchingData(true)
         }, timeLimit)
 
         void (async () => {
@@ -219,10 +220,17 @@ function GenerateSourceCodeBundle({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setIsFetchingData(false)
+                    // keep the overlay up until the table effect rebuilds `data` from the fetched pieces
+                    setIsBuildingTable(true)
+                }
             }
         })()
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         projectId,
         params,
@@ -230,7 +238,9 @@ function GenerateSourceCodeBundle({
 
     useEffect(() => {
         if (memoizedAttachmentUsages === undefined || memoizedLinkedProjects === undefined) return
+        setIsBuildingTable(true)
         buildTable(setData, memoizedAttachmentUsages, memoizedLinkedProjects, hideWithUsage)
+        setIsBuildingTable(false)
     }, [
         memoizedLinkedProjects,
         memoizedAttachmentUsages,
@@ -683,7 +693,7 @@ function GenerateSourceCodeBundle({
                             {table ? (
                                 <SW360Table
                                     table={table}
-                                    showProcessing={showProcessing}
+                                    showProcessing={isFetchingData || isBuildingTable}
                                 />
                             ) : (
                                 <div className='col-12 mt-1 text-center'>

--- a/src/app/[locale]/requests/components/ClearingRequest.tsx
+++ b/src/app/[locale]/requests/components/ClearingRequest.tsx
@@ -398,14 +398,18 @@ function ClearingRequestComponent({ requestType }: { requestType: RequestType })
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
         requestType,
     ])
 

--- a/src/app/[locale]/requests/components/ModerationRequest.tsx
+++ b/src/app/[locale]/requests/components/ModerationRequest.tsx
@@ -234,14 +234,18 @@ function ModerationRequestComponent({
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
         setModerationRequestCount,
         status,
     ])

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentComponent/CurrentComponentDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentComponent/CurrentComponentDetail.tsx
@@ -138,11 +138,16 @@ const CurrentComponentDetail = ({ componentId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         componentId,

--- a/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
+++ b/src/app/[locale]/requests/moderationRequest/[id]/components/currentRelease/CurrentReleaseDetail.tsx
@@ -159,11 +159,16 @@ const CurrentReleaseDetail = ({ releaseId }: Props): ReactNode => {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
         releaseId,

--- a/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
+++ b/src/app/[locale]/vulnerabilities/components/Vulnerabilities.tsx
@@ -267,14 +267,18 @@ function Vulnerabilities(): ReactNode {
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         pageableQueryParam,
-        params.toString(),
     ])
 
     useEffect(() => {

--- a/src/components/Attachments/Attachments.tsx
+++ b/src/components/Attachments/Attachments.tsx
@@ -291,11 +291,16 @@ function Attachments({ documentId, documentType }: { documentId: string; documen
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [])
 
     const table = useReactTable({

--- a/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
+++ b/src/components/ProjectAddSummary/Roles/DepartmentModal.tsx
@@ -135,11 +135,16 @@ export default function DepartmentModal({ show, setShow, department, setDepartme
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [])
 
     const table = useReactTable({

--- a/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
+++ b/src/components/sw360/SearchObligations/LinkedObligationsDialog.tsx
@@ -42,14 +42,14 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
         search: '',
     })
 
-    const searchFunction = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.currentTarget.value === '') {
+    const searchFunction = (value: string) => {
+        if (value === '') {
             setSearch({
                 search: '',
             })
         } else {
             setSearch({
-                search: event.currentTarget.value,
+                search: value,
             })
         }
     }
@@ -215,11 +215,16 @@ const LinkedObligationsDialog = ({ show, setShow, licensePayload, setLicensePayl
                 ApiUtils.reportError(error)
             } finally {
                 clearTimeout(timeout)
-                setShowProcessing(false)
+                if (!signal.aborted) {
+                    setShowProcessing(false)
+                }
             }
         })()
 
-        return () => controller.abort()
+        return () => {
+            controller.abort()
+            clearTimeout(timeout)
+        }
     }, [
         search,
     ])

--- a/src/components/sw360/Table/Components.tsx
+++ b/src/components/sw360/Table/Components.tsx
@@ -7,9 +7,11 @@
 // SPDX-License-Identifier: EPL-2.0
 // License-Filename: LICENSE
 
+'use client'
+
 import { ColumnFiltersState, flexRender, Row, Table } from '@tanstack/react-table'
 import { useTranslations } from 'next-intl'
-import { ChangeEvent, Dispatch, Fragment, ReactNode, SetStateAction } from 'react'
+import { ChangeEvent, Dispatch, Fragment, ReactNode, SetStateAction, useRef } from 'react'
 import { Dropdown, DropdownButton } from 'react-bootstrap'
 import { BiSort } from 'react-icons/bi'
 import { BsCaretDownFill, BsCaretRightFill, BsSortDown, BsSortDownAlt } from 'react-icons/bs'
@@ -516,12 +518,23 @@ export function FilterComponent({
     )
 }
 
-export function TableSearch({
-    searchFunction,
-}: {
-    searchFunction: (event: React.KeyboardEvent<HTMLInputElement>) => void
-}) {
+export function TableSearch({ searchFunction }: { searchFunction: (value: string) => void }) {
     const t = useTranslations('default')
+
+    const debounceRef = useRef<NodeJS.Timeout | null>(null)
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = e.target.value
+
+        if (debounceRef.current) {
+            clearTimeout(debounceRef.current)
+        }
+
+        debounceRef.current = setTimeout(() => {
+            searchFunction?.(value)
+        }, 700)
+    }
+
     return (
         <div className='row mt-3'>
             <div className='col-auto px-0'>
@@ -536,7 +549,7 @@ export function TableSearch({
                 <input
                     className='form-control'
                     type='text'
-                    onKeyUp={searchFunction}
+                    onChange={handleChange}
                     id='table-search'
                 />
             </div>


### PR DESCRIPTION
Currently, when we visit a page with a table, it initially shows 'Processing...', after which, for a brief interval of time, empty table is shown, only after which the table with data shows up.

The empty table is shown due to a race condition on the showProcessing variable in many pages. For example, in src/app/[locale]/components/components/ComponentsTable.tsx, there are the following useEffects:
1. One which loads data from the api.
2. Another one which changes url params.

What happens when useEffect (1) and (2 )run together is, (1) sets showProcessing to true, simultaneously (2) runs and changes pageableQueryParam. This causes (1) to re-run, aborting the previous run of (1). During this abort, showProcessing set to true in run and re-run of (1) is prematurely set to false in the finally block. This shows the empty table flash.